### PR TITLE
allow for 31 occupied bits in vanilla `BoxedSmallWord`

### DIFF
--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -1705,7 +1705,7 @@ module BoxedSmallWord = struct
     get_i
 
   let box env = Func.share_code1 env "box_i32" ("n", I32Type) [I32Type] (fun env get_n ->
-      get_n ^^ compile_unboxed_const (Int32.of_int (1 lsl 30)) ^^
+      get_n ^^ compile_unboxed_const (Int32.of_int (1 lsl 31)) ^^
       G.i (Compare (Wasm.Values.I32 I32Op.LtU)) ^^
       G.if1 I32Type
         (get_n ^^ BitTagged.tag_i32)

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -1193,7 +1193,7 @@ module BitTagged = struct
     E.if_ env retty is1 is2
 
   let if_can_tag_u64 env retty is1 is2 =
-    compile_shrU64_const 30L ^^
+    compile_shrU64_const 31L ^^
     G.i (Test (Wasm.Values.I64 I64Op.Eqz)) ^^
     E.if_ env retty is1 is2
 


### PR DESCRIPTION
fixes #3327

- [ ] Needs a bunch more tests, since the bitwise-operations may also be affected w.r.t bit 31 in `Int32`.