### PR TITLE
fix: use symbolic mangling in rts to avoid platform differences

### DIFF
--- a/rts/motoko-rts/.cargo/config
+++ b/rts/motoko-rts/.cargo/config
@@ -1,4 +1,4 @@
 # NB. codegen-units=1 is not necessary, but it generates less .o files for core,
 # std, and compiler_builtins and makes it easier to find symbols.
 [build]
-rustflags = ["-Crelocation-model=pic", "-Ccodegen-units=1"]
+rustflags = ["-Crelocation-model=pic", "-Ccodegen-units=1", "-Csymbol-mangling-version=v0"]

--- a/rts/motoko-rts/.cargo/config
+++ b/rts/motoko-rts/.cargo/config
@@ -1,4 +1,4 @@
 # NB. codegen-units=1 is not necessary, but it generates less .o files for core,
 # std, and compiler_builtins and makes it easier to find symbols.
 [build]
-rustflags = ["-Crelocation-model=pic", "-Ccodegen-units=1", "-Csymbol-mangling-version=v0"]
+rustflags = ["-Crelocation-model=pic", "-Ccodegen-units=1", "-Csymbol-mangling-version=v0", "-Zremap-cwd-prefix=."]

--- a/rts/motoko-rts/src/lib.rs
+++ b/rts/motoko-rts/src/lib.rs
@@ -93,8 +93,9 @@ pub(crate) unsafe fn rts_trap_with(msg: &str) -> ! {
 
 #[cfg(feature = "ic")]
 #[panic_handler]
-fn panic(info: &core::panic::PanicInfo) -> ! {
+fn panic(_info: &core::panic::PanicInfo) -> ! {
     unsafe {
+        /*
         if let Some(msg) = info.payload().downcast_ref::<&str>() {
             println!(1000, "RTS panic: {}", msg);
         } else if let Some(args) = info.message() {
@@ -114,7 +115,7 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
                 location.line(),
             );
         }
-
+*/
         rts_trap_with("RTS panicked");
     }
 }

--- a/rts/motoko-rts/src/lib.rs
+++ b/rts/motoko-rts/src/lib.rs
@@ -96,26 +96,26 @@ pub(crate) unsafe fn rts_trap_with(msg: &str) -> ! {
 fn panic(_info: &core::panic::PanicInfo) -> ! {
     unsafe {
         /*
-        if let Some(msg) = info.payload().downcast_ref::<&str>() {
-            println!(1000, "RTS panic: {}", msg);
-        } else if let Some(args) = info.message() {
-            let mut buf = [0 as u8; 1000];
-            let mut fmt = print::WriteBuf::new(&mut buf);
-            let _ = core::fmt::write(&mut fmt, *args);
-            print::print(&fmt);
-        } else {
-            println!(1000, "RTS panic: weird payload");
-        }
+                if let Some(msg) = info.payload().downcast_ref::<&str>() {
+                    println!(1000, "RTS panic: {}", msg);
+                } else if let Some(args) = info.message() {
+                    let mut buf = [0 as u8; 1000];
+                    let mut fmt = print::WriteBuf::new(&mut buf);
+                    let _ = core::fmt::write(&mut fmt, *args);
+                    print::print(&fmt);
+                } else {
+                    println!(1000, "RTS panic: weird payload");
+                }
 
-        if let Some(location) = info.location() {
-            println!(
-                1000,
-                "panic occurred in file '{}' at line {}",
-                location.file(),
-                location.line(),
-            );
-        }
-*/
+                if let Some(location) = info.location() {
+                    println!(
+                        1000,
+                        "panic occurred in file '{}' at line {}",
+                        location.file(),
+                        location.line(),
+                    );
+                }
+        */
         rts_trap_with("RTS panicked");
     }
 }


### PR DESCRIPTION
We currently produces different rts binaries on darwin and linux, due to the legacy Rust mangling scheme.

This PR instructs rustc to use the new(ish) symbolic mangling scheme in the hope that it resolves platform differences.