### PR TITLE
fix: remove sanity checks as they might trigger false positives

### DIFF
--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -4478,13 +4478,6 @@ module Serialization = struct
         begin
           (* This is a reference *)
           write_byte (compile_unboxed_const 1l) ^^
-          (* Sanity Checks *)
-          get_tag ^^ compile_eq_const Tagged.(int_of_tag MutBox) ^^
-          E.then_trap_with env "unvisited mutable data in serialize_go (MutBox)" ^^
-          get_tag ^^ compile_eq_const Tagged.(int_of_tag ObjInd) ^^
-          E.then_trap_with env "unvisited mutable data in serialize_go (ObjInd)" ^^
-          get_tag ^^ compile_eq_const Tagged.(int_of_tag Array) ^^
-          E.then_trap_with env "unvisited mutable data in serialize_go (Array)" ^^
           (* Second time we see this *)
           (* Calculate relative offset *)
           let (set_offset, get_offset) = new_local env "offset" in


### PR DESCRIPTION
When the reference being written is near the very start of the stable memory
it *could be* `6l` (corresponding to `MutBox`).

Such is case is probably very rare (for realistic programs), but could be engineered.

This PR avoids the conflating of heap tag constants with absolute stable memory
offsets. For references the heap tag field has either been already changed to hold
the absolute offset (by `write_alias`), or has the `StableSeen` tag value as written by `size_alias`.

This is a preparation for #2790 (but also an independent fix).