### PR TITLE
experiment: diagnosing and addressing Issue 3057

### DIFF
--- a/src/mo_frontend/bi_match.ml
+++ b/src/mo_frontend/bi_match.ml
@@ -81,6 +81,7 @@ let bi_match_subs scope_opt tbs subs typ_opt =
   in
 
   let rec bi_match_typ rel eq ((l, u) as inst) any t1 t2 =
+    (if SS.cardinal (!rel) > 1000 then assert false);
     if t1 == t2 || SS.mem (t1, t2) !rel
     then Some inst
     else begin

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -2431,7 +2431,7 @@ and infer_id_typdecs id c k : Scope.con_env =
   assert (match k with T.Abs (_, T.Pre) -> false | _ -> true);
   (match Cons.kind c with
   | T.Abs (_, T.Pre) -> T.set_kind c k; id.note <- Some c
-  | k' -> assert (T.eq_kind k' k) (* may diverge on expansive types *)
+  | k' -> () (* assert (T.eq_kind k' k) (* may diverge on expansive types *) *)
   );
   T.ConSet.singleton c
 

--- a/src/mo_types/expansive.ml
+++ b/src/mo_types/expansive.ml
@@ -92,9 +92,12 @@ let edges_typ cs c (es : EdgeSet.t) t : EdgeSet.t =
       es2
     | Var (s, j) ->
       assert (j < i);
+      (* need to do something else here, but not this
       let es1 = VertexSet.fold (fun dj es -> EdgeSet.add (dj, 1, dj) es) exp es in
       let es2 = VertexSet.fold (fun dj es -> EdgeSet.add (dj, 1, dj) es) non es1 in
       es2
+      *)
+      es
     | (Prim _ | Any | Non | Pre ) -> es
     | Con (d, ts) when ConSet.mem d cs ->
       let exp1 = VertexSet.union exp non in

--- a/src/mo_types/expansive.ml
+++ b/src/mo_types/expansive.ml
@@ -92,7 +92,9 @@ let edges_typ cs c (es : EdgeSet.t) t : EdgeSet.t =
       es2
     | Var (s, j) ->
       assert (j < i);
-      es
+      let es1 = VertexSet.fold (fun dj es -> EdgeSet.add (dj, 1, dj) es) exp es in
+      let es2 = VertexSet.fold (fun dj es -> EdgeSet.add (dj, 1, dj) es) non es1 in
+      es2
     | (Prim _ | Any | Non | Pre ) -> es
     | Con (d, ts) when ConSet.mem d cs ->
       let exp1 = VertexSet.union exp non in

--- a/src/mo_types/type.ml
+++ b/src/mo_types/type.ml
@@ -653,6 +653,7 @@ let rel_list p rel eq xs1 xs2 =
   try List.for_all2 (p rel eq) xs1 xs2 with Invalid_argument _ -> false
 
 let rec rel_typ rel eq t1 t2 =
+  (if SS.cardinal (!rel) > 1000 then assert false);
   t1 == t2 || SS.mem (t1, t2) !rel || begin
   rel := SS.add (t1, t2) !rel;
   match t1, t2 with

--- a/test/run/3057-b.mo
+++ b/test/run/3057-b.mo
@@ -5,7 +5,6 @@ module {
   }
   */
 
- type Id<A> = object { map : <B>(A->B) -> Id<B> };
- //type Id<A> = ( <B>(A->B) -> Id<(B,B)>, Nat);
+ type Id<A> = object { map : <B>(A->B) -> Id<B> }; // note polymorphic recursion
 }
 

--- a/test/run/3057-b.mo
+++ b/test/run/3057-b.mo
@@ -1,0 +1,11 @@
+module {
+ /*
+  public class Id<A>(x : A) {
+    public func map<B>(f : A -> B) : Id<B> = Id(f x)
+  }
+  */
+
+ type Id<A> = object { map : <B>(A->B) -> Id<B> };
+ //type Id<A> = ( <B>(A->B) -> Id<(B,B)>, Nat);
+}
+

--- a/test/run/3057.mo
+++ b/test/run/3057.mo
@@ -1,6 +1,6 @@
 module {
   public class Id<A>(x : A) {
-    public func map<B>(f : A -> B) : Id<B> = Id(f x)
+    public func map<B>(f : A -> B) : Id<B> = Id<B>(f x)
   }
 }
 


### PR DESCRIPTION
Don't merge this - its just a branch for investigating issue #3057.
* adds another repro
* limits recursion depth for subtyping and bi_matching to generate useful short stack-traces.
* hack definition of expansiveness (totally broken though). Needs some thought on how to recognize polymorphic recursion via a bound type parameter.
