### PR TITLE
Compacting GC: merge threading and marking

### DIFF
--- a/rts/motoko-rts-tests/src/gc.rs
+++ b/rts/motoko-rts-tests/src/gc.rs
@@ -21,23 +21,49 @@ use std::fmt::Write;
 pub fn test() {
     println!("Testing garbage collection ...");
 
-    // TODO: Add more tests
-
     for test_heap in test_heaps() {
         test_gcs(&test_heap);
     }
 }
 
 fn test_heaps() -> Vec<TestHeap> {
-    vec![TestHeap {
-        heap: hashmap! {
-            0 => vec![0, 2],
-            2 => vec![0],
-            3 => vec![3],
+    vec![
+        // Just a random test that covers a bunch of cases:
+        // - Self references
+        // - Forward pointers
+        // - Backwards pointers
+        // - More than one fields in an object
+        TestHeap {
+            heap: hashmap! {
+                0 => vec![0, 2],
+                2 => vec![0],
+                3 => vec![3],
+            },
+            roots: vec![0, 2, 3],
+            closure_table: vec![0],
         },
-        roots: vec![0, 2, 3],
-        closure_table: vec![0],
-    }]
+        // Tests pointing to the same object in multiple fields of an object. Also has unreachable
+        // objects.
+        TestHeap {
+            heap: hashmap! {
+                0 => vec![],
+                1 => vec![],
+                2 => vec![],
+            },
+            roots: vec![1],
+            closure_table: vec![0, 0],
+        },
+        // Root points backwards in heap. Caught a bug in mark-compact collector.
+        TestHeap {
+            heap: hashmap! {
+                0 => vec![],
+                1 => vec![2],
+                2 => vec![1],
+            },
+            roots: vec![2],
+            closure_table: vec![],
+        },
+    ]
 }
 
 #[derive(Debug)]
@@ -66,17 +92,6 @@ fn test_gc(
     closure_table: &[ObjectIdx],
 ) {
     let heap = MotokoHeap::new(refs, roots, closure_table, gc);
-
-    // Check `check_dynamic_heap` sanity
-    check_dynamic_heap(
-        refs,
-        roots,
-        closure_table,
-        &**heap.heap(),
-        heap.heap_base_offset(),
-        heap.heap_ptr_offset(),
-        heap.closure_table_ptr_offset(),
-    );
 
     for _ in 0..3 {
         gc.run(heap.clone());

--- a/rts/motoko-rts-tests/src/mark_stack.rs
+++ b/rts/motoko-rts-tests/src/mark_stack.rs
@@ -32,12 +32,12 @@ fn test_<M: Memory>(mem: &mut M, n_objs: u32) -> TestCaseResult {
         alloc_mark_stack(mem);
 
         for obj in &objs {
-            push_mark_stack(mem, *obj as usize);
+            push_mark_stack(mem, *obj as usize, obj.wrapping_sub(1));
         }
 
-        for obj in objs.iter().rev() {
+        for obj in objs.iter().copied().rev() {
             let popped = pop_mark_stack();
-            if popped != Some(*obj as usize) {
+            if popped != Some((obj as usize, obj.wrapping_sub(1))) {
                 free_mark_stack();
                 return Err(TestCaseError::Fail(
                     format!(

--- a/rts/motoko-rts/src/debug.rs
+++ b/rts/motoko-rts/src/debug.rs
@@ -33,14 +33,21 @@ pub unsafe fn dump_heap(
 }
 
 pub(crate) unsafe fn print_closure_table(closure_tbl_loc: *mut SkewedPtr) {
-    println!(200, "Closure table pointer location: {:#x}", closure_tbl_loc as usize);
+    println!(
+        200,
+        "Closure table pointer location: {:#x}", closure_tbl_loc as usize
+    );
 
     if (*closure_tbl_loc).0 == 0 {
         println!(100, "Closure table not initialized");
         return;
     }
 
-    println!(200, "Closure table pointer: {:#x}", (*closure_tbl_loc).unskew() as usize);
+    println!(
+        200,
+        "Closure table pointer: {:#x}",
+        (*closure_tbl_loc).unskew() as usize
+    );
 
     let arr = (*closure_tbl_loc).unskew() as *mut Array;
     let len = (*arr).len;

--- a/rts/motoko-rts/src/debug.rs
+++ b/rts/motoko-rts/src/debug.rs
@@ -33,10 +33,14 @@ pub unsafe fn dump_heap(
 }
 
 pub(crate) unsafe fn print_closure_table(closure_tbl_loc: *mut SkewedPtr) {
+    println!(200, "Closure table pointer location: {:#x}", closure_tbl_loc as usize);
+
     if (*closure_tbl_loc).0 == 0 {
         println!(100, "Closure table not initialized");
         return;
     }
+
+    println!(200, "Closure table pointer: {:#x}", (*closure_tbl_loc).unskew() as usize);
 
     let arr = (*closure_tbl_loc).unskew() as *mut Array;
     let len = (*arr).len;

--- a/rts/motoko-rts/src/gc/copying.rs
+++ b/rts/motoko-rts/src/gc/copying.rs
@@ -146,7 +146,7 @@ unsafe fn evac<M: Memory>(
 unsafe fn scav<M: Memory>(mem: &mut M, begin_from_space: usize, begin_to_space: usize, obj: usize) {
     let obj = obj as *mut Obj;
 
-    crate::visitor::visit_pointer_fields(obj, begin_from_space, |field_addr| {
+    crate::visitor::visit_pointer_fields(obj, obj.tag(), begin_from_space, |field_addr| {
         evac(mem, begin_from_space, begin_to_space, field_addr as usize);
     });
 }

--- a/rts/motoko-rts/src/gc/mark_compact.rs
+++ b/rts/motoko-rts/src/gc/mark_compact.rs
@@ -157,7 +157,7 @@ unsafe fn update_refs<SetHp: Fn(u32)>(set_hp: SetHp, heap_base: u32) {
         // Update references to the object's new location and restore object header
         unthread(p, free);
 
-        // All references to the object now point to the new location, move the object
+        // All references to the object now point to the new location (object only moved in next pass)
         let p_size_words = object_size(p as usize);
 
         free += p_size_words.to_bytes().0;

--- a/rts/motoko-rts/src/gc/mark_compact.rs
+++ b/rts/motoko-rts/src/gc/mark_compact.rs
@@ -76,27 +76,23 @@ unsafe fn mark_compact<M: Memory, SetHp: Fn(u32)>(
     static_roots: SkewedPtr,
     closure_table_loc: *mut SkewedPtr,
 ) {
-    let mem_size = Bytes(heap_end - heap_base);
+    let heap_size = Bytes(heap_end - heap_base);
 
-    alloc_bitmap(mem, mem_size);
+    alloc_bitmap(mem, heap_size);
     alloc_mark_stack(mem);
 
     mark_static_roots(mem, static_roots, heap_base);
 
     if (*closure_table_loc).unskew() >= heap_base as usize {
         push_mark_stack(mem, *closure_table_loc, heap_base);
+        thread(closure_table_loc);
     }
 
     mark_stack(mem, heap_base);
 
     thread_roots(static_roots, heap_base);
 
-    if (*closure_table_loc).unskew() >= heap_base as usize {
-        thread(closure_table_loc);
-    }
-
-    update_fwd_refs(heap_base);
-    update_bwd_refs(set_hp, heap_base);
+    update_refs(set_hp, heap_base);
 
     free_mark_stack();
     free_bitmap();
@@ -108,11 +104,12 @@ unsafe fn mark_static_roots<M: Memory>(mem: &mut M, static_roots: SkewedPtr, hea
     // Static objects are not in the dynamic heap so don't need marking.
     for i in 0..root_array.len() {
         let obj = root_array.get(i).unskew() as *mut Obj;
-        mark_fields(mem, obj, heap_base);
+        mark_fields(mem, obj, obj.tag(), heap_base);
     }
 }
 
 unsafe fn push_mark_stack<M: Memory>(mem: &mut M, obj: SkewedPtr, heap_base: u32) {
+    let obj_tag = obj.tag();
     let obj = obj.unskew() as u32;
 
     let obj_idx = (obj - heap_base) / WORD_SIZE;
@@ -123,18 +120,19 @@ unsafe fn push_mark_stack<M: Memory>(mem: &mut M, obj: SkewedPtr, heap_base: u32
     }
 
     set_bit(obj_idx);
-    mark_stack::push_mark_stack(mem, obj as usize);
+    mark_stack::push_mark_stack(mem, obj as usize, obj_tag);
 }
 
 unsafe fn mark_stack<M: Memory>(mem: &mut M, heap_base: u32) {
-    while let Some(obj) = pop_mark_stack() {
-        mark_fields(mem, obj as *mut Obj, heap_base);
+    while let Some((obj, tag)) = pop_mark_stack() {
+        mark_fields(mem, obj as *mut Obj, tag, heap_base);
     }
 }
 
-unsafe fn mark_fields<M: Memory>(mem: &mut M, obj: *mut Obj, heap_base: u32) {
-    visit_pointer_fields(obj, heap_base as usize, |field_addr| {
+unsafe fn mark_fields<M: Memory>(mem: &mut M, obj: *mut Obj, obj_tag: Tag, heap_base: u32) {
+    visit_pointer_fields(obj, obj_tag, heap_base as usize, |field_addr| {
         push_mark_stack(mem, *field_addr, heap_base);
+        thread(field_addr);
     });
 }
 
@@ -147,9 +145,8 @@ unsafe fn thread_roots(static_roots: SkewedPtr, heap_base: u32) {
     // No need to thread closure table here as it's on heap and we already marked it
 }
 
-/// Scan the heap, update forward references. At the end of this pass all fields will be threaded
-/// and forward references will be updated, pointing to the object's new location.
-unsafe fn update_fwd_refs(heap_base: u32) {
+/// Expects all fields to be threaded. First pass updates fields, second pass moves objects.
+unsafe fn update_refs<SetHp: Fn(u32)>(set_hp: SetHp, heap_base: u32) {
     let mut free = heap_base;
 
     let mut bitmap_iter = iter_bits();
@@ -157,36 +154,23 @@ unsafe fn update_fwd_refs(heap_base: u32) {
     while bit != BITMAP_ITER_END {
         let p = (heap_base + (bit * WORD_SIZE)) as *mut Obj;
 
-        // Update forward references to the object to the object's new location and restore
-        // object header
-        unthread(p, free);
-
-        // Get the size before threading the fields, to handle self references.
-        let size = object_size(p as usize).to_bytes().0;
-
-        // Thread fields
-        thread_obj_fields(p, heap_base);
-
-        free += size;
-
-        bit = bitmap_iter.next();
-    }
-}
-
-/// Expects all fields to be threaded. Updates backward references and moves objects to their new
-/// locations.
-unsafe fn update_bwd_refs<SetHp: Fn(u32)>(set_hp: SetHp, heap_base: u32) {
-    let mut free = heap_base;
-
-    let mut bitmap_iter = iter_bits();
-    let mut bit = bitmap_iter.next();
-    while bit != BITMAP_ITER_END {
-        let p = (heap_base + (bit * WORD_SIZE)) as *mut Obj;
-
-        // Update backward references to the object's new location and restore object header
+        // Update references to the object's new location and restore object header
         unthread(p, free);
 
         // All references to the object now point to the new location, move the object
+        let p_size_words = object_size(p as usize);
+
+        free += p_size_words.to_bytes().0;
+
+        bit = bitmap_iter.next();
+    }
+
+    let mut free = heap_base;
+    let mut bitmap_iter = iter_bits();
+    let mut bit = bitmap_iter.next();
+    while bit != BITMAP_ITER_END {
+        let p = (heap_base + (bit * WORD_SIZE)) as *mut Obj;
+
         let p_size_words = object_size(p as usize);
         if free as usize != p as usize {
             memcpy_words(free as usize, p as usize, p_size_words);
@@ -201,7 +185,9 @@ unsafe fn update_bwd_refs<SetHp: Fn(u32)>(set_hp: SetHp, heap_base: u32) {
 }
 
 unsafe fn thread_obj_fields(obj: *mut Obj, heap_base: u32) {
-    visit_pointer_fields(obj, heap_base as usize, |field_addr| thread(field_addr));
+    visit_pointer_fields(obj, obj.tag(), heap_base as usize, |field_addr| {
+        thread(field_addr)
+    });
 }
 
 unsafe fn thread(field: *mut SkewedPtr) {

--- a/rts/motoko-rts/src/visitor.rs
+++ b/rts/motoko-rts/src/visitor.rs
@@ -103,6 +103,6 @@ pub unsafe fn visit_pointer_fields<F>(
     }
 }
 
-unsafe fn pointer_to_dynamic_heap(field_addr: *mut SkewedPtr, heap_base: usize) -> bool {
+pub unsafe fn pointer_to_dynamic_heap(field_addr: *mut SkewedPtr, heap_base: usize) -> bool {
     (!(*field_addr).is_tagged_scalar()) && ((*field_addr).unskew() >= heap_base)
 }

--- a/rts/motoko-rts/src/visitor.rs
+++ b/rts/motoko-rts/src/visitor.rs
@@ -3,11 +3,15 @@ use crate::types::*;
 
 /// A visitor that passes field addresses of fields with pointers to dynamic heap to the given
 /// callback
-pub unsafe fn visit_pointer_fields<F>(obj: *mut Obj, heap_base: usize, mut visit_ptr_field: F)
-where
+pub unsafe fn visit_pointer_fields<F>(
+    obj: *mut Obj,
+    tag: Tag,
+    heap_base: usize,
+    mut visit_ptr_field: F,
+) where
     F: FnMut(*mut SkewedPtr),
 {
-    match obj.tag() {
+    match tag {
         TAG_OBJECT => {
             let obj = obj as *mut Object;
             let obj_payload = obj.payload_addr();


### PR DESCRIPTION
This PR merges threading of object fields with marking. The result is
-14% in instructions in CanCan backend benchmark.

Changes:

- Mark phase of compacting GC now threads fields of marked objects.
  After marking all fields are now threaded.

- Because all fields are threaded during marking, the pass for threading
  is now gone.

- However we still need two passes for unthreading and moving the
  objects (see below). So the first pass after marking unthreads fields.
  Then another pass moves objects.

Original idea was to merge marking and threading, and doing unthreading +
moving in one pass. It turns out that doesn't work. To see why, suppose the
heap is like this:

    | ..., object A, ..., object B, ... |

where A and B point to each other. If we unthread + move (slide) in one pass,
then after sliding A, it's possible that live objects between A and B will be
slid to A's original location. So when we unthread B which will have a pointer
to A's old location in its header we'll read random data from whatever's moved
to A's original location.

The solution is to do these in different passes: first unthread, then slide.

The result is still 3 passes as before, but for some reason that I don't
understand, this version is 14% faster on CanCan backend benchmark (42,005,245
instructions to 35,775,591).

I think "An Efficient Garbage Compaction Algorithm" is describing a way to
implement in-sliding compaction in two passes instead of three, but I found
that paper difficult to follow. I will revisit it now to see if this can be
improved further.