### PR TITLE
Use Nat8 for floatToFormattedText

### DIFF
--- a/rts/float.c
+++ b/rts/float.c
@@ -5,8 +5,8 @@
 
 export as_ptr float_fmt(double a, uint32_t prec, uint32_t mode) {
   // prec and mode are passed tagged:
-  mode >>= 24; // untag Word8
-  prec >>= 24; // untag Word8
+  mode >>= 24; // untag Nat8
+  prec >>= 24; // untag Nat8
   if (prec > 100) prec = 100;
   extern int snprintf(char *__restrict, size_t, const char *__restrict, ...);
   char buf[120]; // will be of length less than 110 for max precision

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -7080,8 +7080,8 @@ and compile_exp (env : E.t) ae exp =
     | OtherPrim "Float->Text", [e] ->
       SR.Vanilla,
       compile_exp_as env ae SR.UnboxedFloat64 e ^^
-      compile_unboxed_const (TaggedSmallWord.vanilla_lit Type.Word8 6) ^^
-      compile_unboxed_const (TaggedSmallWord.vanilla_lit Type.Word8 0) ^^
+      compile_unboxed_const (TaggedSmallWord.vanilla_lit Type.Nat8 6) ^^
+      compile_unboxed_const (TaggedSmallWord.vanilla_lit Type.Nat8 0) ^^
       E.call_import env "rts" "float_fmt"
 
     | OtherPrim "fmtFloat->Text", [f; prec; mode] ->

--- a/src/mo_values/prim.ml
+++ b/src/mo_values/prim.ml
@@ -200,7 +200,7 @@ let num_conv_prim t1 t2 =
 let prim =
   let via_float f v = Float.(Float (of_float (f (to_float (as_float v))))) in
   let via_float2 f v w = Float.(Float (of_float (f (to_float (as_float v)) (to_float (as_float w))))) in
-  let unpack_word8 v = Int32.to_int (Word8.to_bits (as_word8 v)) lsr 24 in
+  let unpack_nat8 v = Nat8.to_int (as_nat8 v) in
   let float_formatter prec : int -> float -> string =
     let open Printf in
     function
@@ -233,7 +233,7 @@ let prim =
   | "fmtFloat->Text" -> fun _ v k ->
     (match Value.as_tup v with
      | [f; prec; mode] ->
-       k (Text (float_formatter (unpack_word8 prec) (unpack_word8 mode) Float.(to_float (as_float f))))
+       k (Text (float_formatter (unpack_nat8 prec) (unpack_nat8 mode) Float.(to_float (as_float f))))
      | _ -> assert false)
   | "fsin" -> fun _ v k -> k (via_float Stdlib.sin v)
   | "fcos" -> fun _ v k -> k (via_float Stdlib.cos v)

--- a/src/prelude/prelude.ml
+++ b/src/prelude/prelude.ml
@@ -484,7 +484,7 @@ let floatToText = @text_of_Float;
 //  2) generic format "%.*g"
 //  3) hexadecimal format "%.*h"
 //  _) invalid (traps)
-func floatToFormattedText(f : Float, prec : Word8, mode : Word8) : Text = (prim "fmtFloat->Text" : (Float, Word8, Word8) -> Text) (f, prec, mode);
+func floatToFormattedText(f : Float, prec : Nat8, mode : Nat8) : Text = (prim "fmtFloat->Text" : (Float, Nat8, Nat8) -> Text) (f, prec, mode);
 
 // Trigonometric and transcendental functions
 


### PR DESCRIPTION
this is just a small tweak, no functionality change

Both latter args of `floatToFormattedText ` were `Word8`, now `Nat8`. Shorter, slightly better semantics.