### PR TITLE
add makefile helper to only run a single test

### DIFF
--- a/test/only.mk
+++ b/test/only.mk
@@ -1,0 +1,4 @@
+.PHONY: %.only
+
+%.only: %.mo
+	../run.sh $(RUNFLAGS) $<


### PR DESCRIPTION
Usage:
```
make -C test/run-drun commit-on-await.only
```
The test must be a Motoko one from an inner directory.
This is pretty neat when you repeatedly run your preferred test and don't want to waste time waiting on the others.

Otherwise this extension should be rather cheap, and won't interfere if you don't want to use it.
