### PR TITLE
fix trapping behaviour of intToWord64

### DIFF
--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -6398,7 +6398,7 @@ and compile_exp (env : E.t) ae exp =
       | (Nat|Int), Word64 ->
         SR.UnboxedWord64,
         compile_exp_vanilla env ae e ^^
-        BigNum.to_word64 env
+        BigNum.truncate_to_word64 env
 
       | Nat64, Word64
       | Int64, Word64

--- a/test/random/Main.hs
+++ b/test/random/Main.hs
@@ -896,6 +896,7 @@ unparseWord p a = "(word" <> bitWidth p <> "ToNat(" <> unparseAS a <> "))" -- TO
 
 -- TODOs:
 --   - wordToInt
+--   - natToNat64/intToWord64 (and round-trips)
 --   - bitwise ops (btst?)
 --   - pattern matches (over numeric, bool, structured)
 --   - trapping flavour-preserving conversions Nat -> NatN

--- a/test/run/ok/conversions.wasm-run.ok
+++ b/test/run/ok/conversions.wasm-run.ok
@@ -1,1 +1,0 @@
-_out/conversions.wasm:0x___: runtime trap: unreachable executed

--- a/test/run/ok/conversions.wasm-run.ret.ok
+++ b/test/run/ok/conversions.wasm-run.ret.ok
@@ -1,1 +1,0 @@
-Return code 1


### PR DESCRIPTION
(it should wrap, of course)

Eliminates the test failure in `test/run/ok/conversions.wasm-run.ok`.