### PR TITLE
feat: actor class management: syntactic sugar using 'system' sub module

### DIFF
--- a/doc/md/examples/grammar.txt
+++ b/doc/md/examples/grammar.txt
@@ -155,6 +155,7 @@
     '[' 'var'? <list(<exp_nonvar>, ',')> ']'
     <exp_post> '[' <exp> ']'
     <exp_post> '.'<nat>
+    <exp_post> '.' 'system'
     <exp_post> '.' <id>
     <exp_post> ('<' <list(<typ>, ',')> '>')? <exp_nullary>
     <exp_post> BANG

--- a/src/ir_def/construct.ml
+++ b/src/ir_def/construct.ml
@@ -682,14 +682,17 @@ let unreachableE () =
   (* Do we want a dedicated UnreachableE in the AST? *)
   loopE (unitE ())
 
-let recordE flds =
+
+let objE sort typ_flds flds =
   let rec go ds fields fld_tys flds =
     match flds with
     | [] ->
       blockE
         (List.rev ds)
-        (newObjE T.Object fields
-          (T.obj T.Object fld_tys))
+        (newObjE sort fields
+           (T.obj sort
+              ((List.map (fun (id,c) -> (id, T.Typ c)) typ_flds)
+               @ fld_tys)))
     | (lab, exp)::flds ->
       let v = fresh_var lab (typ exp) in
       let field = {
@@ -700,3 +703,5 @@ let recordE flds =
       go ((letD v exp)::ds) (field::fields) ((lab, typ exp)::fld_tys) flds
   in
   go [] [] [] flds
+
+let recordE flds = objE T.Object [] flds

--- a/src/ir_def/construct.mli
+++ b/src/ir_def/construct.mli
@@ -135,5 +135,8 @@ val forall : typ_bind list -> exp -> exp (* generalization *)
 val (-*-) : exp -> exp -> exp       (* application *)
 
 
+(* Objects *)
+val objE : obj_sort -> (lab * con) list -> (lab * exp) list -> exp
+
 (* Records *)
 val recordE : (lab * exp) list -> exp

--- a/src/lowering/desugar.ml
+++ b/src/lowering/desugar.ml
@@ -872,24 +872,12 @@ let actor_class_mod_exp id class_typ install =
   let install_new =
     (varE install_var) -*- (tagE "new" (recordE ["settings", nullE()]))
   in
-  let fun_typ = install_new.note.Note.typ in
-  let func_var = fresh_var id fun_typ in
   blockE
-    [ letD install_var install;
-      letD func_var install_new ]
-    (newObjE T.Module
-       [ { it = {I.name = "install" ^ id; I.var = id_of_var install_var};
-           at = no_region;
-           note = install_typ };
-         { it = {I.name = id; I.var = id_of_var func_var};
-           at = no_region;
-           note = fun_typ };
-       ]
-       (T.Obj(T.Module, List.sort T.compare_field [
-          { T.lab = id; T.typ = T.Typ class_con; depr = None };
-          { T.lab = "install" ^ id; T.typ = install_typ; depr = None };
-          { T.lab = id; T.typ = fun_typ; depr = None };
-    ])))
+    [ letD install_var install ]
+    (objE T.Module
+      [(id, class_con)]
+      [(id, install_new);
+       ("system", objE T.Module [] [(id, varE install_var)])])
 
 let import_compiled_class (lib : S.comp_unit) wasm : import_declaration =
   let f = lib.note.filename in

--- a/src/mo_frontend/parser.mly
+++ b/src/mo_frontend/parser.mly
@@ -575,6 +575,8 @@ exp_post(B) :
     { IdxE(e1, e2) @? at $sloc }
   | e=exp_post(B) s=DOT_NUM
     { ProjE (e, int_of_string s) @? at $sloc }
+  | e=exp_post(B) DOT SYSTEM
+    { DotE(e, "system" @@ at ($startpos($3),$endpos($3))) @? at $sloc }
   | e=exp_post(B) DOT x=id
     { DotE(e, x) @? at $sloc }
   | e1=exp_post(B) inst=inst e2=exp_nullary(ob)

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -2629,10 +2629,10 @@ let check_lib scope lib : Scope.t Diag.result =
                 | _ -> assert false
               in
               let con = Cons.fresh id.it (T.Def([], class_typ)) in
-              T.Obj(T.Module, List.sort T.compare_field [
-                { T.lab = id.it; T.typ = T.Typ con; depr = None };
-                { T.lab = id.it; T.typ = fun_typ; depr = None };
-                { T.lab = "install"^id.it; T.typ = T.install_typ (List.map (T.close cs) ts1) class_typ; depr = None }
+              T.(obj Module [
+                (id.it, Typ con);
+                (id.it, fun_typ);
+                ("system", obj Module [id.it, install_typ (List.map (close cs) ts1) class_typ])
               ])
             | ActorU _ ->
               error env cub.at "M0144" "bad import: expected a module or actor class but found an actor"

--- a/src/mo_interpreter/interpret.ml
+++ b/src/mo_interpreter/interpret.ml
@@ -967,13 +967,14 @@ let import_lib env lib =
   | Syntax.ActorClassU (_sp, id, _tbs, _p, _typ, _self_id, _dec_fields) ->
     fun v -> V.Obj (V.Env.from_list
       [ (id.it, v);
-        ("install" ^ id.it,
+        ("system",
+         V.Obj (V.Env.singleton id.it (
           V.local_func 1 1 (fun c w k ->
             let tag, w1 = V.as_variant w in
             let o = V.as_obj w1 in
             if tag = "new" && V.Env.find "settings" o = V.Null
             then k v
-            else trap cub.at "actor class configuration unsupported in interpreter"))])
+            else trap cub.at "actor class configuration unsupported in interpreter")))) ])
   | _ -> assert false
 
 

--- a/test/fail/ok/syntax2.tc.ok
+++ b/test/fail/ok/syntax2.tc.ok
@@ -8,6 +8,7 @@ syntax2.mo:2.1-2.4: syntax error [M0001], unexpected token 'let', expected one o
   or <exp_bin(ob)>
   <unassign> <exp(ob)>
   <relop> <exp_bin(ob)>
+  . system
   . <id>
   : <typ_nobin>
   <binop> <exp_bin(ob)>

--- a/test/fail/ok/syntax3.tc.ok
+++ b/test/fail/ok/syntax3.tc.ok
@@ -7,6 +7,7 @@ syntax3.mo:1.3-1.4: syntax error [M0001], unexpected token ';', expected one of 
   or <exp_bin(ob)>
   <unassign> <exp(ob)>
   <relop> <exp_bin(ob)>
+  . system
   . <id>
   , seplist(<exp_nonvar(ob)>,,)
   : <typ_nobin>

--- a/test/fail/ok/syntax5.tc.ok
+++ b/test/fail/ok/syntax5.tc.ok
@@ -7,6 +7,7 @@ syntax5.mo:3.1: syntax error [M0001], unexpected end of input, expected one of t
   or <exp_bin(ob)>
   <unassign> <exp(ob)>
   <relop> <exp_bin(ob)>
+  . system
   . <id>
   , seplist(<exp(ob)>,,)
   : <typ_nobin>

--- a/test/run-drun/actor-class-mgmt-interp.mo
+++ b/test/run-drun/actor-class-mgmt-interp.mo
@@ -24,14 +24,14 @@ actor a {
       assert ({args = 0; upgrades = 0} == (await c0.observe()));
 
       let c1 = await
-         C.installC (#new default_settings) 1;
+         C.system.C (#new default_settings) 1;
       assert ({args = 1; upgrades = 0} == (await c1.observe()));
       assert (c1 != c0);
 
       try {
         await async {
           let c2 = await
-          (C.installC (#new settings) 2);
+          (C.system.C (#new settings) 2);
           assert ({args = 2; upgrades = 0} == (await c2.observe()));
           assert (c2 != c1);
         }
@@ -41,7 +41,7 @@ actor a {
         await async {
           let p = Prim.principalOfBlob("");
           let c3 = await
-            C.installC (#install p) 3;
+            C.system.C (#install p) 3;
           assert false;
         };
       } catch e { };
@@ -49,7 +49,7 @@ actor a {
       try {
         await async {
           let c4 = await
-            C.installC (#upgrade c1) 4;
+            C.system.C (#upgrade c1) 4;
           assert false;
         }
       } catch e { };
@@ -57,7 +57,7 @@ actor a {
       try {
         await async {
           let c5 = await
-            C.installC (#reinstall c1) 5;
+            C.system.C (#reinstall c1) 5;
           assert false;
         }
       }

--- a/test/run-drun/actor-class-mgmt.mo
+++ b/test/run-drun/actor-class-mgmt.mo
@@ -39,13 +39,13 @@ actor a {
 
       Cycles.add(2_000_000_000_000);
       let c1 = await
-         C.installC (#new default_settings) 1;
+         C.system.C (#new default_settings) 1;
       assert ({args = 1; upgrades = 0} == (await c1.observe()));
       assert (c1 != c0);
 
       Cycles.add(2_000_000_000_000);
       let c2 = await
-         (C.installC (#new settings) 2);
+         (C.system.C (#new settings) 2);
       assert ({args = 2; upgrades = 0} == (await c2.observe()));
       assert (c2 != c1);
 
@@ -54,20 +54,20 @@ actor a {
          ic00.create_canister default_settings;
       // no need to add cycles
       let c3 = await
-         C.installC (#install p) 3;
+         C.system.C (#install p) 3;
       assert ({args = 3; upgrades = 0} == (await c3.observe()));
       assert (Prim.principalOfActor c3 == p);
       assert (c3 != c2);
 
       // no need to add cycles
       let c4 = await
-         C.installC (#upgrade c3) 4;
+         C.system.C (#upgrade c3) 4;
       assert ({args = 4; upgrades = 1} == (await c4.observe()));
       assert (c4 == c3);
 
       // no need to add cycles
       let c5 = await
-         C.installC (#reinstall c4) 5;
+         C.system.C (#reinstall c4) 5;
       assert ({args = 5; upgrades = 0} == (await c5.observe()));
       assert (c5 == c4);
     };

--- a/test/run-drun/map-upgrades/map0.mo
+++ b/test/run-drun/map-upgrades/map0.mo
@@ -55,7 +55,7 @@ actor a {
          case null {};
          case (?n) {
            nodes[i] :=
-             ? (await Lib.installNode(#upgrade n)(i)); // upgrade!
+             ? (await Lib.system.Node(#upgrade n)(i)); // upgrade!
          }
        }
     }

--- a/test/run-drun/map-upgrades/map1.mo
+++ b/test/run-drun/map-upgrades/map1.mo
@@ -65,7 +65,7 @@ actor a {
          case null {};
          case (?n) {
            nodes[i] :=
-             ? (await Lib.installNode(#upgrade n)(i)); // upgrade!
+             ? (await Lib.system.Node(#upgrade n)(i)); // upgrade!
          }
        }
     }


### PR DESCRIPTION
This PR puts the secondary constructor in a submodule called `system` and extends the dot notation to allow `exp.system` (projecting on the *keyword* `system`).

That should prevent users from redefining `system` fields, but allow them to access them, and might be used for other `system` functions.

```
eg. Lib.system.Node(#upgrade a)(i);
```

Implements the alternative sugar described here:

https://github.com/dfinity/motoko/pull/3394#issuecomment-1215603163