### PR TITLE
backend: Do not memoize Const values

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -659,6 +659,7 @@ rec {
           nixpkgs.ocamlformat
           nixpkgs.ocamlPackages.utop
           nixpkgs.niv
+          nixpkgs.inotify-tools
         ]
       ));
 

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -5282,7 +5282,8 @@ module StackRep = struct
       | Const.Blob t     -> Blob.vanilla_lit env t
 
   let rec materialize_const_t env (p, cv) : int32 =
-    Lib.Promise.lazy_value p (fun () -> materialize_const_v env cv)
+    materialize_const_v env cv
+    (* Lib.Promise.lazy_value p (fun () -> materialize_const_v env cv) *)
 
   and materialize_const_v env = function
     | Const.Fun get_fi -> Closure.static_closure env (get_fi ())

--- a/test/run/issue2714.mo
+++ b/test/run/issue2714.mo
@@ -1,0 +1,4 @@
+type A = { #y : A };
+// func bar(x: A): Text { debug_show(x); };
+func foo(blob: ?A) : () { ignore (debug_show(blob)); };
+foo(null);


### PR DESCRIPTION
this is in a way a premature optimization, as `materialize_const_v`
eventually calls `E.add_static`, which itself also memoizes. So we at
most save some CPU time in the compiler. But this memoization seem to
stumble over certain recrusive patterns so this code simplifications
fixes #2714.