### PR TITLE
Record typing test

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Motoko compiler changelog
 
+## 0.6.28 (2022-05-19)
+
 * motoko (`moc`)
 
   * Add `to_candid`, `from_candid` language constructs for Candid serialization to/from Blobs (#3155)

--- a/test/run/records.mo
+++ b/test/run/records.mo
@@ -23,3 +23,7 @@ assert(rec3.y == y);
 assert(rec3.z == 13);
 assert(rec3.a == 4);
 assert(rec3.b == 5);
+
+type List<X> = ?(X, List<X>);
+func nil<X>() : List<X> = null;
+let rec4 : { var myList : List<Nat> } = { var myList = nil() };


### PR DESCRIPTION
Reproduces a bug in the lowering or other front-end phases of the compiler, where the initial type-check passes, but post lowering, the IR does not carry enough type information to check anymore (my best guess).

Thanks to @ninegua for reporting to the team Slack today, based on another dev's comment.

I'm not committing the new test outcome, because it's erroneous.

This message appears:
```
Ill-typed intermediate code after Desugaring (use -v to see dumped IR):
(unknown location): IR type error [M0000], subtype violation:
  {var myList : List<None>}
  {var myList : List<Nat>}
```