### PR TITLE
feat: yet another variant of actor class management syntax

### DIFF
--- a/doc/md/examples/grammar.txt
+++ b/doc/md/examples/grammar.txt
@@ -159,6 +159,7 @@
     <exp_post> '.' <id>
     <exp_post> ('<' <list(<typ>, ',')> '>')? <exp_nullary>
     <exp_post> BANG
+    '(' 'system' <exp_nullary> <exp_nullary> '.' <id> <exp_nullary> ')'
 
 <exp_un> ::= 
     <exp_post>

--- a/src/mo_frontend/parser.mly
+++ b/src/mo_frontend/parser.mly
@@ -594,7 +594,7 @@ exp_post(B) :
             DotE(
               DotE(
                 e2,
-                "system" @@ at ($startpos(e1),$endpos(e1))) @? at $sloc,
+                "system" @@ at ($startpos(e1), $endpos(e1))) @? at $sloc,
               c) @? no_region,
             no_inst(),
             VarE x @? at $sloc) @? at $sloc,

--- a/test/run-drun/actor-class-mgmt-interp.mo
+++ b/test/run-drun/actor-class-mgmt-interp.mo
@@ -1,6 +1,6 @@
 import Prim "mo:⛔";
 import Cycles = "cycles/cycles";
-import C "actor-class-mgmt/C";
+import Cs "actor-class-mgmt/C";
 
 // test gracefull failure of actor class system calls in intrepreters
 actor a {
@@ -20,18 +20,18 @@ actor a {
     do {
 
       let c0 = await
-         C.C 0;
+         Cs.C 0;
       assert ({args = 0; upgrades = 0} == (await c0.observe()));
 
       let c1 = await
-         C.system.C (#new default_settings) 1;
+         (system (#new default_settings) Cs.C(1));
       assert ({args = 1; upgrades = 0} == (await c1.observe()));
       assert (c1 != c0);
 
       try {
         await async {
           let c2 = await
-          (C.system.C (#new settings) 2);
+          (system (#new settings) Cs.C(2));
           assert ({args = 2; upgrades = 0} == (await c2.observe()));
           assert (c2 != c1);
         }
@@ -41,7 +41,7 @@ actor a {
         await async {
           let p = Prim.principalOfBlob("");
           let c3 = await
-            C.system.C (#install p) 3;
+            (system (#install p) Cs.C(3));
           assert false;
         };
       } catch e { };
@@ -49,7 +49,7 @@ actor a {
       try {
         await async {
           let c4 = await
-            C.system.C (#upgrade c1) 4;
+            (system (#upgrade c1) Cs.C(4));
           assert false;
         }
       } catch e { };
@@ -57,7 +57,7 @@ actor a {
       try {
         await async {
           let c5 = await
-            C.system.C (#reinstall c1) 5;
+            (system (#reinstall c1) Cs.C(5));
           assert false;
         }
       }

--- a/test/run-drun/actor-class-mgmt.mo
+++ b/test/run-drun/actor-class-mgmt.mo
@@ -1,6 +1,6 @@
 import Prim "mo:⛔";
 import Cycles = "cycles/cycles";
-import C "actor-class-mgmt/C";
+import Cs "actor-class-mgmt/C";
 
 actor a {
 
@@ -34,18 +34,18 @@ actor a {
     do {
       Cycles.add(2_000_000_000_000);
       let c0 = await
-         C.C 0;
+         Cs.C 0;
       assert ({args = 0; upgrades = 0} == (await c0.observe()));
 
       Cycles.add(2_000_000_000_000);
       let c1 = await
-         C.system.C (#new default_settings) 1;
+         (system (#new default_settings) Cs.C(1));
       assert ({args = 1; upgrades = 0} == (await c1.observe()));
       assert (c1 != c0);
 
       Cycles.add(2_000_000_000_000);
       let c2 = await
-         (C.system.C (#new settings) 2);
+         (system (#new settings) Cs.C(2));
       assert ({args = 2; upgrades = 0} == (await c2.observe()));
       assert (c2 != c1);
 
@@ -54,20 +54,20 @@ actor a {
          ic00.create_canister default_settings;
       // no need to add cycles
       let c3 = await
-         C.system.C (#install p) 3;
+         (system (#install p) Cs.C(3));
       assert ({args = 3; upgrades = 0} == (await c3.observe()));
       assert (Prim.principalOfActor c3 == p);
       assert (c3 != c2);
 
       // no need to add cycles
       let c4 = await
-         C.system.C (#upgrade c3) 4;
+         (system (#upgrade c3) Cs.C(4));
       assert ({args = 4; upgrades = 1} == (await c4.observe()));
       assert (c4 == c3);
 
       // no need to add cycles
       let c5 = await
-         C.system.C (#reinstall c4) 5;
+         (system (#reinstall c4) Cs.C(5));
       assert ({args = 5; upgrades = 0} == (await c5.observe()));
       assert (c5 == c4);
     };

--- a/test/run-drun/map-upgrades/map0.mo
+++ b/test/run-drun/map-upgrades/map0.mo
@@ -4,7 +4,7 @@ import Lib "node0";
 
 // A naive, distributed map from Nat to Text.
 // Illustrates dynamic installation of imported actor classes.
-// Uses a fixed number of nodes, dynamically installed on demand 
+// Uses a fixed number of nodes, dynamically installed on demand
 // .. and upgraded with a call to upgradeNodes() (without data loss)
 
 actor a {
@@ -55,7 +55,7 @@ actor a {
          case null {};
          case (?n) {
            nodes[i] :=
-             ? (await Lib.system.Node(#upgrade n)(i)); // upgrade!
+             ? (await (system (#upgrade n) Lib.Node(i))); // upgrade!
          }
        }
     }

--- a/test/run-drun/map-upgrades/map1.mo
+++ b/test/run-drun/map-upgrades/map1.mo
@@ -65,7 +65,7 @@ actor a {
          case null {};
          case (?n) {
            nodes[i] :=
-             ? (await Lib.system.Node(#upgrade n)(i)); // upgrade!
+             ? (await (system (#upgrade n) Lib.Node(i))); // upgrade!
          }
        }
     }


### PR DESCRIPTION
Builds on the Lib.system variant (#3403) (to avoid mangling), but also adds sugar. We can drop the Lib.system support, if desired (though its actually more discoverable in an IDE).
```
'(' 'system' <exp_nullary> <exp_nullary> '.' <id> <exp_nullary> ')'
```

eg.
```
 (system (#upgrade n) Lib.Node(i))
```
(but `Lib.system.Node(#upgrade)(i)` also works)