### PR TITLE
Increase the buffer for storing the float string

### DIFF
--- a/rts/motoko-rts/src/float.rs
+++ b/rts/motoko-rts/src/float.rs
@@ -11,8 +11,8 @@ unsafe fn float_fmt<M: Memory>(mem: &mut M, a: f64, prec: u32, mode: u32) -> Ske
     let mode = mode >> 24;
     let prec = core::cmp::min(prec >> 24, 100) as usize;
 
-    // 110 bytes needed for max precision (TODO (osa): why? how?)
-    let buf = [0u8; 120];
+    // 320 bytes needed for max precision (1.7e308)
+    let buf = [0u8; 320];
 
     // NB. Using snprintf because I think only 0 and 3 are supposed by Rust's built-in formatter
     let fmt = match mode {
@@ -25,7 +25,7 @@ unsafe fn float_fmt<M: Memory>(mem: &mut M, a: f64, prec: u32, mode: u32) -> Ske
 
     let n_written = libc::snprintf(
         buf.as_ptr() as *mut _,
-        120,
+        320,
         fmt.as_ptr() as *const _,
         prec,
         a as libc::c_double,


### PR DESCRIPTION
It did crash in tests for #2733. For `-1.7e308` 318 bytes are needed.

``` python
>>> len('-169999999999999993883079578865998174333346074304075874502773119193537729178160565864330091787584707988572262467983188919169916105593357174268369962062473635296474636515660464935663040684957844303524367815028553272712298986386310828644513212353921123253311675499856875650512437415429217994623324794855339589632.000000')
317
```