### PR TITLE
moc: Flag --gc-testing to allow testing the GC in WASI

### DIFF
--- a/src/exes/moc.ml
+++ b/src/exes/moc.ml
@@ -99,7 +99,7 @@ let argspec = Arg.align [
   "--gc-testing",
   Arg.Unit
     (fun () -> Flags.gc_testing := true),
-    " run program twice, with GHC in between (only wasi or no system api mode)";
+    " run program twice, with GC in between (only wasi or no system api mode)";
 ]
 
 

--- a/src/exes/moc.ml
+++ b/src/exes/moc.ml
@@ -96,6 +96,10 @@ let argspec = Arg.align [
   Arg.Unit
     (fun () -> Flags.sanity := true),
     " enable sanity checking in the RTS and generated code";
+  "--gc-testing",
+  Arg.Unit
+    (fun () -> Flags.gc_testing := true),
+    " run program twice, with GHC in between (only wasi or no system api mode)";
 ]
 
 

--- a/src/exes/moc.ml
+++ b/src/exes/moc.ml
@@ -109,7 +109,7 @@ let set_out_file files ext =
     | [n] -> out_file := Filename.remove_extension (Filename.basename n) ^ ext
     | ns -> eprintf "moc: no output file specified"; exit 1
   end
-  
+
 (* Main *)
 
 let exit_on_none = function
@@ -176,6 +176,13 @@ let () =
   Arg.parse argspec add_arg usage;
   if !mode = Default then mode := (if !args = [] then Interact else Compile);
   Flags.compiled := (!mode = Compile || !mode = Idl);
+  if !Flags.gc_testing then begin
+    if not (!mode = Compile)
+    then (eprintf "--gc-testing only makes sense when compiling\n"; exit 1);
+    if not Flags.(!compile_mode = WasmMode || !compile_mode = WASIMode)
+    then (eprintf "--gc-testing only makes sense with no or wasi system api\n"; exit 1)
+  end;
+
   process_profiler_flags ();
   try
     process_files !args

--- a/src/exes/moc.ml
+++ b/src/exes/moc.ml
@@ -177,10 +177,12 @@ let () =
   if !mode = Default then mode := (if !args = [] then Interact else Compile);
   Flags.compiled := (!mode = Compile || !mode = Idl);
   if !Flags.gc_testing then begin
-    if not (!mode = Compile)
-    then (eprintf "--gc-testing only makes sense when compiling\n"; exit 1);
-    if not Flags.(!compile_mode = WasmMode || !compile_mode = WASIMode)
-    then (eprintf "--gc-testing only makes sense with no or wasi system api\n"; exit 1)
+    match !mode with
+    | Check -> ()
+    | Compile ->
+      if not Flags.(!compile_mode = WasmMode || !compile_mode = WASIMode)
+      then (eprintf "--gc-testing only makes sense with no or wasi system api\n"; exit 1)
+    | _ -> eprintf "--gc-testing only makes sense when compiling\n"; exit 1
   end;
 
   process_profiler_flags ();

--- a/src/mo_config/flags.ml
+++ b/src/mo_config/flags.ml
@@ -29,3 +29,4 @@ let profile_field_names : string list ref = ref []
 let compiled = ref false
 let error_detail = ref 2
 let sanity = ref false
+let gc_testing = ref false

--- a/test/run/gc-testing.mo
+++ b/test/run/gc-testing.mo
@@ -1,0 +1,21 @@
+//MOC-FLAG --gc-testing
+//SKIP run
+//SKIP run-ir
+//SKIP run-low
+
+import Prim "mo:prim";
+
+var i = 0;
+
+Prim.debugPrint("main program running... i = " # debug_show i);
+
+func post_gc() : Bool {
+  Prim.debugPrint("post gc code running... i = " # debug_show i);
+  Prim.debugPrint("Ignore Diff: Heap size: " # debug_show Prim.rts_heap_size());
+  Prim.debugPrint("Ignore Diff: Total allocation: " # debug_show Prim.rts_total_allocation());
+  Prim.debugPrint("Ignore Diff: Max live size: " # debug_show Prim.rts_max_live_size());
+  Prim.debugPrint("Ignore Diff: Reclaimed: " # debug_show Prim.rts_reclaimed());
+  i += 1;
+  return (i <= 5)
+}
+

--- a/test/run/ok/gc-testing.wasm-run.ok
+++ b/test/run/ok/gc-testing.wasm-run.ok
@@ -1,0 +1,31 @@
+main program running... i = 0
+post gc code running... i = 0
+Ignore Diff: (ignored)
+Ignore Diff: (ignored)
+Ignore Diff: (ignored)
+Ignore Diff: (ignored)
+post gc code running... i = 1
+Ignore Diff: (ignored)
+Ignore Diff: (ignored)
+Ignore Diff: (ignored)
+Ignore Diff: (ignored)
+post gc code running... i = 2
+Ignore Diff: (ignored)
+Ignore Diff: (ignored)
+Ignore Diff: (ignored)
+Ignore Diff: (ignored)
+post gc code running... i = 3
+Ignore Diff: (ignored)
+Ignore Diff: (ignored)
+Ignore Diff: (ignored)
+Ignore Diff: (ignored)
+post gc code running... i = 4
+Ignore Diff: (ignored)
+Ignore Diff: (ignored)
+Ignore Diff: (ignored)
+Ignore Diff: (ignored)
+post gc code running... i = 5
+Ignore Diff: (ignored)
+Ignore Diff: (ignored)
+Ignore Diff: (ignored)
+Ignore Diff: (ignored)


### PR DESCRIPTION
it would be good to write regression tests and observe other aspects of
the the GHC in plain WASI mode, without needing `drun` or `ic-ref-test`.

This is a hack to achieve that: With `--gc-testing`, a program with a
top-level function `post_gc : () -> Bool` will run the main program,
then GC, then `post_gc()`, and as long as that returns `true`, keep
running GC.