### PR TITLE
example showing serialization stack overflow during upgrade

### DIFF
--- a/test/run-drun/message-overflow.mo
+++ b/test/run-drun/message-overflow.mo
@@ -10,7 +10,7 @@ actor a {
    };
 
    public func go () : async () {
-      let n = toN(10000, null);
+      let n = toN(50000, null);
       await m(n);
    };
 

--- a/test/run-drun/message-overflow.mo
+++ b/test/run-drun/message-overflow.mo
@@ -1,0 +1,27 @@
+// fails to send due to recursive implementation of Candid serialization
+import Prim "mo:⛔";
+actor a {
+
+   type N = ?N;
+
+   func toN(n : Int, k : N) : N {
+       if (n == 0) k
+       else toN(n - 1, ?k );
+   };
+
+   public func go () : async () {
+      let n = toN(10000, null);
+      await m(n);
+   };
+
+   public func m(n : N) : async () {
+      Prim.debugPrint("done");
+   };
+};
+
+
+//CALL ingress go 0x4449444C0000
+//SKIP run
+//SKIP run-ir
+//SKIP run-low
+

--- a/test/run-drun/ok/message-overflow.drun-run.ok
+++ b/test/run-drun/ok/message-overflow.drun-run.ok
@@ -1,4 +1,3 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-debug.print: done
-ingress Completed: Reply: 0x4449444c0000
+ingress Completed: Reject: IC0502: Canister rwlgt-iiaaa-aaaaa-aaaaa-cai trapped: stack overflow

--- a/test/run-drun/ok/message-overflow.drun-run.ok
+++ b/test/run-drun/ok/message-overflow.drun-run.ok
@@ -1,0 +1,4 @@
+ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
+ingress Completed: Reply: 0x4449444c0000
+debug.print: done
+ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/ok/message-overflow.ic-ref-run.ok
+++ b/test/run-drun/ok/message-overflow.ic-ref-run.ok
@@ -1,0 +1,6 @@
+→ update create_canister(record {settings = null})
+← replied: (record {hymijyo = principal "cvccv-qqaaq-aaaaa-aaaaa-c"})
+→ update install_code(record {arg = blob ""; kca_xin = blob "\00asm\01\00\00\00\0…
+← replied: ()
+→ update go()
+← rejected (RC_CANISTER_ERROR): canister trapped: EvalExhaustionError region:0xXXX-0xXXX "call stack exhausted"

--- a/test/run-drun/ok/upgrade-overflow.drun.ok
+++ b/test/run-drun/ok/upgrade-overflow.drun.ok
@@ -1,0 +1,3 @@
+ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
+ingress Completed: Reply: 0x4449444c0000
+ingress Err: IC0502: Canister rwlgt-iiaaa-aaaaa-aaaaa-cai trapped: heap out of bounds

--- a/test/run-drun/ok/upgrade-overflow.ic-ref-run.ok
+++ b/test/run-drun/ok/upgrade-overflow.ic-ref-run.ok
@@ -1,0 +1,6 @@
+→ update create_canister(record {settings = null})
+← replied: (record {hymijyo = principal "cvccv-qqaaq-aaaaa-aaaaa-c"})
+→ update install_code(record {arg = blob ""; kca_xin = blob "\00asm\01\00\00\00\0…
+← replied: ()
+→ update install_code(record {arg = blob ""; kca_xin = blob "\00asm\01\00\00\00\0…
+← rejected (RC_CANISTER_ERROR): Pre-upgrade trapped: EvalExhaustionError region:0xXXX-0xXXX "call stack exhausted"

--- a/test/run-drun/upgrade-overflow.drun
+++ b/test/run-drun/upgrade-overflow.drun
@@ -1,0 +1,3 @@
+install $ID upgrade-overflow/upgrade-overflow.mo ""
+upgrade $ID upgrade-overflow/upgrade-overflow.mo ""
+

--- a/test/run-drun/upgrade-overflow/upgrade-overflow.mo
+++ b/test/run-drun/upgrade-overflow/upgrade-overflow.mo
@@ -1,0 +1,13 @@
+// fails to upgrade due to recursive implementation of Candid serialization
+actor {
+
+   type List = ?(Int, List);
+
+   func list(n : Int, acc : List) : List {
+       if (n == 0) acc
+       else list(n - 1, ?(n,acc));
+   };
+
+   stable var l = list(10000, null);
+
+}


### PR DESCRIPTION
Demonstrate failure to upgrade due to candid serialization failure on deeply nested data structure (stack overflow).