### PR TITLE
perf: optimize overflow check in RTS `alloc_words`, fix and update tests

### DIFF
--- a/rts/motoko-rts/src/memory/ic.rs
+++ b/rts/motoko-rts/src/memory/ic.rs
@@ -95,7 +95,7 @@ unsafe fn grow_memory(ptr: u64) {
     debug_assert!(ptr <= 2 * u64::from(core::u32::MAX));
     let page_size = u64::from(WASM_PAGE_SIZE.as_u32());
     let total_pages_needed = ((ptr + page_size - 1) / page_size) as usize;
-    let current_pages = wasm32::memory_size(0) as usize;
+    let current_pages = wasm32::memory_size(0);
     if total_pages_needed > current_pages {
         if wasm32::memory_grow(0, total_pages_needed - current_pages) == core::usize::MAX {
             rts_trap_with("Cannot grow memory");

--- a/rts/motoko-rts/src/memory/ic.rs
+++ b/rts/motoko-rts/src/memory/ic.rs
@@ -79,10 +79,10 @@ impl Memory for IcMemory {
         let old_hp = u64::from(HP);
         let new_hp = old_hp + delta;
 
-
         // Grow memory if needed
         grow_memory(new_hp);
 
+        debug_assert!(new_hp <= u64::from(core::u32::MAX));
         HP = new_hp as u32;
 
         Value::from_ptr(old_hp as usize)
@@ -92,11 +92,12 @@ impl Memory for IcMemory {
 /// Page allocation. Ensures that the memory up to, but excluding, the given pointer is allocated.
 #[inline(never)]
 unsafe fn grow_memory(ptr: u64) {
+    debug_assert!(ptr <= 2*u64::from(core::u32::MAX));
     let page_size = u64::from(WASM_PAGE_SIZE.as_u32());
-    let total_pages_needed = (ptr + page_size - 1) / page_size;
-    let current_pages = wasm32::memory_size(0) as u64;
+    let total_pages_needed = ((ptr + page_size - 1) / page_size) as usize;
+    let current_pages = wasm32::memory_size(0) as usize;
     if total_pages_needed > current_pages {
-        if wasm32::memory_grow(0, (total_pages_needed - current_pages) as usize) == core::usize::MAX {
+        if wasm32::memory_grow(0, total_pages_needed - current_pages) == core::usize::MAX {
             rts_trap_with("Cannot grow memory");
         }
     }

--- a/rts/motoko-rts/src/memory/ic.rs
+++ b/rts/motoko-rts/src/memory/ic.rs
@@ -72,19 +72,18 @@ impl Memory for IcMemory {
     unsafe fn alloc_words(&mut self, n: Words<u32>) -> Value {
         let bytes = n.to_bytes();
         // Update ALLOCATED
-        ALLOCATED += Bytes(u64::from(bytes.as_u32()));
+        let delta = u64::from(bytes.as_u32());
+        ALLOCATED += Bytes(delta);
 
         // Update heap pointer
-        let old_hp = HP;
-        let (new_hp, overflow) = old_hp.overflowing_add(bytes.as_u32());
-        // Check for overflow
-        if overflow {
-            rts_trap_with("Out of memory");
-        }
-        HP = new_hp;
+        let old_hp = u64::from(HP);
+        let new_hp = old_hp + delta;
+
 
         // Grow memory if needed
-        grow_memory(new_hp as usize);
+        grow_memory(new_hp);
+
+        HP = new_hp as u32;
 
         Value::from_ptr(old_hp as usize)
     }
@@ -92,12 +91,12 @@ impl Memory for IcMemory {
 
 /// Page allocation. Ensures that the memory up to, but excluding, the given pointer is allocated.
 #[inline(never)]
-unsafe fn grow_memory(ptr: usize) {
+unsafe fn grow_memory(ptr: u64) {
     let page_size = u64::from(WASM_PAGE_SIZE.as_u32());
-    let total_pages_needed = (((ptr as u64) + page_size - 1) / page_size) as usize;
-    let current_pages = wasm32::memory_size(0);
+    let total_pages_needed = (ptr + page_size - 1) / page_size;
+    let current_pages = wasm32::memory_size(0) as u64;
     if total_pages_needed > current_pages {
-        if wasm32::memory_grow(0, total_pages_needed - current_pages) == core::usize::MAX {
+        if wasm32::memory_grow(0, (total_pages_needed - current_pages) as usize) == core::usize::MAX {
             rts_trap_with("Cannot grow memory");
         }
     }

--- a/rts/motoko-rts/src/memory/ic.rs
+++ b/rts/motoko-rts/src/memory/ic.rs
@@ -92,7 +92,7 @@ impl Memory for IcMemory {
 /// Page allocation. Ensures that the memory up to, but excluding, the given pointer is allocated.
 #[inline(never)]
 unsafe fn grow_memory(ptr: u64) {
-    debug_assert!(ptr <= 2*u64::from(core::u32::MAX));
+    debug_assert!(ptr <= 2 * u64::from(core::u32::MAX));
     let page_size = u64::from(WASM_PAGE_SIZE.as_u32());
     let total_pages_needed = ((ptr + page_size - 1) / page_size) as usize;
     let current_pages = wasm32::memory_size(0) as usize;

--- a/test/run-drun/ok/oom-query.drun-run.ok
+++ b/test/run-drun/ok/oom-query.drun-run.ok
@@ -1,3 +1,3 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-Err: IC0503: Canister rwlgt-iiaaa-aaaaa-aaaaa-cai trapped explicitly: RTS error: Out of memory
+Err: IC0503: Canister rwlgt-iiaaa-aaaaa-aaaaa-cai trapped explicitly: RTS error: Cannot grow memory

--- a/test/run-drun/ok/oom-update.drun-run.ok
+++ b/test/run-drun/ok/oom-update.drun-run.ok
@@ -1,3 +1,3 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-Err: IC0503: Canister rwlgt-iiaaa-aaaaa-aaaaa-cai trapped explicitly: RTS error: Out of memory
+ingress Err: IC0503: Canister rwlgt-iiaaa-aaaaa-aaaaa-cai trapped explicitly: RTS error: Cannot grow memory

--- a/test/run-drun/oom-update.mo
+++ b/test/run-drun/oom-update.mo
@@ -2,7 +2,7 @@
 import P "mo:⛔";
 actor {
 
-  public query func go() : async () {
+  public func go() : async () {
     // allocate 3GB
     var c = 3;
     while(c > 0) {
@@ -25,5 +25,5 @@ actor {
 //SKIP run-ir
 // too slow on ic-ref-run:
 //SKIP comp-ref
-//CALL query go "DIDL\x00\x00"
+//CALL ingress go "DIDL\x00\x00"
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -87,7 +87,7 @@ function normalize () {
     # Normalize instruction locations on traps, added by ic-ref ad6ea9e
     sed 's/region:0x[0-9a-fA-F]\+-0x[0-9a-fA-F]\+/region:0xXXX-0xXXX/g' |
     # Delete everything after Oom
-    sed '/RTS error: Out of memory/q' |
+    sed '/RTS error: Cannot grow memory/q' |
     cat > $1.norm
     mv $1.norm $1
   fi

--- a/test/run/ok/inc-oom.wasm-run.ok
+++ b/test/run/ok/inc-oom.wasm-run.ok
@@ -1,1 +1,1 @@
-RTS error: Out of memory
+RTS error: Cannot grow memory


### PR DESCRIPTION
#3077 added an expensive, but necessary overflow check to `alloc_words`, to prevent allocating addresses outside the 32-bit heap.

* This PR optimizes that check to avoid the conditional test by doing the page diff arithmetic in u64s, 
relying on `grow_memory` to trap when asked to grow beyond 2^16 pages.
* fixes test `run-drun/oom-update` to actually use an update (not query) method as advertised.

I wonder why `grow_memory` is marked `inline_never`? Seems like we'd save a function call on each allocation...
