### PR TITLE
Align semantics of --idl and --stable-types command line options

### DIFF
--- a/design/DFX-Interface.md
+++ b/design/DFX-Interface.md
@@ -72,10 +72,12 @@ Compiler warnings and errors are reported to `stderr`. Nothing writes to `stdout
 Compiling Motoko Files to IDL
 -----------------------------
 
-As the previous point, but passing `--idl` to `moc`.
+As the previous point, but passing `--idl` to `moc`, generating the `output.wasm` and
+an additional `output.did` file (in the same directory).
 
 The IDL generation does not issue any warnings.
 
+Compilation and `.did` generation can (optionally) be combined in a single step.
 
 Resolving Canister aliases
 --------------------------

--- a/doc/modules/language-guide/pages/compiler-ref.adoc
+++ b/doc/modules/language-guide/pages/compiler-ref.adoc
@@ -60,7 +60,7 @@ You can use the following options with the `+moc+` command.
 
 |`+-Werror+` |Treat warnings as errors.
 
-|`+--idl+` |Generates the interface description language specification.
+|`+--idl+` | Compile binary and emit Candid IDL specification to `.did` file.
 
 |`+-i+` |Runs the compiler in an interactive read–eval–print loop (REPL) shell so you can evaluate program execution (implies -r).
 
@@ -102,7 +102,7 @@ You can use the following options with the `+moc+` command.
 
 //|`+--sanity-checks+` |Enable sanity checking in the runtime system and generated code (for compiler development only).
 
-| `--stable-types` |Emit signature of stable types to .most file
+| `--stable-types` |Compile binary and emit signature of stable types to `.most` file.
 
 | `--stable-compatible <pre> <post>` |Test upgrade compatibility between stable-type signatures <pre> and <post>
 

--- a/src/js/common.ml
+++ b/src/js/common.ml
@@ -65,7 +65,7 @@ let js_compile_wasm mode source =
     | _ -> raise (Invalid_argument "js_compile_with: Unexpected mode")
   in
   js_result (Pipeline.compile_files mode true [Js.to_string source])
-    (fun m ->
+    (fun (_, m) ->
       let (_, wasm) = CustomModuleEncode.encode m in
       let constructor = Js.Unsafe.global##._Uint8Array in
       let code = constructor##from

--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -474,6 +474,14 @@ let check_files' parsefn files : check_result =
 let check_files files : check_result =
   check_files' parse_file files
 
+(* Generate IDL *)
+
+let generate_idl files : Idllib.Syntax.prog Diag.result =
+  let open Diag.Syntax in
+  let* libs, progs, senv = load_progs parse_file files initial_stat_env in
+  let* () = Typing.check_actors senv progs in
+  Diag.return (Mo_idl.Mo_to_idl.prog (progs, senv))
+
 (* Running *)
 
 let run_files files : unit option =

--- a/src/pipeline/pipeline.mli
+++ b/src/pipeline/pipeline.mli
@@ -17,6 +17,8 @@ val check_files' : parse_fn -> string list -> unit Diag.result
 
 val stable_compatible : string -> string -> unit Diag.result
 
+val generate_idl : string list -> Idllib.Syntax.prog Diag.result
+
 val initial_stat_env : Scope.scope
 val chase_imports : parse_fn -> Scope.scope -> Resolve_import.resolved_imports ->
   (Syntax.lib list * Scope.scope) Diag.result

--- a/src/pipeline/pipeline.mli
+++ b/src/pipeline/pipeline.mli
@@ -17,8 +17,6 @@ val check_files' : parse_fn -> string list -> unit Diag.result
 
 val stable_compatible : string -> string -> unit Diag.result
 
-val generate_idl : string list -> Idllib.Syntax.prog Diag.result
-
 val initial_stat_env : Scope.scope
 val chase_imports : parse_fn -> Scope.scope -> Resolve_import.resolved_imports ->
   (Syntax.lib list * Scope.scope) Diag.result
@@ -28,7 +26,8 @@ val run_stdin_from_file : string list -> string -> unit option
 val interpret_ir_files  : string list -> unit option
 val run_files_and_stdin : string list -> unit option
 
-type compile_result = Wasm_exts.CustomModule.extended_module Diag.result
+type compile_result =
+  (Idllib.Syntax.prog * Wasm_exts.CustomModule.extended_module) Diag.result
 
 val compile_files : Flags.compile_mode -> bool -> string list -> compile_result
 


### PR DESCRIPTION
@chenyan-dfinity 

My attempt to converge the --idl and --stable-types so they are consistent without breaking dfx or requiring two compiles.

In dfx. just add --idl to the second invocation, delete the first, and do the sensible things with the error settings.

Fingers crossed.


If this is ok, and works for you, I'll merge it into the main PR (#2887) and pull the trigger.