### PR TITLE
experiments to get extended candid-tests passing

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -6,10 +6,10 @@
         "homepage": "",
         "owner": "dfinity",
         "repo": "candid",
-        "rev": "734b796a7c2ffc8f4bb317c99ee3281d54bb36d5",
-        "sha256": "0nx0bw0r3l9zpvczrh0w97sng2900hh987yx7gakzahff4albl5v",
+        "rev": "0889e288c8c44ce36682ffa67df010c83e912a33",
+        "sha256": "122v440prlcr0z6zj1a7j0rjpk1a2xwpvj8vxrdbldl6ss1krbff",
         "type": "tarball",
-        "url": "https://github.com/dfinity/candid/archive/734b796a7c2ffc8f4bb317c99ee3281d54bb36d5.tar.gz",
+        "url": "https://github.com/dfinity/candid/archive/0889e288c8c44ce36682ffa67df010c83e912a33.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "esm": {

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -5687,7 +5687,8 @@ module MakeSerialization (Strm : Stream) = struct
           Heap.store_field MutBox.field
         )
       | Non ->
-        E.trap_with env "IDL error: deserializing value of type None"
+        skip get_idltyp ^^
+        coercion_failed "IDL error: deserializing value of type None"
       | _ -> todo_trap env "deserialize" (Arrange_ir.typ t)
       end ^^
       (* Parsed value on the stack, return that, unless the failure flag is set *)

--- a/src/mo_idl/idl_to_mo_value.ml
+++ b/src/mo_idl/idl_to_mo_value.ml
@@ -3,6 +3,7 @@ open Idllib.Exception
 open Source
 module T = Mo_types.Type
 
+module Pretty = T.MakePretty(T.ElideStamps)
 (*
 This module can translate Candid values (as parsed from the textual
 representation) into Motoko values. This is a pragmatic translation which is
@@ -71,7 +72,7 @@ let rec value v t =
     Printf.sprintf "(actor %s : actor { %s : %s }).%s"
       (text_lit s)
       (Idllib.Escape.escape_method Source.no_region m)
-      (T.string_of_typ t)
+      (Pretty.string_of_typ t)
       (Idllib.Escape.escape_method Source.no_region m)
   | PrincipalV s, _ ->
     "Prim.principalOfActor" ^ parens ("actor " ^ text_lit s ^ " : actor {}")

--- a/src/mo_types/type.ml
+++ b/src/mo_types/type.ml
@@ -1184,9 +1184,8 @@ let rec pp_typ_nullary vs ppf = function
     fprintf ppf "@[<1>[var %a]@]" (pp_typ_nullary vs) t
   | Array t ->
     fprintf ppf "@[<1>[%a]@]" (pp_typ_nullary vs) t
-  | Obj (s, fs) ->
-    fprintf ppf "@[<hv 2>%s{@;<0 0>%a@;<0 -2>}@]"
-      (string_of_obj_sort s)
+  | Obj (Object, fs) ->
+    fprintf ppf "@[<hv 2>{@;<0 0>%a@;<0 -2>}@]"
       (pp_print_list ~pp_sep:semi (pp_field vs)) fs
   | Variant [] -> pr ppf "{#}"
   | Variant fs ->

--- a/src/mo_types/type.ml
+++ b/src/mo_types/type.ml
@@ -1224,13 +1224,13 @@ and pp_dom parens vs ppf ts =
 and pp_cod vs ppf ts =
   match ts with
   | [Tup _] -> fprintf ppf "@[<1>(%a)@]" (pp_typ' vs) (seq ts)
-  | _ -> pp_typ' vs ppf (seq ts)
+  | _ -> pp_typ_nullary vs ppf (seq ts)
 
 and pp_control_cod sugar c vs ppf ts =
   match c, ts with
   (* sugar *)
   | Returns, [Async (_,t)] when sugar ->
-    fprintf ppf "@[<2>async@ %a@]" (pp_typ' vs) t
+    fprintf ppf "@[<2>async@ %a@]" (pp_typ_nullary vs) t
   | Promises, ts when sugar ->
     fprintf ppf "@[<2>async@ %a@]" (pp_cod vs) ts
   (* explicit *)

--- a/src/mo_types/type.ml
+++ b/src/mo_types/type.ml
@@ -1279,7 +1279,7 @@ and pp_typ' vs ppf t =
     | [tb] ->
       fprintf ppf "@[<2>%s%a ->@ %a@]"
         (string_of_func_sort s)
-        (pp_dom false (vs'vs)) ts1
+        (pp_dom true (vs'vs)) ts1
         (pp_control_cod true c (vs'vs)) ts2
     | _ ->
       fprintf ppf "@[<2>%s%a%a ->@ %a@]"

--- a/src/mo_types/type.ml
+++ b/src/mo_types/type.ml
@@ -1284,7 +1284,7 @@ and pp_typ' vs ppf t =
       fprintf ppf "@[<2>%s%a%a ->@ %a@]"
         (string_of_func_sort s)
         (pp_binds (vs'vs) vs'') tbs'
-        (pp_dom (tbs <> []) (vs'vs)) ts1
+        (pp_dom (tbs' <> []) (vs'vs)) ts1
         (pp_control_cod true c (vs'vs)) ts2
     )
   | Func (s, c, [], ts1, ts2) ->

--- a/src/mo_types/type.ml
+++ b/src/mo_types/type.ml
@@ -1184,8 +1184,9 @@ let rec pp_typ_nullary vs ppf = function
     fprintf ppf "@[<1>[var %a]@]" (pp_typ_nullary vs) t
   | Array t ->
     fprintf ppf "@[<1>[%a]@]" (pp_typ_nullary vs) t
-  | Obj (Object, fs) ->
-    fprintf ppf "@[<hv 2>{@;<0 0>%a@;<0 -2>}@]"
+  | Obj (s, fs) ->
+    fprintf ppf "@[<hv 2>%s{@;<0 0>%a@;<0 -2>}@]"
+      (string_of_obj_sort s)
       (pp_print_list ~pp_sep:semi (pp_field vs)) fs
   | Variant [] -> pr ppf "{#}"
   | Variant fs ->

--- a/src/mo_types/type.ml
+++ b/src/mo_types/type.ml
@@ -1279,7 +1279,7 @@ and pp_typ' vs ppf t =
     | [tb] ->
       fprintf ppf "@[<2>%s%a ->@ %a@]"
         (string_of_func_sort s)
-        (pp_dom true (vs'vs)) ts1
+        (pp_dom false (vs'vs)) ts1
         (pp_control_cod true c (vs'vs)) ts2
     | _ ->
       fprintf ppf "@[<2>%s%a%a ->@ %a@]"

--- a/src/mo_types/type.ml
+++ b/src/mo_types/type.ml
@@ -1224,7 +1224,7 @@ and pp_dom parens vs ppf ts =
 and pp_cod vs ppf ts =
   match ts with
   | [Tup _] -> fprintf ppf "@[<1>(%a)@]" (pp_typ' vs) (seq ts)
-  | _ -> pp_typ_nullary vs ppf (seq ts)
+  | _ -> pp_typ' vs ppf (seq ts)
 
 and pp_control_cod sugar c vs ppf ts =
   match c, ts with
@@ -1232,7 +1232,7 @@ and pp_control_cod sugar c vs ppf ts =
   | Returns, [Async (_,t)] when sugar ->
     fprintf ppf "@[<2>async@ %a@]" (pp_typ_nullary vs) t
   | Promises, ts when sugar ->
-    fprintf ppf "@[<2>async@ %a@]" (pp_cod vs) ts
+    fprintf ppf "@[<2>async@ %a@]" (pp_typ_nullary vs) (seq ts)
   (* explicit *)
   | (Returns | Promises), _ -> pp_cod vs ppf ts
   | Replies, _ -> fprintf ppf "@[<2>replies@ %a@]"  (pp_cod vs) ts

--- a/test/run-drun/ok/explicit-actor-import.tc.ok
+++ b/test/run-drun/ok/explicit-actor-import.tc.ok
@@ -1,4 +1,4 @@
 explicit-actor-import.mo:10.8-10.29: type error [M0114], object pattern cannot consume actor type
-  actor {go : shared () -> async actor {}}
+  actor {go : shared () -> async (actor {})}
 explicit-actor-import.mo:11.8-11.29: type error [M0114], object pattern cannot consume actor type
-  actor {go : shared () -> async actor {}}
+  actor {go : shared () -> async (actor {})}


### PR DESCRIPTION
Mostly good except (only 2 tests fail). Lessons:

- Motoko can't handle empty candid method names
- Future types break moc (in idl subtyping?)
- Moc pretty printing of types of higher order async function types may produce unparseable types, breaking suite.
- mo_idl lib needs a hack to avoid printing type stamps in idl function values and references.

Do not merge as type pretty printing needs (better) fixing (best in separate PR I guess)

 Failind candid tests:
 ```
construct:209 skipping minimal future type ... not ok (unwanted trap)!
IDL error: deserializing value of type None
Error: failed to run main module `tmp.wasm`

Caused by:
    0: failed to invoke command default
    1: wasm trap: unreachable
       wasm backtrace:
construct:210 skipping future type with data ... not ok (unwanted trap)!
IDL error: deserializing value of type None
Error: failed to run main module `tmp.wasm`

Caused by:
    0: failed to invoke command default
    1: wasm trap: unreachable
       wasm backtrace:
```