### PR TITLE
Reduce number of serialized `Nat` values in `ser-many-int` test

### DIFF
--- a/test/run-drun/ser-many-int.mo
+++ b/test/run-drun/ser-many-int.mo
@@ -13,7 +13,7 @@ public func go() : async () {
    if (n != deserInt(serInt(n))) {
      Prim.debugPrint(debug_show {failure = n});
    };
-   n -= 7919;
+   n -= 104729;
    c -= 1;
    if (c % 1024 == 0) {
        await async (); // trigger gc


### PR DESCRIPTION
Because this test often times out during CI, I increased the testing interval from the 1.000th prime number (7919) to the 10.000th prime number (104729). 