### PR TITLE
Claudio/async experiment

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -13,7 +13,7 @@ DESER_TARGET = _build/default/exes/deser.exe
 
 DUNE_OPTS ?=
 
-ALL_TARGETS = $(MO_IDE_TARGET) $(MO_LD_TARGET) $(MO_DOC_TARGET) $(MOC_TARGET) $(MOC_JS_TARGET) $(DIDC_TARGET) $(DESER_TARGET) ($DIDC_JS_TARGET)
+ALL_TARGETS = $(MO_IDE_TARGET) $(MO_LD_TARGET) $(MO_DOC_TARGET) $(MOC_TARGET) $(MOC_JS_TARGET) $(DIDC_TARGET) $(DESER_TARGET) $(DIDC_JS_TARGET)
 
 .PHONY: all clean moc mo-doc mo-ide mo-ld moc.js didc deser unit-tests didc.js
 

--- a/test/run-drun/calc.mo
+++ b/test/run-drun/calc.mo
@@ -28,13 +28,13 @@ actor a {
   };
 
 
-  func evil(exp : Expression) : async Int {
+  func evalAsync(exp : Expression) : async Int {
     switch (exp) {
       case (#const(n)) n;
-      case (#add(e1, e2)) (await evil(e1)) + (await evil(e2));
-      case (#mul(e1, e2)) (await evil(e1)) * (await evil(e2));
-      case (#sub(e1, e2)) (await evil(e1)) - (await evil(e2));
-      case (#pow(e1, e2)) await (pow(await (evil e1), await (evil e2)));
+      case (#add(e1, e2)) (await evalAsync(e1)) + (await evalAsync(e2));
+      case (#mul(e1, e2)) (await evalAsync(e1)) * (await evalAsync(e2));
+      case (#sub(e1, e2)) (await evalAsync(e1)) - (await evalAsync(e2));
+      case (#pow(e1, e2)) await (pow(await (evalAsync e1), await (evalAsync e2)));
     }
   };
 
@@ -49,16 +49,16 @@ actor a {
     P.debugPrint (debug_show(eval(#pow(#const 2,#const 10))));
   };
 
-  public func eviluate() : async () {
-    P.debugPrint (debug_show(await(evil(sum(32)))));
-    P.debugPrint (debug_show(await(evil(#pow(#const 2,#const 10)))));
+  public func evaluateAsync() : async () {
+    P.debugPrint (debug_show(await(evalAsync(sum(32)))));
+    P.debugPrint (debug_show(await(evalAsync(#pow(#const 2,#const 10)))));
   };
 
 
 };
 
 ignore a.evaluate(); //OR-CALL ingress evaluate "DIDL\x00\x00"
-ignore a.eviluate(); //OR-CALL ingress eviluate "DIDL\x00\x00"
+ignore a.evaluateAsync(); //OR-CALL ingress eviluate "DIDL\x00\x00"
 
 //SKIP run
 //SKIP run-low

--- a/test/run-drun/calc.mo
+++ b/test/run-drun/calc.mo
@@ -1,0 +1,51 @@
+import P "mo:prim";
+actor a {
+  public type Expression = {
+    #const : Int;
+    #add : (Expression, Expression);
+    #mul : (Expression, Expression);
+    #sub : (Expression, Expression);
+  };
+
+  func eval(exp : Expression) : Int {
+    switch (exp) {
+      case (#const(n)) n;
+      case (#add(e1, e2)) eval(e1) + eval(e2);
+      case (#mul(e1, e2)) eval(e1) * eval(e2);
+      case (#sub(e1, e2)) eval(e1) - eval(e2);
+    }
+  };
+
+
+  func evil(exp : Expression) : async Int {
+    switch (exp) {
+      case (#const(n)) n;
+      case (#add(e1, e2)) (await evil(e1)) + (await evil(e2));
+      case (#mul(e1, e2)) (await evil(e1)) * (await evil(e2));
+      case (#sub(e1, e2)) (await evil(e1)) - (await evil(e2));
+    }
+  };
+
+  func sum(n : Int) : Expression {
+     if (n <= 0)
+       #const 0
+     else #add(#const n,sum (n-1));
+  };
+
+  public func evaluate() : async () {
+    P.debugPrint (debug_show(eval(sum(32))));
+  };
+
+  public func eviluate() : async () {
+    P.debugPrint (debug_show(await(evil(sum(32)))));
+  };
+
+
+};
+
+ignore a.evaluate(); //OR-CALL ingress evaluate "DIDL\x00\x00"
+ignore a.eviluate(); //OR-CALL ingress eviluate "DIDL\x00\x00"
+
+//SKIP run
+//SKIP run-low
+//SKIP run-ir

--- a/test/run-drun/calc.mo
+++ b/test/run-drun/calc.mo
@@ -1,10 +1,20 @@
 import P "mo:prim";
 actor a {
+
+  func power(i:Int, n: Int) : Int {
+    if (n<=0) i else i*power(i, n-1);
+  };
+
+  public query func pow(i :Int, n:Int) : async Int {
+     power(i, n);
+  };
+
   public type Expression = {
     #const : Int;
     #add : (Expression, Expression);
     #mul : (Expression, Expression);
     #sub : (Expression, Expression);
+    #pow : (Expression, Expression);
   };
 
   func eval(exp : Expression) : Int {
@@ -13,6 +23,7 @@ actor a {
       case (#add(e1, e2)) eval(e1) + eval(e2);
       case (#mul(e1, e2)) eval(e1) * eval(e2);
       case (#sub(e1, e2)) eval(e1) - eval(e2);
+      case (#pow(e1, e2)) power(eval e1, eval e2);
     }
   };
 
@@ -23,6 +34,7 @@ actor a {
       case (#add(e1, e2)) (await evil(e1)) + (await evil(e2));
       case (#mul(e1, e2)) (await evil(e1)) * (await evil(e2));
       case (#sub(e1, e2)) (await evil(e1)) - (await evil(e2));
+      case (#pow(e1, e2)) await (pow(await (evil e1), await (evil e2)));
     }
   };
 
@@ -34,10 +46,12 @@ actor a {
 
   public func evaluate() : async () {
     P.debugPrint (debug_show(eval(sum(32))));
+    P.debugPrint (debug_show(eval(#pow(#const 2,#const 10))));
   };
 
   public func eviluate() : async () {
     P.debugPrint (debug_show(await(evil(sum(32)))));
+    P.debugPrint (debug_show(await(evil(#pow(#const 2,#const 10)))));
   };
 
 

--- a/test/run-drun/calc.mo
+++ b/test/run-drun/calc.mo
@@ -58,7 +58,7 @@ actor a {
 };
 
 ignore a.evaluate(); //OR-CALL ingress evaluate "DIDL\x00\x00"
-ignore a.evaluateAsync(); //OR-CALL ingress eviluate "DIDL\x00\x00"
+ignore a.evaluateAsync(); //OR-CALL ingress evaluateAsync "DIDL\x00\x00"
 
 //SKIP run
 //SKIP run-low


### PR DESCRIPTION
Inspired by @nomeata's async evaluator puzzle I did a little experiment to remove the context switch from local async functions.

The run-time improvements of avoiding recursive communication (~30x here) are unsurprisingly quite spectacular, and since we already remove the extra context switch implied by the sugar from async shared functions, I'm not sure this hack for local function is really any worse that the ones we already do. Maybe its time to rethink the meaning of async block (or at least the desugaring of async functions to async blocks). 

Needs more testing, but interesting to consider, I think.

See test calc.mo

Before (master)
```
[nix-shell:~/motoko/test/run-drun]$ time ../run.sh -d calc.mo
calc: [tc] [comp] [comp-ref] [valid] [valid-ref] [drun-run] [ic-ref-run]
--- calc.drun-run (expected)
+++ calc.drun-run (actual)
@@ -0,0 +1,5 @@
+ingress System
+debug.print: +528
+ingress Completed: Canister: Reply: 0x4449444c0000
+debug.print: +528
+ingress Completed: Canister: Reply: 0x4449444c0000
--- calc.ic-ref-run (expected)
+++ calc.ic-ref-run (actual)
@@ -0,0 +1,10 @@
+→ create
+← completed: canister-id = ic:2a012b
+→ install
+← completed
+→ update evaluate(0x4449444c0000)
+debug.print: +528
+← completed: 0x4449444c0000
+→ update eviluate(0x4449444c0000)
+debug.print: +528
+← completed: 0x4449444c0000
Some tests failed.

real	0m19.723s
user	0m40.724s
sys	0m1.611s
```

After (this branch)
```
[nix-shell:~/motoko/test/run-drun]$ time ../run.sh -d calc.mo
calc: [tc] [comp] [comp-ref] [valid] [valid-ref] [drun-run] [ic-ref-run]
--- calc.drun-run (expected)
+++ calc.drun-run (actual)
@@ -0,0 +1,5 @@
+ingress System
+debug.print: +528
+ingress Completed: Canister: Reply: 0x4449444c0000
+debug.print: +528
+ingress Completed: Canister: Reply: 0x4449444c0000
--- calc.ic-ref-run (expected)
+++ calc.ic-ref-run (actual)
@@ -0,0 +1,10 @@
+→ create
+← completed: canister-id = ic:2a012b
+→ install
+← completed
+→ update evaluate(0x4449444c0000)
+debug.print: +528
+← completed: 0x4449444c0000
+→ update eviluate(0x4449444c0000)
+debug.print: +528
+← completed: 0x4449444c0000
Some tests failed.

real	0m1.021s
user	0m1.758s
sys	0m0.203s

```

