### PR TITLE
feat: support 128 bit cycles API

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -68,12 +68,6 @@
         "sha256": "0mky8ld089ym311zd945lhfvd81aqrn2h37rx33m0j3gj0qpcw1p",
         "type": "tarball",
         "url": "https://github.com/dfinity/motoko-base/archive/c78a28f407014a3f4e81216cdc2ed05472b8d051.tar.gz",
-=======
-        "rev": "0c6f57a7fee067c1086dc96cc4f3d93d50e0af14",
-        "sha256": "1s0blqj5d22cnrgi77sldwmwh942kv42xfz945pj3ywd13nl23v1",
-        "type": "tarball",
-        "url": "https://github.com/dfinity/motoko-base/archive/0c6f57a7fee067c1086dc96cc4f3d93d50e0af14.tar.gz",
->>>>>>> origin/master
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "motoko-matchers": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -64,10 +64,10 @@
         "homepage": null,
         "owner": "dfinity",
         "repo": "motoko-base",
-        "rev": "01355c21813ca131040c125d5a4e5fcf11c24071",
-        "sha256": "14x25dg99vvwam6b859wwf97fqs7rm20rrgyvzqf62lf40s61vcv",
+        "rev": "c78a28f407014a3f4e81216cdc2ed05472b8d051",
+        "sha256": "0mky8ld089ym311zd945lhfvd81aqrn2h37rx33m0j3gj0qpcw1p",
         "type": "tarball",
-        "url": "https://github.com/dfinity/motoko-base/archive/01355c21813ca131040c125d5a4e5fcf11c24071.tar.gz",
+        "url": "https://github.com/dfinity/motoko-base/archive/c78a28f407014a3f4e81216cdc2ed05472b8d051.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "motoko-matchers": {

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -3417,7 +3417,7 @@ module IC = struct
   let import_ic0 env =
       E.add_func_import env "ic0" "call_data_append" (i32s 2) [];
       (* E.add_func_import env "ic0" "call_cycles_add" [I64Type] [] *)
-      E.add_func_import env "ic0" "call_cycles_add128" [I32Type] [];
+      E.add_func_import env "ic0" "call_cycles_add128" (i64s 2) [];
       E.add_func_import env "ic0" "call_new" (i32s 8) [];
       E.add_func_import env "ic0" "call_perform" [] [I32Type];
       E.add_func_import env "ic0" "call_on_cleanup" (i32s 2) [];
@@ -3434,9 +3434,9 @@ module IC = struct
       (* E.add_func_import env "ic0" "msg_cycles_available" [] [I64Type]; *)
       E.add_func_import env "ic0" "msg_cycles_available128" [I32Type] [];
       (* E.add_func_import env "ic0" "msg_cycles_refunded" [] [I64Type]; *)
-      E.add_func_import env "ic0" "msg_cycles_refunded" [I32Type] [];
+      E.add_func_import env "ic0" "msg_cycles_refunded128" [I32Type] [];
       (* E.add_func_import env "ic0" "msg_cycles_accept" [I64Type] [I64Type]; *)
-      E.add_func_import env "ic0" "msg_cycles_accept128" (i32s 2) [I32Type];
+      E.add_func_import env "ic0" "msg_cycles_accept128" [I64Type; I64Type; I32Type] [];
       E.add_func_import env "ic0" "certified_data_set" (i32s 2) [];
       E.add_func_import env "ic0" "data_certificate_present" [] [I32Type];
       E.add_func_import env "ic0" "data_certificate_size" [] [I32Type];
@@ -3869,6 +3869,7 @@ module Cycles = struct
 *)
   let push_high_low env =  Func.share_code1 env "push_high_low" ("val", I32Type) [I64Type; I64Type]
     (fun env get_val ->
+      get_val ^^
       BigNum.fits_unsigned_bits env 64 ^^
       E.else_trap_with env "Cycles out of bounds" ^^
       get_val ^^
@@ -8250,7 +8251,7 @@ and compile_exp (env : E.t) ae exp =
     (* Cycles *)
     | SystemCyclesBalancePrim, [] ->
       SR.Vanilla,
-      Stack.with_words env "dst" 8l (fun get_dst ->
+      Stack.with_words env "dst" 4l (fun get_dst ->
         get_dst ^^
         IC.cycle_balance env ^^
         get_dst ^^
@@ -8263,7 +8264,7 @@ and compile_exp (env : E.t) ae exp =
       IC.cycles_add env
     | SystemCyclesAcceptPrim, [e1] ->
       SR.Vanilla,
-      Stack.with_words env "dst" 8l (fun get_dst ->
+      Stack.with_words env "dst" 4l (fun get_dst ->
         compile_exp_vanilla env ae e1 ^^
         Cycles.push_high_low env ^^
         get_dst ^^
@@ -8273,7 +8274,7 @@ and compile_exp (env : E.t) ae exp =
       )
     | SystemCyclesAvailablePrim, [] ->
       SR.Vanilla,
-      Stack.with_words env "dst" 8l (fun get_dst ->
+      Stack.with_words env "dst" 4l (fun get_dst ->
         get_dst ^^
         IC.cycles_available env ^^
         get_dst ^^
@@ -8281,7 +8282,7 @@ and compile_exp (env : E.t) ae exp =
       )
     | SystemCyclesRefundedPrim, [] ->
       SR.Vanilla,
-      Stack.with_words env "dst" 8l (fun get_dst ->
+      Stack.with_words env "dst" 4l (fun get_dst ->
         get_dst ^^
         IC.cycles_refunded env ^^
         get_dst ^^

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -2061,7 +2061,7 @@ sig
   (* given a numeric object on the stack as skewed pointer, check whether
      it can be faithfully stored in N unsigned bits
      leaves boolean result on the stack
-     N must be 1..128
+     N must be 1..64
    *)
   val fits_unsigned_bits : E.t -> int -> G.t
 end
@@ -6818,26 +6818,6 @@ module Cycles = struct
         (Big_int.power_int_positive_int 2 64))) ^^
       BigNum.compile_mul env ^^ (* TODO: use shift left instead *)
       BigNum.compile_add env)
-
-(*
-  (* TODO: if we had i64 (fake) multivalue support, we could use this instead of the follow three *)
-  let push_high_low env =  Func.share_code1 env "push_high_low" ("val", I32Type) [I64Type; I64Type]
-    (fun env get_val ->
-      get_val ^^
-      compile_lit_as env SR.Vanilla (Ir.NatLit (Numerics.Nat.of_big_int
-        (Big_int.power_int_positive_int 2 128))) ^^
-      BigNum.compile_relop env Lt ^^
-      E.else_trap_with env "cycles out of bounds" ^^
-      get_val ^^
-      (* shift right 64 bits *)
-      compile_lit_as env SR.Vanilla (Ir.NatLit (Numerics.Nat.of_big_int
-        (Big_int.power_int_positive_int 2 64))) ^^
-      BigNum.compile_unsigned_div env ^^ (* TODO: use shift right instead *)
-      BigNum.truncate_to_word64 env ^^
-      get_val ^^
-      BigNum.truncate_to_word64 env)
- *)
-
 
   let guard env =  Func.share_code1 env "__cycles_guard" ("val", I32Type) []
     (fun env get_val ->

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -3833,7 +3833,7 @@ module Cycles = struct
       (G.i (Load {ty = I64Type; align = 0; offset = 0l; sz = None })) ^^
       BigNum.from_word64 env ^^
       get_ptr ^^
-      compile_add_const 4l ^^
+      compile_add_const 8l ^^
       (G.i (Load {ty = I64Type; align = 0; offset = 0l; sz = None })) ^^
       BigNum.from_word64 env ^^
       (* shift left 64 *)

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -3416,12 +3416,10 @@ module IC = struct
 
   let import_ic0 env =
       E.add_func_import env "ic0" "call_data_append" (i32s 2) [];
-      (* E.add_func_import env "ic0" "call_cycles_add" [I64Type] [] *)
       E.add_func_import env "ic0" "call_cycles_add128" (i64s 2) [];
       E.add_func_import env "ic0" "call_new" (i32s 8) [];
       E.add_func_import env "ic0" "call_perform" [] [I32Type];
       E.add_func_import env "ic0" "call_on_cleanup" (i32s 2) [];
-      (* E.add_func_import env "ic0" "canister_cycle_balance" [] [I64Type]; *)
       E.add_func_import env "ic0" "canister_cycle_balance128" [I32Type] [];
       E.add_func_import env "ic0" "canister_self_copy" (i32s 3) [];
       E.add_func_import env "ic0" "canister_self_size" [] [I32Type];
@@ -3431,11 +3429,8 @@ module IC = struct
       E.add_func_import env "ic0" "msg_arg_data_size" [] [I32Type];
       E.add_func_import env "ic0" "msg_caller_copy" (i32s 3) [];
       E.add_func_import env "ic0" "msg_caller_size" [] [I32Type];
-      (* E.add_func_import env "ic0" "msg_cycles_available" [] [I64Type]; *)
       E.add_func_import env "ic0" "msg_cycles_available128" [I32Type] [];
-      (* E.add_func_import env "ic0" "msg_cycles_refunded" [] [I64Type]; *)
       E.add_func_import env "ic0" "msg_cycles_refunded128" [I32Type] [];
-      (* E.add_func_import env "ic0" "msg_cycles_accept" [I64Type] [I64Type]; *)
       E.add_func_import env "ic0" "msg_cycles_accept128" [I64Type; I64Type; I32Type] [];
       E.add_func_import env "ic0" "certified_data_set" (i32s 2) [];
       E.add_func_import env "ic0" "data_certificate_present" [] [I32Type];

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -3831,12 +3831,13 @@ module Cycles = struct
       compile_add_const 4l ^^
       (G.i (Load {ty = I64Type; align = 0; offset = 0l; sz = None })) ^^
       BigNum.from_word64 env ^^
+      (* shift left 64 *)
       compile_unboxed_const 2l ^^
       BigNum.from_word32 env ^^
       compile_unboxed_const 64l ^^
       BigNum.from_word32 env ^^
       BigNum.compile_unsigned_pow env ^^
-      BigNum.compile_mul env ^^
+      BigNum.compile_mul env ^^ (* TODO: use shift left instead *)
       BigNum.compile_add env)
 
   let store_cycles env =  Func.share_code2 env "store_cycles" (("ptr", I32Type), ("val", I32Type)) []
@@ -3851,12 +3852,13 @@ module Cycles = struct
       get_ptr ^^
       compile_add_const 4l ^^
       get_val ^^
+      (* shift right 64 bits *)
       compile_unboxed_const 2l ^^
       BigNum.from_word32 env ^^
       compile_unboxed_const 64l ^^
       BigNum.from_word32 env ^^
       BigNum.compile_unsigned_pow env ^^
-      BigNum.compile_unsigned_div env ^^
+      BigNum.compile_unsigned_div env ^^ (* TODO: use shift right instead *)
       BigNum.truncate_to_word64 env ^^
       (G.i (Store {ty = I64Type; align = 0; offset = 0l; sz = None })))
 

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -6827,7 +6827,7 @@ module Cycles = struct
       compile_lit_as env SR.Vanilla (Ir.NatLit (Numerics.Nat.of_big_int
         (Big_int.power_int_positive_int 2 128))) ^^
       BigNum.compile_relop env Lt ^^
-      E.else_trap_with env "Cycles out of bounds" ^^
+      E.else_trap_with env "cycles out of bounds" ^^
       get_val ^^
       (* shift right 64 bits *)
       compile_lit_as env SR.Vanilla (Ir.NatLit (Numerics.Nat.of_big_int
@@ -6839,15 +6839,15 @@ module Cycles = struct
  *)
 
 
-  let guard env =  Func.share_code1 env "Cycles.guard" ("val", I32Type) []
+  let guard env =  Func.share_code1 env "__cycles_guard" ("val", I32Type) []
     (fun env get_val ->
       get_val ^^
       compile_lit_as env SR.Vanilla (Ir.NatLit (Numerics.Nat.of_big_int
         (Big_int.power_int_positive_int 2 128))) ^^
       BigNum.compile_relop env Lt ^^
-      E.else_trap_with env "Cycles out of bounds")
+      E.else_trap_with env "cycles out of bounds")
 
-  let push_high env =  Func.share_code1 env "Cycles.push_high" ("val", I32Type) [I64Type]
+  let push_high env =  Func.share_code1 env "__cycles_push_high" ("val", I32Type) [I64Type]
     (fun env get_val ->
       get_val ^^
       (* shift right 64 bits *)
@@ -6856,7 +6856,7 @@ module Cycles = struct
       BigNum.compile_unsigned_div env ^^ (* TODO: use shift right instead *)
       BigNum.truncate_to_word64 env)
 
-  let push_low env =  Func.share_code1 env "Cycles.push_low" ("val", I32Type) [I64Type]
+  let push_low env =  Func.share_code1 env "__cycles_push_low" ("val", I32Type) [I64Type]
     (fun env get_val ->
       get_val ^^
       BigNum.truncate_to_word64 env)

--- a/src/ir_def/check_ir.ml
+++ b/src/ir_def/check_ir.ml
@@ -642,12 +642,12 @@ let rec check_exp env (exp:Ir.exp) : unit =
       T.(Prim Nat64) <: t;
     (* Cycles *)
     | (SystemCyclesBalancePrim | SystemCyclesAvailablePrim | SystemCyclesRefundedPrim), [] ->
-      T.nat64 <: t
+      T.nat <: t
     | SystemCyclesAcceptPrim, [e1] ->
-      typ e1 <: T.nat64;
-      T.nat64 <: t
+      typ e1 <: T.nat;
+      T.nat <: t
     | SystemCyclesAddPrim, [e1] ->
-      typ e1 <: T.nat64;
+      typ e1 <: T.nat;
       T.unit <: t
     (* Certified Data *)
     | SetCertifiedData, [e1] ->

--- a/src/ir_def/construct.ml
+++ b/src/ir_def/construct.ml
@@ -101,7 +101,7 @@ let primE prim es =
     | RelPrim _ -> T.bool
     | SerializePrim _ -> T.blob
     | SystemCyclesAvailablePrim
-    | SystemCyclesAcceptPrim -> T.nat64
+    | SystemCyclesAcceptPrim -> T.nat
     | _ -> assert false (* implement more as needed *)
   in
   let effs = List.map eff es in

--- a/src/lowering/desugar.ml
+++ b/src/lowering/desugar.ml
@@ -798,9 +798,9 @@ let import_compiled_class (lib : S.comp_unit)  wasm : import_declaration =
   in
   let cs' = T.open_binds tbs in
   let c', _ = T.as_con (List.hd cs') in
-  let available = fresh_var "available" T.nat64 in
-  let accepted = fresh_var "accepted" T.nat64 in
-  let cycles = var "@cycles" (T.Mut (T.nat64)) in
+  let available = fresh_var "available" T.nat in
+  let accepted = fresh_var "accepted" T.nat in
+  let cycles = var "@cycles" (T.Mut (T.nat)) in
   let body =
     asyncE
       (typ_arg c' T.Scope T.scope_bound)

--- a/src/prelude/internals.mo
+++ b/src/prelude/internals.mo
@@ -16,7 +16,7 @@ var @cycles : Nat = 0;
 func @add_cycles() {
   let cycles = @cycles;
   @reset_cycles();
-  (prim "cyclesAdd" : Nat -> ()) (cycles);
+  (prim "cyclesAdd" : (Nat) -> ()) (cycles);
 };
 
 // Function called by backend to zero cycles on context switch.

--- a/src/prelude/internals.mo
+++ b/src/prelude/internals.mo
@@ -9,14 +9,14 @@ code, and cannot be shadowed.
 
 type @Iter<T_> = {next : () -> ?T_};
 
-var @cycles : Nat64 = 0;
+var @cycles : Nat = 0;
 
 // Function called by backend to add funds to call.
 // DO NOT RENAME without modifying compilation.
 func @add_cycles() {
   let cycles = @cycles;
   @reset_cycles();
-  (prim "cyclesAdd" : (Nat64) -> ()) (cycles);
+  (prim "cyclesAdd" : Nat -> ()) (cycles);
 };
 
 // Function called by backend to zero cycles on context switch.

--- a/src/prelude/internals.mo
+++ b/src/prelude/internals.mo
@@ -285,7 +285,7 @@ func @equal_array<T>(eq : (T, T) -> Bool, a : [T], b : [T]) : Bool {
 type @Cont<T> = T -> () ;
 type @Async<T> = (@Cont<T>,@Cont<Error>) -> ?(() -> ());
 
-type @Refund = Nat64;
+type @Refund = Nat;
 type @Result<T> = {#ok : (refund : @Refund, value: T); #error : Error};
 
 type @Waiter<T> = (@Refund,T) -> () ;
@@ -299,7 +299,7 @@ func @reset_refund() {
 };
 
 func @getSystemRefund() : @Refund {
-  return (prim "cyclesRefunded" : () -> Nat64) ();
+  return (prim "cyclesRefunded" : () -> Nat) ();
 };
 
 func @new_async<T <: Any>() : (@Async<T>, @Cont<T>, @Cont<Error>) {
@@ -393,8 +393,8 @@ let @ic00 = actor "aaaaa-aa" :
 // It would be desirable if create_actor_helper can be defined
 // without paying the extra self-remote-call-cost
 func @create_actor_helper(wasm_module_ : Blob, arg_ : Blob) : async Principal = async {
-  let available = (prim "cyclesAvailable" : () -> Nat64) ();
-  let accepted = (prim "cyclesAccept" : Nat64 -> Nat64) (available);
+  let available = (prim "cyclesAvailable" : () -> Nat) ();
+  let accepted = (prim "cyclesAccept" : Nat -> Nat) (available);
   @cycles += accepted;
   let { canister_id = canister_id_ } =
     await @ic00.create_canister({settings = null});

--- a/src/prelude/prim.mo
+++ b/src/prelude/prim.mo
@@ -278,6 +278,10 @@ func cyclesAccept(amount: Nat) : Nat {
 };
 
 func cyclesAdd(amount: Nat) : () {
+  // trap if @cycles would exceed 2^128
+  if ((@cycles + amount) > 0xFFFFFFFF_FFFFFFFF_FFFFFFFF_FFFFFFFF) {
+    trap("cannot add more than 2^128 cycles")
+  };
   @cycles += amount;
 };
 

--- a/src/prelude/prim.mo
+++ b/src/prelude/prim.mo
@@ -261,23 +261,23 @@ func principalOfActor(act : actor {}) : Principal = (prim "cast" : (actor {}) ->
 // Untyped dynamic actor creation from blobs
 let createActor : (wasm : Blob, argument : Blob) -> async Principal = @create_actor_helper;
 
-func cyclesBalance() : Nat64 {
-  (prim "cyclesBalance" : () -> Nat64) ();
+func cyclesBalance() : Nat {
+  (prim "cyclesBalance" : () -> Nat) ();
 };
 
-func cyclesAvailable() : Nat64 {
-  (prim "cyclesAvailable" : () -> Nat64) ();
+func cyclesAvailable() : Nat {
+  (prim "cyclesAvailable" : () -> Nat) ();
 };
 
-func cyclesRefunded() : Nat64 {
+func cyclesRefunded() : Nat {
     @refund
 };
 
-func cyclesAccept(amount: Nat64) : Nat64 {
-  (prim "cyclesAccept" : Nat64 -> Nat64) (amount);
+func cyclesAccept(amount: Nat) : Nat {
+  (prim "cyclesAccept" : Nat -> Nat) (amount);
 };
 
-func cyclesAdd(amount: Nat64) : () {
+func cyclesAdd(amount: Nat) : () {
   @cycles += amount;
 };
 

--- a/test/run-drun/actor-class-cycles.mo
+++ b/test/run-drun/actor-class-cycles.mo
@@ -5,7 +5,7 @@ import Lib = "actor-class-cycles/C";
 // test cycle transfer on class instantiation
 actor a {
 
-  func round(n : Nat64) : Text {
+  func round(n : Nat) : Text {
     debug_show((n + 500_000_000_000) / 1_000_000_000_000) # "T";
   };
 
@@ -19,7 +19,7 @@ actor a {
       Prim.debugPrint(debug_show({ iteration = i }));
       Prim.debugPrint(debug_show({ balance = round(Cycles.balance()) }));
       let c = await {
-        Cycles.add(Prim.natToNat64((i + 1) * 10_000_000_000_000));
+        Cycles.add((i + 1) * 10_000_000_000_000);
 	Lib.C();
       };
       let {current = cur; initial = init} = await c.balance();

--- a/test/run-drun/actor-class-cycles/C.mo
+++ b/test/run-drun/actor-class-cycles/C.mo
@@ -4,7 +4,7 @@ import Cycles = "../cycles/cycles"
 actor class C() = c {
   let initial_ = Cycles.balance();
   Prim.debugPrint(debug_show({ initial_C = initial_}));
-  public func balance() : async {initial: Nat64; current: Nat64} {
+  public func balance() : async {initial: Nat; current: Nat} {
      Prim.debugPrint(debug_show({ Principal = Prim.principalOfActor c }));
      return {
        initial = initial_;

--- a/test/run-drun/basic-cycles.mo
+++ b/test/run-drun/basic-cycles.mo
@@ -1,0 +1,70 @@
+import Prim "mo:⛔";
+
+actor a {
+
+  let balance : () -> Nat = Prim.cyclesBalance;
+  let available : () -> Nat = Prim.cyclesAvailable;
+  let accept : Nat-> Nat = Prim.cyclesAccept;
+  let add : Nat -> () = Prim.cyclesAdd;
+
+  let refunded : () -> Nat = Prim.cyclesRefunded;
+
+
+  public func provisional_top_up_actor(a : actor {}, amount : Nat) : async () {
+    let amount_ = amount;
+    let ic00 = actor "aaaaa-aa" : actor {
+      provisional_top_up_canister :
+        { canister_id: Principal; amount : Nat } -> async ();
+    };
+    await ic00.provisional_top_up_canister({
+      canister_id = Prim.principalOfActor(a);
+      amount = amount_})
+  };
+
+
+  public func test(amount : Nat) : async () {
+     Prim.debugPrint(debug_show({available=available(); amount = amount}));
+     assert (available() == amount);
+  };
+
+  var tests = [
+     0x0,
+     0xFFFFFFFF,
+     0xFFFFFFFF_FFFFFFFF,
+     0x1_00000000_00000000,
+     0xFFFFFFFF_FFFFFFFF_FFFFFFFF,
+     0xFFFFFFFF_FFFFFFFF_FFFFFFFF_FFFFFFFF,
+  ];
+
+  public func iter() : async () {
+
+     for (amount in tests.vals()) {
+       Prim.debugPrint(debug_show {balance = balance()});
+       if (balance() < amount) {
+         await provisional_top_up_actor(a, amount - balance());
+       };
+       Prim.debugPrint(debug_show {topped_up_balance = balance()});
+       if (amount > balance()) {
+         Prim.debugPrint("can't top up more");
+         return; // give up on test
+       };
+       add(amount);
+       Prim.debugPrint(debug_show({added = amount}));
+       try {
+         await test(amount);
+       } catch e {
+         Prim.debugPrint(Prim.errorMessage(e));
+       }
+     }
+  };
+
+  public func go() : async (){
+     await iter();
+  }
+};
+
+a.go(); //OR-CALL ingress go "DIDL\x00\x00"
+//SKIP run
+//SKIP run-ir
+//SKIP run-low
+

--- a/test/run-drun/basic-cycles.mo
+++ b/test/run-drun/basic-cycles.mo
@@ -1,3 +1,5 @@
+// test cycle overflow detection and larger cycle transfers
+
 import Prim "mo:⛔";
 
 actor a {
@@ -25,6 +27,34 @@ actor a {
   public func test(amount : Nat) : async () {
      Prim.debugPrint(debug_show({available=available(); amount = amount}));
      assert (available() == amount);
+  };
+
+  // test overflow of 128 bit cylce amounts
+  public func overflow() : async () {
+
+     // detect immediate overflow of add
+     try (await async {
+       add(0x1_00000000_00000000_00000000_00000000);
+       assert false;
+     })
+     catch (e) {Prim.debugPrint(Prim.errorMessage(e))};
+
+     // detect incremental overflow of add
+     try (await async {
+       add(0xFFFFFFFF_FFFFFFFF_FFFFFFFFF_FFFFFFF);
+       Prim.debugPrint("ok");
+       add(0x1);
+       assert false;
+     })
+     catch (e) { Prim.debugPrint(Prim.errorMessage(e)) };
+
+     // detect accept overflow
+     try (await async {
+       let _ = accept(0x1_00000000_00000000_00000000_00000000);
+       assert false;
+     })
+     catch (e) { Prim.debugPrint(Prim.errorMessage(e)) };
+
   };
 
   var tests = [
@@ -59,7 +89,8 @@ actor a {
   };
 
   public func go() : async (){
-     await iter();
+    await overflow();
+    await iter();
   }
 };
 

--- a/test/run-drun/basic-cycles.mo
+++ b/test/run-drun/basic-cycles.mo
@@ -29,7 +29,7 @@ actor a {
      assert (available() == amount);
   };
 
-  // test overflow of 128 bit cylce amounts
+  // test overflow of 128 bit cycle amounts
   public func overflow() : async () {
 
      // detect immediate overflow of add

--- a/test/run-drun/class-import.mo
+++ b/test/run-drun/class-import.mo
@@ -8,7 +8,7 @@ import M3 "class-import/trap";
 actor a {
  public func go() : async () {
    // To get lots of cycles in both drun and ic-ref-run
-   if (Cycles.balance() == (0 : Nat64))
+   if (Cycles.balance() == 0)
      await Cycles.provisional_top_up_actor(a, 100_000_000_000_000);
 
    // test no arg class

--- a/test/run-drun/clone.mo
+++ b/test/run-drun/clone.mo
@@ -14,7 +14,7 @@ actor Cloner {
 
    public shared func test() : async () {
       // get some cycles
-      if (Cycles.balance() == (0 : Nat64))
+      if (Cycles.balance() == 0)
       await Cycles.provisional_top_up_actor(Cloner, 100_000_000_000_000);
 
       // create the original Cloneable object

--- a/test/run-drun/cycles/cycles.mo
+++ b/test/run-drun/cycles/cycles.mo
@@ -2,15 +2,20 @@ import Prim "mo:⛔";
 
 module {
 
-  public let balance : () -> Nat64 = Prim.cyclesBalance;
+  //public let balance : () -> Nat64 = Prim.cyclesBalance;
+  public func balance() : Nat64 = Prim.natToNat64(Prim.cyclesBalance());
 
-  public let available : () -> Nat64 = Prim.cyclesAvailable;
+  //public let available : () -> Nat64 = Prim.cyclesAvailable;
+  public func avalable() : Nat64 = Prim.natToNat64(Prim.cyclesAvailable());
 
-  public let accept : Nat64 -> Nat64 = Prim.cyclesAccept;
+  //public let accept : Nat64 -> Nat64 = Prim.cyclesAccept;
+  public func accept(n : Nat64) : Nat64 = Prim.natToNat64(Prim.cyclesAccept(Prim.nat64ToNat(n)));
 
-  public let add : Nat64 -> () = Prim.cyclesAdd;
+  // public let add : Nat64 -> () = Prim.cyclesAdd;
+  public func add(n : Nat64) : () =  Prim.cyclesAdd(Prim.nat64ToNat(n));
 
-  public let refunded : () -> Nat64 = Prim.cyclesRefunded;
+  //public let refunded : () -> Nat64 = Prim.cyclesRefunded;
+  public func refunded() : Nat64 = Prim.natToNat64(Prim.cyclesRefunded());
 
   public func provisional_top_up_actor(a : actor {}, amount : Nat) : async () {
     let amount_ = amount;

--- a/test/run-drun/cycles/cycles.mo
+++ b/test/run-drun/cycles/cycles.mo
@@ -2,20 +2,15 @@ import Prim "mo:⛔";
 
 module {
 
-  //public let balance : () -> Nat64 = Prim.cyclesBalance;
-  public func balance() : Nat64 = Prim.natToNat64(Prim.cyclesBalance());
+  public let balance : () -> Nat = Prim.cyclesBalance;
 
-  //public let available : () -> Nat64 = Prim.cyclesAvailable;
-  public func available() : Nat64 = Prim.natToNat64(Prim.cyclesAvailable());
+  public let available : () -> Nat = Prim.cyclesAvailable;
 
-  //public let accept : Nat64 -> Nat64 = Prim.cyclesAccept;
-  public func accept(n : Nat64) : Nat64 = Prim.natToNat64(Prim.cyclesAccept(Prim.nat64ToNat(n)));
+  public let accept : Nat -> Nat = Prim.cyclesAccept;
 
-  // public let add : Nat64 -> () = Prim.cyclesAdd;
-  public func add(n : Nat64) : () =  Prim.cyclesAdd(Prim.nat64ToNat(n));
+  public let add : Nat -> () = Prim.cyclesAdd;
 
-  //public let refunded : () -> Nat64 = Prim.cyclesRefunded;
-  public func refunded() : Nat64 = Prim.natToNat64(Prim.cyclesRefunded());
+  public let refunded : () -> Nat = Prim.cyclesRefunded;
 
   public func provisional_top_up_actor(a : actor {}, amount : Nat) : async () {
     let amount_ = amount;

--- a/test/run-drun/cycles/cycles.mo
+++ b/test/run-drun/cycles/cycles.mo
@@ -6,7 +6,7 @@ module {
   public func balance() : Nat64 = Prim.natToNat64(Prim.cyclesBalance());
 
   //public let available : () -> Nat64 = Prim.cyclesAvailable;
-  public func avalable() : Nat64 = Prim.natToNat64(Prim.cyclesAvailable());
+  public func available() : Nat64 = Prim.natToNat64(Prim.cyclesAvailable());
 
   //public let accept : Nat64 -> Nat64 = Prim.cyclesAccept;
   public func accept(n : Nat64) : Nat64 = Prim.natToNat64(Prim.cyclesAccept(Prim.nat64ToNat(n)));

--- a/test/run-drun/cycles/wallet.mo
+++ b/test/run-drun/cycles/wallet.mo
@@ -13,7 +13,7 @@ shared(msg) actor class Wallet() {
     }));
   };
 
-  public func balance() : async Nat64 {
+  public func balance() : async Nat {
     return Cycles.balance();
   };
 
@@ -25,7 +25,7 @@ shared(msg) actor class Wallet() {
   };
 
   public shared(msg) func debit(
-    amount : Nat64,
+    amount : Nat,
     credit : shared () -> async ())
     : async () {
     if (msg.caller != owner) assert false;
@@ -34,14 +34,14 @@ shared(msg) actor class Wallet() {
   };
 
   public shared func refund(
-    amount : Nat64)
+    amount : Nat)
     : async () {
     ignore Cycles.accept(Cycles.available() - amount);
     print("refunding: " #  debug_show(amount));
   };
 
   public shared func available()
-    : async Nat64 {
+    : async Nat {
     let available = Cycles.available();
     print("available: " #  debug_show(available));
     return available;

--- a/test/run-drun/distributor.mo
+++ b/test/run-drun/distributor.mo
@@ -42,7 +42,7 @@ actor a {
   // Test
   public func go() : async () {
     // To get lots of cycles in both drun and ic-ref-run
-    if (Cycles.balance() == (0 : Nat64))
+    if (Cycles.balance() == 0)
       await Cycles.provisional_top_up_actor(a, 100_000_000_000_000);
 
     var i = 0;

--- a/test/run-drun/install-empty-actor.mo
+++ b/test/run-drun/install-empty-actor.mo
@@ -7,7 +7,7 @@ actor a {
 
   public func go() : async() {
     // To get lots of cycles in both drun and ic-ref-run
-    if (Cycles.balance() == (0 : Nat64))
+    if (Cycles.balance() == 0)
       await Cycles.provisional_top_up_actor(a, 100_000_000_000_000);
 
     try {

--- a/test/run-drun/ok/basic-cycles.drun-run.ok
+++ b/test/run-drun/ok/basic-cycles.drun-run.ok
@@ -1,0 +1,22 @@
+ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
+ingress Completed: Reply: 0x4449444c0000
+debug.print: {balance = 100_000_000_000_000}
+debug.print: {topped_up_balance = 100_000_000_000_000}
+debug.print: {added = 0}
+debug.print: {amount = 0; available = 0}
+debug.print: {balance = 100_000_000_000_000}
+debug.print: {topped_up_balance = 100_000_000_000_000}
+debug.print: {added = 4_294_967_295}
+debug.print: {amount = 4_294_967_295; available = 4_294_967_295}
+debug.print: {balance = 100_000_000_000_000}
+debug.print: {topped_up_balance = 18_446_744_073_709_551_615}
+debug.print: {added = 18_446_744_073_709_551_615}
+debug.print: {amount = 18_446_744_073_709_551_615; available = 18_446_744_073_709_551_615}
+debug.print: {balance = 18_446_744_073_709_551_615}
+debug.print: {topped_up_balance = 18_446_744_073_709_551_616}
+debug.print: {added = 18_446_744_073_709_551_616}
+debug.print: {amount = 18_446_744_073_709_551_616; available = 18_446_744_073_709_551_616}
+debug.print: {balance = 18_446_744_073_709_551_616}
+debug.print: {topped_up_balance = 18_446_844_073_709_551_616}
+debug.print: can't top up more
+ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/ok/basic-cycles.drun-run.ok
+++ b/test/run-drun/ok/basic-cycles.drun-run.ok
@@ -1,5 +1,9 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
+debug.print: IC0503: Canister rwlgt-iiaaa-aaaaa-aaaaa-cai trapped explicitly: cannot add more than 2^128 cycles
+debug.print: ok
+debug.print: IC0503: Canister rwlgt-iiaaa-aaaaa-aaaaa-cai trapped explicitly: cannot add more than 2^128 cycles
+debug.print: IC0503: Canister rwlgt-iiaaa-aaaaa-aaaaa-cai trapped explicitly: cycles out of bounds
 debug.print: {balance = 100_000_000_000_000}
 debug.print: {topped_up_balance = 100_000_000_000_000}
 debug.print: {added = 0}

--- a/test/run-drun/ok/basic-cycles.ic-ref-run.ok
+++ b/test/run-drun/ok/basic-cycles.ic-ref-run.ok
@@ -1,0 +1,29 @@
+→ update create_canister(record {settings = null})
+← replied: (record {hymijyo = principal "cvccv-qqaaq-aaaaa-aaaaa-c"})
+→ update install_code(record {arg = blob ""; kca_xin = blob "\00asm\01\00\00\00\0…
+← replied: ()
+→ update go()
+debug.print: {balance = 0}
+debug.print: {topped_up_balance = 0}
+debug.print: {added = 0}
+debug.print: {amount = 0; available = 0}
+debug.print: {balance = 0}
+debug.print: {topped_up_balance = 4_294_967_295}
+debug.print: {added = 4_294_967_295}
+debug.print: {amount = 4_294_967_295; available = 4_294_967_295}
+debug.print: {balance = 4_294_967_295}
+debug.print: {topped_up_balance = 18_446_744_073_709_551_615}
+debug.print: {added = 18_446_744_073_709_551_615}
+debug.print: {amount = 18_446_744_073_709_551_615; available = 18_446_744_073_709_551_615}
+debug.print: {balance = 18_446_744_073_709_551_615}
+debug.print: {topped_up_balance = 18_446_744_073_709_551_616}
+debug.print: {added = 18_446_744_073_709_551_616}
+debug.print: {amount = 18_446_744_073_709_551_616; available = 18_446_744_073_709_551_616}
+debug.print: {balance = 18_446_744_073_709_551_616}
+debug.print: {topped_up_balance = 79_228_162_514_264_337_593_543_950_335}
+debug.print: {added = 79_228_162_514_264_337_593_543_950_335}
+debug.print: {amount = 79_228_162_514_264_337_593_543_950_335; available = 79_228_162_514_264_337_593_543_950_335}
+debug.print: {balance = 79_228_162_514_264_337_593_543_950_335}
+debug.print: {topped_up_balance = 1_329_227_995_784_915_872_903_807_060_280_344_576}
+debug.print: can't top up more
+← replied: ()

--- a/test/run-drun/ok/basic-cycles.ic-ref-run.ok
+++ b/test/run-drun/ok/basic-cycles.ic-ref-run.ok
@@ -3,6 +3,10 @@
 → update install_code(record {arg = blob ""; kca_xin = blob "\00asm\01\00\00\00\0…
 ← replied: ()
 → update go()
+debug.print: canister trapped: EvalTrapError region:0xXXX-0xXXX "canister trapped explicitly: cannot add more than 2^128 cycles"
+debug.print: ok
+debug.print: canister trapped: EvalTrapError region:0xXXX-0xXXX "canister trapped explicitly: cannot add more than 2^128 cycles"
+debug.print: canister trapped: EvalTrapError region:0xXXX-0xXXX "canister trapped explicitly: cycles out of bounds"
 debug.print: {balance = 0}
 debug.print: {topped_up_balance = 0}
 debug.print: {added = 0}

--- a/test/run-drun/piggy-bank/ExperimentalCycles.mo
+++ b/test/run-drun/piggy-bank/ExperimentalCycles.mo
@@ -15,7 +15,7 @@ module {
 
   /// Returns the actor's current balance of cycles as `amount`.
   public func balance() : (amount : Nat) {
-    Prim.nat64ToNat(Prim.cyclesBalance())
+    Prim.cyclesBalance()
   };
 
   /// Returns the currently available `amount` of cycles.
@@ -25,14 +25,14 @@ module {
   /// any remaining available amount is automatically
   /// refunded to the caller/context.
   public func available() : (amount : Nat) {
-    Prim.nat64ToNat(Prim.cyclesAvailable())
+    Prim.cyclesAvailable()
   };
 
   /// Transfers up to `amount` from `available()` to `balance()`.
   /// Returns the amount actually transferred, which may be less than
   /// requested, for example, if less is available, or if canister balance limits are reached.
   public func accept(amount : Nat) : (accepted : Nat) {
-    Prim.nat64ToNat(Prim.cyclesAccept(Prim.natToNat64(amount)));
+    Prim.cyclesAccept(amount)
   };
 
   /// Indicates additional `amount` of cycles to be transferred in
@@ -45,7 +45,7 @@ module {
   /// **Note**: the implicit register of added amounts is reset to zero on entry to
   /// a shared function and after each shared function call or resume from an await.
   public func add(amount : Nat) : () {
-    Prim.cyclesAdd(Prim.natToNat64(amount))
+    Prim.cyclesAdd(amount)
   };
 
   /// Reports `amount` of cycles refunded in the last `await` of the current
@@ -54,7 +54,7 @@ module {
   /// Instead, refunds are automatically added to the current balance,
   /// whether or not `refunded` is used to observe them.
   public func refunded() : (amount : Nat) {
-    Prim.nat64ToNat(Prim.cyclesRefunded())
+    Prim.cyclesRefunded()
   };
 
 }

--- a/test/run-drun/test-cycles.mo
+++ b/test/run-drun/test-cycles.mo
@@ -8,7 +8,7 @@ actor client {
  func print(t:Text) { Prim.debugPrint("client: " # t); };
 
  public func go() : async () {
-  if (Cycles.balance() == (0 : Nat64))
+  if (Cycles.balance() == 0)
     await Cycles.provisional_top_up_actor(client, 3_000_000_000_000);
 
 //  print("balance: " # debug_show(Cycles.balance()) ); // to volatile to show
@@ -25,7 +25,7 @@ actor client {
   await wallet.show();
 
   // debit from the wallet, crediting this actor via callback
-  let amount : Nat64 = 1000_000;
+  let amount = 1000_000;
   print("# debit");
 //  print("balance: " # debug_show(Cycles.balance()));
   let b = Cycles.balance();
@@ -62,12 +62,12 @@ actor client {
 
 
   // issue a bunch of refund requests, await them in reverse and check the refunds are as expected.
-  func testRefunds(n : Nat64) : async () {
-     if (n == (0 : Nat64)) return;
+  func testRefunds(n : Nat) : async () {
+     if (n == 0) return;
      Cycles.add(n);
      print("refund(" # debug_show(n) # ")");
      let a = wallet.refund(n);
-     await testRefunds( n - (1 : Nat64));
+     await testRefunds( n - 1);
      await a;
      print("refunded: " # debug_show(Cycles.refunded()));
      assert (Cycles.refunded() == n);


### PR DESCRIPTION
Upgrades Motoko to use new 128 bit cycle transfer API.

- Uses `Nat` and overflow checks to represent 128 bit values.
- Adds test `basic-cycles.mo` to check transfer work (complicated by fact that topping up of `drun` canisters is limited to 64-bit values).
- Rewrites existing tests to avoid old 64 bit prims.
- bumps `motoko-base` to use revamped `ExperimentalCycles.mo` with same external API, but new internal implementation. 

(Stumbled across restriction that multivalue elimination doesn't support anything but i32. Otherwise, could have combined `push_high` and `push_low` into single `push_high_low` operation. But that can come later).
