### PR TITLE
Fix issue #2319 (crash on import of candid class)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Motoko compiler changelog
 
+* Fix issue #2319 (crash on import of Candid class)
+
 == 0.6.4 (2021-06-12)
 
 * For release builds, the banner (`moc --version`) now includes the release

--- a/src/exes/candid_tests.ml
+++ b/src/exes/candid_tests.ml
@@ -101,8 +101,8 @@ let mo_of_test tenv test : (string * expected_behaviour, string) result =
     | ParsesEqual (false, i1, i2)
     -> Ok (defs ^ not_equal (deser ts i1) (deser ts i2), ShouldPass)
   with
-    | Exception.UnsupportedCandidFeature what ->
-      Error what
+    | Exception.UnsupportedCandidFeature message ->
+      Error (Diag.string_of_message message)
     | TextualParseError (x, msgs) ->
       Error (Printf.sprintf "Could not parse %S:\n%s" x
           (String.concat ", " (List.map Diag.string_of_message msgs))

--- a/src/idllib/escape.ml
+++ b/src/idllib/escape.ml
@@ -111,11 +111,13 @@ let escape str =
   then if ends_with_underscore str then str ^ "_" else str
   else escape_num (IdlHash.idl_hash str)
 
-let escape_method str =
+let escape_method at str =
   if is_motoko_keyword str then str ^ "_" else
   if is_valid_as_id str
   then if ends_with_underscore str then str ^ "_" else str
-  else raise (Exception.UnsupportedCandidFeature "Candid method not a valid Motoko id")
+  else raise (Exception.UnsupportedCandidFeature
+    (Diag.error_message at "M0160" "import"
+      (Printf.sprintf "Candid method name '%s' is not a valid Motoko identifier" str)))
 
 (* Unescaping (used for Motoko → Candid) *)
 

--- a/src/idllib/escape.mli
+++ b/src/idllib/escape.mli
@@ -2,7 +2,7 @@
 type label = Nat of Lib.Uint32.t | Id of string
 val escape : string -> string
 val escape_num : Lib.Uint32.t -> string
-val escape_method : string -> string
+val escape_method : Source.region -> string -> string
 val unescape : string -> label
 val unescape_hash : string -> Lib.Uint32.t
 val unescape_method : string -> string

--- a/src/idllib/exception.ml
+++ b/src/idllib/exception.ml
@@ -1,2 +1,2 @@
-exception UnsupportedCandidFeature of string
+exception UnsupportedCandidFeature of Diag.message
 

--- a/src/lang_utils/error_codes.ml
+++ b/src/lang_utils/error_codes.ml
@@ -163,4 +163,10 @@ let error_codes : (string * string option) list =
     "M0157", Some([%blob "error_codes/M0157.adoc"]); (* block contains non-productive type definitions *)
     "M0158", Some([%blob "error_codes/M0158.adoc"]); (* a public class cannot be anonymous, please provide a name *)
     (* "M0159" DEFUNCT Word deprecation *)
+    "M0160", None;
+    "M0161", None; (* Candid float32 type cannot be imported as a Motoko type *)
+    "M0162", None; (* Candid service constructor type not supported as Motoko type *)
+    "M0163", None; (* cannot import a Candid service constructor *)
+    "M0164", None; (* unknown record or variant label in textual representation *)
+    "M0165", None; (* odd expected type *)
   ]

--- a/src/mo_idl/idl_to_mo.ml
+++ b/src/mo_idl/idl_to_mo.ml
@@ -6,7 +6,7 @@ module I = Idllib.Typing
 
 let m_env = ref M.Env.empty
 
-let check_prim p =
+let check_prim at p =
   match p with
   | Null -> M.Prim M.Null
   | Bool -> M.Prim M.Bool
@@ -20,7 +20,9 @@ let check_prim p =
   | Nat16 -> M.Prim M.Nat16
   | Nat32 -> M.Prim M.Nat32
   | Nat64 -> M.Prim M.Nat64
-  | Float32 -> raise (UnsupportedCandidFeature "float32")
+  | Float32 -> raise (UnsupportedCandidFeature
+     (Diag.error_message at "M0161" "import"
+       "Candid 'float32' type cannot be imported as a Motoko type"))
   | Float64 -> M.Prim M.Float
   | Text -> M.Prim M.Text
   | Reserved -> M.Any
@@ -49,7 +51,7 @@ let is_tuple fs =
 
 let rec check_typ env t =
   match t.it with
-  | PrimT p -> check_prim p
+  | PrimT p -> check_prim t.at p
   | PrincipalT -> M.Prim M.Principal
   | VarT {it=id; _} ->
      (match M.Env.find_opt id !m_env with
@@ -81,7 +83,8 @@ let rec check_typ env t =
   | ServT ms ->
      let fs = List.map (check_meth env) ms in
      M.Obj (M.Actor, List.sort M.compare_field fs)
-  | ClassT _ -> raise (UnsupportedCandidFeature "service constructor not supported")
+  | ClassT _ -> raise (UnsupportedCandidFeature
+     (Diag.error_message t.at "M0162" "import" "Candid service constructor type not supported as Motoko type"))
   | PreT -> assert false
 and check_typs env ts = List.map (check_typ env) ts
 and check_field env f =
@@ -91,7 +94,7 @@ and check_variant_field env f =
   | PrimT Null -> M.{lab = check_label f.it.label; typ = M.Tup []; depr = None}
   | _ -> check_field env f
 and check_meth env (m: typ_meth) =
-  M.{lab = Idllib.Escape.escape_method m.it.var.it; typ = check_typ env m.it.meth; depr = None}
+  M.{lab = Idllib.Escape.escape_method m.it.var.at m.it.var.it; typ = check_typ env m.it.meth; depr = None}
 
 let check_prog (env: typ I.Env.t) actor : M.typ =
   match actor with
@@ -102,8 +105,9 @@ let check_prog (env: typ I.Env.t) actor : M.typ =
        | M.Con (c, _) -> M.{lab = id; typ = M.Typ c; depr = None}::fs
        | _ -> assert false) !m_env fs in
      M.Obj (M.Actor, List.sort M.compare_field fs)
-  | Some {it=ClassT _; _} ->
-     raise (UnsupportedCandidFeature "cannot import a service constructor")
+  | Some {it=ClassT _; at; _} ->
+     raise (UnsupportedCandidFeature
+       (Diag.error_message at "M0163" "import" "cannot import a Candid service constructor"))
   | None -> assert false
   | _ -> assert false
 

--- a/src/mo_idl/idl_to_mo.ml
+++ b/src/mo_idl/idl_to_mo.ml
@@ -81,7 +81,7 @@ let rec check_typ env t =
   | ServT ms ->
      let fs = List.map (check_meth env) ms in
      M.Obj (M.Actor, List.sort M.compare_field fs)
-  | ClassT _ -> raise (Invalid_argument "service constructor not supported")
+  | ClassT _ -> raise (UnsupportedCandidFeature "service constructor not supported")
   | PreT -> assert false
 and check_typs env ts = List.map (check_typ env) ts
 and check_field env f =
@@ -102,6 +102,8 @@ let check_prog (env: typ I.Env.t) actor : M.typ =
        | M.Con (c, _) -> M.{lab = id; typ = M.Typ c; depr = None}::fs
        | _ -> assert false) !m_env fs in
      M.Obj (M.Actor, List.sort M.compare_field fs)
+  | Some {it=ClassT _; _} ->
+     raise (UnsupportedCandidFeature "cannot import a service constructor")
   | None -> assert false
   | _ -> assert false
 

--- a/src/mo_idl/idl_to_mo_value.ml
+++ b/src/mo_idl/idl_to_mo_value.ml
@@ -34,7 +34,8 @@ let text_lit s = "\"" ^ Mo_values.Value.Blob.escape s ^ "\""
 let find_typ tfs f =
   try T.lookup_val_field (Idl_to_mo.check_label (fst (f.it))) tfs
   with Invalid_argument _ ->
-    raise (UnsupportedCandidFeature "unknown record or variant label in textual representation")
+    raise (UnsupportedCandidFeature
+      (Diag.error_message f.at "M0164" "import" "unknown record or variant label in textual representation"))
 
 (* Also compare with Mo_values.Show.show_val, which we cannot use here, because
    we don’t have the full type (although we could have that), and we have
@@ -69,11 +70,12 @@ let rec value v t =
   | FuncV (s, m), _ ->
     Printf.sprintf "(actor %s : actor { %s : %s }).%s"
       (text_lit s)
-      (Idllib.Escape.escape_method m)
+      (Idllib.Escape.escape_method Source.no_region m)
       (T.string_of_typ t)
-      (Idllib.Escape.escape_method m)
+      (Idllib.Escape.escape_method Source.no_region m)
   | PrincipalV s, _ ->
     "Prim.principalOfActor" ^ parens ("actor " ^ text_lit s ^ " : actor {}")
-  | _ -> raise (UnsupportedCandidFeature "Odd expected type")
+  | _ -> raise (UnsupportedCandidFeature
+    (Diag.error_message v.at "M0165" "import" "odd expected type"))
 
 let args vs ts = parens_comma (List.map2 value vs.it ts)

--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -344,11 +344,13 @@ let chase_imports parsefn senv0 imports : (Syntax.lib list * Scope.scope) Diag.r
       else
         match Mo_idl.Idl_to_mo.check_prog idl_scope actor_opt with
         | exception Idllib.Exception.UnsupportedCandidFeature error_message ->
-          Diag.error
-            ri.Source.at
-            "M0153"
-            "import"
-            (Printf.sprintf "file %s uses Candid types without corresponding Motoko type:\n  %s" f (Diag.string_of_message error_message))
+          Stdlib.Error [
+            Diag.error_message
+              ri.Source.at
+              "M0153"
+              "import"
+              (Printf.sprintf "file %s uses Candid types without corresponding Motoko type" f);
+            error_message ]
         | actor ->
           let sscope = Scope.lib f actor in
           senv := Scope.adjoin !senv sscope;

--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -343,12 +343,12 @@ let chase_imports parsefn senv0 imports : (Syntax.lib list * Scope.scope) Diag.r
           (Printf.sprintf "file %s does not define a service" f)
       else
         match Mo_idl.Idl_to_mo.check_prog idl_scope actor_opt with
-        | exception Idllib.Exception.UnsupportedCandidFeature s ->
+        | exception Idllib.Exception.UnsupportedCandidFeature error_message ->
           Diag.error
             ri.Source.at
             "M0153"
             "import"
-            (Printf.sprintf "file %s uses Candid types without corresponding Motoko type:\n  %s" f s)
+            (Printf.sprintf "file %s uses Candid types without corresponding Motoko type:\n  %s" f (Diag.string_of_message error_message))
         | actor ->
           let sscope = Scope.lib f actor in
           senv := Scope.adjoin !senv sscope;

--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -348,7 +348,7 @@ let chase_imports parsefn senv0 imports : (Syntax.lib list * Scope.scope) Diag.r
             ri.Source.at
             "M0153"
             "import"
-            (Printf.sprintf "file %s uses Candid types without corresponding Motoko type" f)
+            (Printf.sprintf "file %s uses Candid types without corresponding Motoko type:\n  %s" f s)
         | actor ->
           let sscope = Scope.lib f actor in
           senv := Scope.adjoin !senv sscope;

--- a/test/check-error-codes.py
+++ b/test/check-error-codes.py
@@ -38,6 +38,10 @@ known_untested_codes = {
     "M0100", # hard to trigger (syntactic checks hit first)
     "M0108", # mode-specific
     "M0144", # bad import, but seems to be shadowed by non-static expression
+    "M0161", # Candid float32 type cannot be imported as a Motoko type
+    "M0162", # Candid service constructor type not supported as Motoko type
+    "M0164", # unknown record or variant label in textual representation
+    "M0165", # odd expected type
     }
 
 def populate_error_codes():

--- a/test/fail/ok/idl-mo-bad-method.tc.ok
+++ b/test/fail/ok/idl-mo-bad-method.tc.ok
@@ -1,1 +1,2 @@
-idl-mo-bad-method.mo:3.1-3.30: import error [M0153], file idl-mo-bad-method/aaaaa-aa.did uses Candid types without corresponding Motoko type
+idl-mo-bad-method.mo:3.1-3.30: import error [M0153], file idl-mo-bad-method/aaaaa-aa.did uses Candid types without corresponding Motoko type:
+  Candid method not a valid Motoko id

--- a/test/fail/ok/idl-mo-bad-method.tc.ok
+++ b/test/fail/ok/idl-mo-bad-method.tc.ok
@@ -1,3 +1,2 @@
-idl-mo-bad-method.mo:3.1-3.30: import error [M0153], file idl-mo-bad-method/aaaaa-aa.did uses Candid types without corresponding Motoko type:
-  aaaaa-aa.did:2.3-2.8: import error [M0160], Candid method name '☃' is not a valid Motoko identifier
-
+idl-mo-bad-method.mo:3.1-3.30: import error [M0153], file idl-mo-bad-method/aaaaa-aa.did uses Candid types without corresponding Motoko type
+aaaaa-aa.did:2.3-2.8: import error [M0160], Candid method name '☃' is not a valid Motoko identifier

--- a/test/fail/ok/idl-mo-bad-method.tc.ok
+++ b/test/fail/ok/idl-mo-bad-method.tc.ok
@@ -1,2 +1,3 @@
 idl-mo-bad-method.mo:3.1-3.30: import error [M0153], file idl-mo-bad-method/aaaaa-aa.did uses Candid types without corresponding Motoko type:
-  Candid method not a valid Motoko id
+  aaaaa-aa.did:2.3-2.8: import error [M0160], Candid method name '☃' is not a valid Motoko identifier
+

--- a/test/fail/ok/idl-mo-float32.tc.ok
+++ b/test/fail/ok/idl-mo-float32.tc.ok
@@ -1,2 +1,3 @@
 idl-mo-float32.mo:3.1-3.30: import error [M0153], file idl-mo-bad-method/aaaaa-aa.did uses Candid types without corresponding Motoko type:
-  Candid method not a valid Motoko id
+  aaaaa-aa.did:2.3-2.8: import error [M0160], Candid method name '☃' is not a valid Motoko identifier
+

--- a/test/fail/ok/idl-mo-float32.tc.ok
+++ b/test/fail/ok/idl-mo-float32.tc.ok
@@ -1,3 +1,2 @@
-idl-mo-float32.mo:3.1-3.30: import error [M0153], file idl-mo-bad-method/aaaaa-aa.did uses Candid types without corresponding Motoko type:
-  aaaaa-aa.did:2.3-2.8: import error [M0160], Candid method name '☃' is not a valid Motoko identifier
-
+idl-mo-float32.mo:3.1-3.30: import error [M0153], file idl-mo-bad-method/aaaaa-aa.did uses Candid types without corresponding Motoko type
+aaaaa-aa.did:2.3-2.8: import error [M0160], Candid method name '☃' is not a valid Motoko identifier

--- a/test/fail/ok/idl-mo-float32.tc.ok
+++ b/test/fail/ok/idl-mo-float32.tc.ok
@@ -1,1 +1,2 @@
-idl-mo-float32.mo:3.1-3.30: import error [M0153], file idl-mo-bad-method/aaaaa-aa.did uses Candid types without corresponding Motoko type
+idl-mo-float32.mo:3.1-3.30: import error [M0153], file idl-mo-bad-method/aaaaa-aa.did uses Candid types without corresponding Motoko type:
+  Candid method not a valid Motoko id

--- a/test/run-drun/issue-2319.mo
+++ b/test/run-drun/issue-2319.mo
@@ -1,0 +1,17 @@
+//MOC-FLAG --actor-idl issue-2319
+//MOC-FLAG --actor-alias class lg264-qjkae
+
+import imported1 "ic:lg264-qjkae";
+import imported2 "canister:class";
+actor a {
+  public func go() : async (actor {}) = async imported1;
+};
+
+//SKIP run
+//SKIP run-ir
+//SKIP run-low
+
+// Skip running on drun for now; hard to pass a `--actor-alias` that works for
+// both drun and ic-ref-run
+//SKIP comp
+

--- a/test/run-drun/issue-2319/lg264-qjkae.did
+++ b/test/run-drun/issue-2319/lg264-qjkae.did
@@ -1,0 +1,3 @@
+service : () -> {
+  "go": () -> (service {});
+}

--- a/test/run-drun/ok/issue-2319.tc.ok
+++ b/test/run-drun/ok/issue-2319.tc.ok
@@ -1,6 +1,2 @@
-OOPS! You've triggered a compiler bug.
-Please report this Motoko issue at forum.dfinity.org with the following details:
-
-Motoko (revision 0.6.2-22-gdae7f3a1)
-
-Fatal error: exception "Assert_failure mo_idl/idl_to_mo.ml:106:9"
+issue-2319.mo:5.1-5.34: import error [M0153], file issue-2319/lg264-qjkae.did uses Candid types without corresponding Motoko type:
+  cannot import a service constructor

--- a/test/run-drun/ok/issue-2319.tc.ok
+++ b/test/run-drun/ok/issue-2319.tc.ok
@@ -1,3 +1,2 @@
-issue-2319.mo:5.1-5.34: import error [M0153], file issue-2319/lg264-qjkae.did uses Candid types without corresponding Motoko type:
-  lg264-qjkae.did:1.11-3.2: import error [M0163], cannot import a Candid service constructor
-
+issue-2319.mo:5.1-5.34: import error [M0153], file issue-2319/lg264-qjkae.did uses Candid types without corresponding Motoko type
+lg264-qjkae.did:1.11-3.2: import error [M0163], cannot import a Candid service constructor

--- a/test/run-drun/ok/issue-2319.tc.ok
+++ b/test/run-drun/ok/issue-2319.tc.ok
@@ -1,0 +1,6 @@
+OOPS! You've triggered a compiler bug.
+Please report this Motoko issue at forum.dfinity.org with the following details:
+
+Motoko (revision 0.6.2-22-gdae7f3a1)
+
+Fatal error: exception "Assert_failure mo_idl/idl_to_mo.ml:106:9"

--- a/test/run-drun/ok/issue-2319.tc.ok
+++ b/test/run-drun/ok/issue-2319.tc.ok
@@ -1,2 +1,3 @@
 issue-2319.mo:5.1-5.34: import error [M0153], file issue-2319/lg264-qjkae.did uses Candid types without corresponding Motoko type:
-  cannot import a service constructor
+  lg264-qjkae.did:1.11-3.2: import error [M0163], cannot import a Candid service constructor
+

--- a/test/run-drun/ok/issue-2319.tc.ret.ok
+++ b/test/run-drun/ok/issue-2319.tc.ret.ok
@@ -1,1 +1,1 @@
-Return code 2
+Return code 1

--- a/test/run-drun/ok/issue-2319.tc.ret.ok
+++ b/test/run-drun/ok/issue-2319.tc.ret.ok
@@ -1,0 +1,1 @@
+Return code 2


### PR DESCRIPTION
* errors, doesn't crash, on import of candid service class
* improves on UnsupportedCandid error reporting, adding source location and message.