### PR TITLE
feat: actor class management syntactic sugar

### DIFF
--- a/doc/md/examples/grammar.txt
+++ b/doc/md/examples/grammar.txt
@@ -158,6 +158,7 @@
     <exp_post> '.' <id>
     <exp_post> ('<' <list(<typ>, ',')> '>')? <exp_nullary>
     <exp_post> BANG
+    '(' 'system' ')' <id> '.' <id>
 
 <exp_un> ::= 
     <exp_post>

--- a/doc/md/examples/grammar.txt
+++ b/doc/md/examples/grammar.txt
@@ -158,7 +158,7 @@
     <exp_post> '.' <id>
     <exp_post> ('<' <list(<typ>, ',')> '>')? <exp_nullary>
     <exp_post> BANG
-    '(' 'system' ')' <id> '.' <id>
+    '(' 'system' ')' <exp_nullary> '.' <id>
 
 <exp_un> ::= 
     <exp_post>

--- a/src/mo_frontend/parser.mly
+++ b/src/mo_frontend/parser.mly
@@ -582,9 +582,8 @@ exp_post(B) :
     { CallE(e1, inst, e2) @? at $sloc }
   | e1=exp_post(B) BANG
     { BangE(e1) @? at $sloc }
-  | LPAR SYSTEM RPAR lib = id DOT c=id
-    { DotE((VarE(lib.it @@ lib.at)) @? lib.at,
-       { c with it = "install" ^ c.it}) @? at $sloc }
+  | LPAR SYSTEM RPAR e1=exp_nullary(B) DOT c=id
+    { DotE(e1, { c with it = "install" ^ c.it}) @? at $sloc }
 
 exp_un(B) :
   | e=exp_post(B)

--- a/src/mo_frontend/parser.mly
+++ b/src/mo_frontend/parser.mly
@@ -556,6 +556,7 @@ exp_plain :
   | LPAR es=seplist(exp(ob), COMMA) RPAR
     { match es with [e] -> e | _ -> TupE(es) @? at $sloc }
 
+
 exp_nullary(B) :
   | e=B
     { e }
@@ -581,6 +582,9 @@ exp_post(B) :
     { CallE(e1, inst, e2) @? at $sloc }
   | e1=exp_post(B) BANG
     { BangE(e1) @? at $sloc }
+  | LPAR SYSTEM RPAR lib = id DOT c=id
+    { DotE((VarE(lib.it @@ lib.at)) @? lib.at,
+       { c with it = "install" ^ c.it}) @? at $sloc }
 
 exp_un(B) :
   | e=exp_post(B)
@@ -689,7 +693,6 @@ exp_nondec(B) :
     { e }
   | DO QUEST e=block
     { DoOptE(e) @? at $sloc }
-
 
 exp_nonvar(B) :
   | e=exp_nondec(B)

--- a/test/run-drun/actor-class-mgmt.mo
+++ b/test/run-drun/actor-class-mgmt.mo
@@ -39,13 +39,13 @@ actor a {
 
       Cycles.add(2_000_000_000_000);
       let c1 = await
-         C.installC (#new default_settings) 1;
+         (system) C.C (#new default_settings) 1;
       assert ({args = 1; upgrades = 0} == (await c1.observe()));
       assert (c1 != c0);
 
       Cycles.add(2_000_000_000_000);
       let c2 = await
-         (C.installC (#new settings) 2);
+         (system) C.C (#new settings) 2;
       assert ({args = 2; upgrades = 0} == (await c2.observe()));
       assert (c2 != c1);
 
@@ -54,20 +54,20 @@ actor a {
          ic00.create_canister default_settings;
       // no need to add cycles
       let c3 = await
-         C.installC (#install p) 3;
+         (system) C.C (#install p) 3;
       assert ({args = 3; upgrades = 0} == (await c3.observe()));
       assert (Prim.principalOfActor c3 == p);
       assert (c3 != c2);
 
       // no need to add cycles
       let c4 = await
-         C.installC (#upgrade c3) 4;
+         (system) C.C (#upgrade c3) 4;
       assert ({args = 4; upgrades = 1} == (await c4.observe()));
       assert (c4 == c3);
 
       // no need to add cycles
       let c5 = await
-         C.installC (#reinstall c4) 5;
+         (system) C.C (#reinstall c4) 5;
       assert ({args = 5; upgrades = 0} == (await c5.observe()));
       assert (c5 == c4);
     };

--- a/test/run-drun/map-upgrades/map0.mo
+++ b/test/run-drun/map-upgrades/map0.mo
@@ -4,7 +4,7 @@ import Lib "node0";
 
 // A naive, distributed map from Nat to Text.
 // Illustrates dynamic installation of imported actor classes.
-// Uses a fixed number of nodes, dynamically installed on demand 
+// Uses a fixed number of nodes, dynamically installed on demand
 // .. and upgraded with a call to upgradeNodes() (without data loss)
 
 actor a {
@@ -55,7 +55,7 @@ actor a {
          case null {};
          case (?n) {
            nodes[i] :=
-             ? (await Lib.installNode(#upgrade n)(i)); // upgrade!
+             ? (await (system) Lib.Node (#upgrade n) (i)); // upgrade!
          }
        }
     }

--- a/test/run-drun/map-upgrades/map1.mo
+++ b/test/run-drun/map-upgrades/map1.mo
@@ -65,7 +65,7 @@ actor a {
          case null {};
          case (?n) {
            nodes[i] :=
-             ? (await Lib.installNode(#upgrade n)(i)); // upgrade!
+             ? (await (system) Lib.Node (#upgrade n) (i)); // upgrade!
          }
        }
     }


### PR DESCRIPTION
Builds on #3386 
Add sugar 
```
<exp_post> ::=
   ...
  '(' 'system' ')' <exp_nullary> '.' <id>
```
for actor class management.

For example:

```
 await (system) Lib.Node (#upgrade n) (i); // upgrade!
````
is just

```
await Lib.installNode (#upgrade n) (i); // upgrade!
```
(accessing the secondary, mangled, power-user constructor).

This is just sugar so the error messages will be cryptic if the expression isn't an actor class lib or the name is wrong. To improve that, we need a new AST node, typing rules and slightly richer type environment (tracking classes vs functions).