### PR TITLE
Doc fixes

### DIFF
--- a/doc/modules/language-guide/examples/atomicity.mo
+++ b/doc/modules/language-guide/examples/atomicity.mo
@@ -17,7 +17,7 @@ actor Atomicity {
   // a non-atomic method
   public func nonAtomic() : async () {
     s := 1;
-    let f = ping();
+    let f = ping(); // this will not be rolled back!
     s := 2;
     await f;
     s := 3; // this will not be rolled back!

--- a/doc/modules/language-guide/pages/actors-async.adoc
+++ b/doc/modules/language-guide/pages/actors-async.adoc
@@ -21,9 +21,9 @@ of the request, that the caller can later query. Between issuing the
 request, and deciding to wait for the result, the caller is free to do
 other work, including issuing more requests to the same or other
 actors.
-Once the caller has processed the request, the future is completed and its result made
-available to the callee.
-If the callee is waiting on the future, its execution can resume with the result, otherwise the result is simply stored in the future for later use.
+Once the callee has processed the request, the future is completed and its result made
+available to the caller.
+If the caller is waiting on the future, its execution can resume with the result, otherwise the result is simply stored in the future for later use.
 
 In {proglang}, actors have dedicated syntax and types; messaging is handled by so called _shared_ functions returning futures (shared because they are available to remote actors);
 a future, `f`, is a value of the special type `async T` for some type `T`; waiting


### PR DESCRIPTION
* swap confused caller/callee in actors-async.adoc (mentioned on forum)
* add comment to atomicity.mo (addressing issue reported in PR #2591)

