### PR TITLE
viper: adorn invariants with permissions

### DIFF
--- a/src/viper/pretty.ml
+++ b/src/viper/pretty.ml
@@ -117,6 +117,7 @@ and pp_exp ppf exp =
        | Implies _ -> "==>" | OrE _ -> "||" | AndE _ -> "&&"
        | _ -> failwith "not a binary operator" in
      fprintf ppf "(%a %s %a)" pp_exp e1 op pp_exp e2
+  | PermExp { it = WildcardP; _ } -> fprintf ppf "@[acc(self.claimed)@]"
 
 and pp_stmt ppf stmt =
   marks := stmt.at :: !marks;

--- a/src/viper/pretty.ml
+++ b/src/viper/pretty.ml
@@ -117,7 +117,8 @@ and pp_exp ppf exp =
        | Implies _ -> "==>" | OrE _ -> "||" | AndE _ -> "&&"
        | _ -> failwith "not a binary operator" in
      fprintf ppf "(%a %s %a)" pp_exp e1 op pp_exp e2
-  | PermExp { it = WildcardP; _ } -> fprintf ppf "@[acc(self.claimed)@]"
+  | PermExp { it = WildcardP; _ } -> fprintf ppf "@[acc(*)@]"
+  | PermExp { it = FullP acc; _ } -> fprintf ppf "@[acc(%a)@]" pp_fldacc acc
 
 and pp_stmt ppf stmt =
   marks := stmt.at :: !marks;

--- a/src/viper/syntax.ml
+++ b/src/viper/syntax.ml
@@ -49,7 +49,7 @@ and perm = (perm', info) Source.annotated_phrase
 
 and perm' =
   | WildcardP
-  | FullP
+  | FullP of fldacc
   | NoP
   | EpsilonP
 (* | FractionalP of exp * exp | ...*)

--- a/src/viper/trans.ml
+++ b/src/viper/trans.ml
@@ -52,7 +52,8 @@ let rec extract_stmt_permissions s : exp -> exp =
       fun e -> e' (s1 (s2 e))
   | WhileS _ | LabelS _ -> failwith "cannot do loops yet"
 
-and extract_seqn_permissions _ = failwith "cannot do seqn yet"
+and extract_seqn_permissions s =
+  List.fold_left (fun f s -> fun e -> f (extract_stmt_permissions s e)) (fun x -> x) (snd s.it)
 
 let rec extract_invariants : item list -> (par -> invariants -> invariants) = function
   | [] -> fun _ x -> x

--- a/src/viper/trans.ml
+++ b/src/viper/trans.ml
@@ -149,7 +149,10 @@ and dec_field' ctxt d =
         let self_id = id_at "$Self" Source.no_region in
         let ctxt'' = { ctxt' with self = Some self_id.it }
         in (* TODO: add args (and rets?) *)
-        (MethodI(id f, (self_id, {it = RefT; at = Source.no_region; note = NoInfo})::args p, rets t_opt, [], [], Some (stmt ctxt'' e)),
+        let seqn = stmt ctxt'' e in
+        let permf = extract_seqn_permissions seqn in
+        let perms = [permf { it = BoolLitE true; at = no_region; note = NoInfo }] in
+        (MethodI(id f, (self_id, {it = RefT; at = Source.no_region; note = NoInfo})::args p, rets t_opt, perms, perms, Some seqn),
         NoInfo)
   | M.(ExpD { it = AssertE e; at; _ }) ->
 	    ctxt,

--- a/src/viper/trans.ml
+++ b/src/viper/trans.ml
@@ -29,7 +29,7 @@ let rec extract_permissions e : exp -> exp =
   match e.it with
   | LocalVar _ | Result _ | BoolLitE _ | NullLitE | IntLitE _ -> fun x -> x
   | PermExp _ | MacroCall _ -> failwith "we should not encounter these"
-  | FldAcc acc -> fun e -> { e with it = AndE ({ e with it = PermExp { e with it = FullP acc }; note = NoInfo }, e); note = NoInfo }
+  | FldAcc acc -> fun e -> { e with it = AndE ({ e with it = PermExp { e with it = FullP acc; note = NoInfo }; note = NoInfo }, e); note = NoInfo }
   | NotE e1 | MinusE e1 -> fun e -> extract_permissions e1 e
   | AddE (e1, e2) | SubE (e1, e2) | MulE (e1, e2) | DivE (e1, e2) | ModE (e1, e2)
   | EqCmpE (e1, e2) | NeCmpE (e1, e2) | GtCmpE (e1, e2) | GeCmpE (e1, e2) | LtCmpE (e1, e2) | LeCmpE (e1, e2)
@@ -43,7 +43,7 @@ let rec extract_stmt_permissions s : exp -> exp =
   | ExhaleS e | InhaleS e | AssertS e | AssumeS e | VarAssignS (_, e) -> extract_permissions e
   | SeqnS seqn -> extract_seqn_permissions seqn
   | FieldAssignS (acc, e) ->
-      fun e -> { it = AndE ({ e with it = PermExp { e with it = FullP acc; note = NoInfo } }, e)
+      fun e -> { it = AndE ({ e with it = PermExp { e with it = FullP acc; note = NoInfo }; note = NoInfo }, e)
                ; at = s.at
                ; note = NoInfo
                }

--- a/src/viper/trans.ml
+++ b/src/viper/trans.ml
@@ -29,7 +29,7 @@ let rec extract_permissions e : exp -> exp =
   match e.it with
   | LocalVar _ | Result _ | BoolLitE _ | NullLitE | IntLitE _ -> fun x -> x
   | PermExp _ | MacroCall _ -> failwith "we should not encounter these"
-  | FldAcc acc -> fun e -> { e with it = AndE ({ e with it = PermExp { e with it = WildcardP } }, e) }
+  | FldAcc acc -> fun e -> { e with it = AndE ({ e with it = PermExp { e with it = FullP acc } }, e) }
   | NotE e1 | MinusE e1 -> fun e -> extract_permissions e1 e
   | AddE (e1, e2) | SubE (e1, e2) | MulE (e1, e2) | DivE (e1, e2) | ModE (e1, e2)
   | EqCmpE (e1, e2) | NeCmpE (e1, e2) | GtCmpE (e1, e2) | GeCmpE (e1, e2) | LtCmpE (e1, e2) | LeCmpE (e1, e2)

--- a/src/viper/trans.ml
+++ b/src/viper/trans.ml
@@ -96,10 +96,12 @@ let rec unit (u : M.comp_unit) : prog =
         it = [], init_list;
         note = NoInfo
       } in
-    let m = 
+    let m =
+      let permf = extract_seqn_permissions init_body in
+      let perms = [permf { it = BoolLitE true; at = no_region; note = NoInfo }] in
       { it = MethodI(init_id, [
           self_id, { it = RefT; at = self_id.at; note = NoInfo }
-        ], [], [], [], Some init_body);
+        ], [], perms, perms, Some init_body);
         at = no_region;
         note = NoInfo
       } in
@@ -152,8 +154,8 @@ and dec_field' ctxt d =
         let seqn = stmt ctxt'' e in
         let permf = extract_seqn_permissions seqn in
         let perms = [permf { it = BoolLitE true; at = no_region; note = NoInfo }] in
-        (MethodI(id f, (self_id, {it = RefT; at = Source.no_region; note = NoInfo})::args p, rets t_opt, perms, perms, Some seqn),
-        NoInfo)
+        MethodI(id f, (self_id, {it = RefT; at = Source.no_region; note = NoInfo})::args p, rets t_opt, perms, perms, Some seqn),
+        NoInfo
   | M.(ExpD { it = AssertE e; at; _ }) ->
 	    ctxt,
       None,

--- a/test/viper/invariant.mo
+++ b/test/viper/invariant.mo
@@ -4,7 +4,7 @@ actor {
 
   var count = 0 : Int;
 
-  assert claimed and not (-1 == -1) and (-42 == -42) or true;
+  assert claimed and not (-1 >= count) and (-42 < count) or true;
   assert count > 0;
 
   public shared func claim() : async () {

--- a/test/viper/ok/claim-broken.silicon.ok
+++ b/test/viper/ok/claim-broken.silicon.ok
@@ -1,1 +1,0 @@
-  [0] Assignment might fail. There might be insufficient permission to access $Self.claimed (claim-broken.vpr@3.6--3.30)

--- a/test/viper/ok/claim-broken.silicon.ok
+++ b/test/viper/ok/claim-broken.silicon.ok
@@ -1,2 +1,1 @@
   [0] Assignment might fail. There might be insufficient permission to access $Self.claimed (claim-broken.vpr@3.6--3.30)
-  [1] Conditional statement might fail. There might be insufficient permission to access $Self.claimed (claim-broken.vpr@10.10--10.26)

--- a/test/viper/ok/claim-broken.silicon.ret.ok
+++ b/test/viper/ok/claim-broken.silicon.ret.ok
@@ -1,1 +1,0 @@
-Return code 1

--- a/test/viper/ok/claim-broken.vpr.ok
+++ b/test/viper/ok/claim-broken.vpr.ok
@@ -5,7 +5,9 @@ method __init__($Self: Ref)
    }
 field claimed: Bool
 field count: Int
-method claim($Self: Ref)   
+method claim($Self: Ref) 
+  requires (acc(($Self).claimed) && (acc(($Self).claimed) && (acc(($Self).count) && true)))
+  ensures (acc(($Self).claimed) && (acc(($Self).claimed) && (acc(($Self).count) && true)))
    { 
      if (!($Self).claimed)
         { 

--- a/test/viper/ok/claim-broken.vpr.ok
+++ b/test/viper/ok/claim-broken.vpr.ok
@@ -1,4 +1,6 @@
-method __init__($Self: Ref)   
+method __init__($Self: Ref) 
+  requires (acc(($Self).claimed) && (acc(($Self).count) && true))
+  ensures (acc(($Self).claimed) && (acc(($Self).count) && true))
    { 
      ($Self).claimed := false
      ($Self).count := 0 

--- a/test/viper/ok/claim-simple.silicon.ok
+++ b/test/viper/ok/claim-simple.silicon.ok
@@ -1,2 +1,1 @@
   [0] Assignment might fail. There might be insufficient permission to access $Self.claimed (claim-simple.vpr@3.6--3.30)
-  [1] Conditional statement might fail. There might be insufficient permission to access $Self.claimed (claim-simple.vpr@10.10--10.26)

--- a/test/viper/ok/claim-simple.silicon.ok
+++ b/test/viper/ok/claim-simple.silicon.ok
@@ -1,1 +1,0 @@
-  [0] Assignment might fail. There might be insufficient permission to access $Self.claimed (claim-simple.vpr@3.6--3.30)

--- a/test/viper/ok/claim-simple.silicon.ret.ok
+++ b/test/viper/ok/claim-simple.silicon.ret.ok
@@ -1,1 +1,0 @@
-Return code 1

--- a/test/viper/ok/claim-simple.vpr.ok
+++ b/test/viper/ok/claim-simple.vpr.ok
@@ -5,7 +5,9 @@ method __init__($Self: Ref)
    }
 field claimed: Bool
 field count: Int
-method claim($Self: Ref)   
+method claim($Self: Ref) 
+  requires (acc(($Self).claimed) && (acc(($Self).claimed) && (acc(($Self).count) && true)))
+  ensures (acc(($Self).claimed) && (acc(($Self).claimed) && (acc(($Self).count) && true)))
    { 
      if (!($Self).claimed)
         { 

--- a/test/viper/ok/claim-simple.vpr.ok
+++ b/test/viper/ok/claim-simple.vpr.ok
@@ -1,4 +1,6 @@
-method __init__($Self: Ref)   
+method __init__($Self: Ref) 
+  requires (acc(($Self).claimed) && (acc(($Self).count) && true))
+  ensures (acc(($Self).claimed) && (acc(($Self).count) && true))
    { 
      ($Self).claimed := false
      ($Self).count := 0 

--- a/test/viper/ok/claim.silicon.ok
+++ b/test/viper/ok/claim.silicon.ok
@@ -1,2 +1,1 @@
   [0] Assignment might fail. There might be insufficient permission to access $Self.claimed (claim.vpr@3.6--3.30)
-  [1] Conditional statement might fail. There might be insufficient permission to access $Self.claimed (claim.vpr@10.10--10.26)

--- a/test/viper/ok/claim.silicon.ok
+++ b/test/viper/ok/claim.silicon.ok
@@ -1,1 +1,0 @@
-  [0] Assignment might fail. There might be insufficient permission to access $Self.claimed (claim.vpr@3.6--3.30)

--- a/test/viper/ok/claim.silicon.ret.ok
+++ b/test/viper/ok/claim.silicon.ret.ok
@@ -1,1 +1,0 @@
-Return code 1

--- a/test/viper/ok/claim.vpr.ok
+++ b/test/viper/ok/claim.vpr.ok
@@ -5,7 +5,9 @@ method __init__($Self: Ref)
    }
 field claimed: Bool
 field count: Int
-method claim($Self: Ref)   
+method claim($Self: Ref) 
+  requires (acc(($Self).claimed) && (acc(($Self).claimed) && (acc(($Self).count) && true)))
+  ensures (acc(($Self).claimed) && (acc(($Self).claimed) && (acc(($Self).count) && true)))
    { 
      if (!($Self).claimed)
         { 

--- a/test/viper/ok/claim.vpr.ok
+++ b/test/viper/ok/claim.vpr.ok
@@ -1,4 +1,6 @@
-method __init__($Self: Ref)   
+method __init__($Self: Ref) 
+  requires (acc(($Self).claimed) && (acc(($Self).count) && true))
+  ensures (acc(($Self).claimed) && (acc(($Self).count) && true))
    { 
      ($Self).claimed := false
      ($Self).count := 0 

--- a/test/viper/ok/invariant.silicon.ok
+++ b/test/viper/ok/invariant.silicon.ok
@@ -1,1 +1,0 @@
-  [0] Contract might not be well-formed. There might be insufficient permission to access $Self.claimed (invariant.vpr@6.12--6.30)

--- a/test/viper/ok/invariant.silicon.ret.ok
+++ b/test/viper/ok/invariant.silicon.ret.ok
@@ -1,1 +1,0 @@
-Return code 1

--- a/test/viper/ok/invariant.vpr.ok
+++ b/test/viper/ok/invariant.vpr.ok
@@ -1,7 +1,8 @@
 field claimed: Bool
 field count: Int
-define invariant_7(self) ((acc((self).claimed) && ((((self).claimed && 
-  (!(-1 == -1))) && (-42 == -42)) || true)))
+define invariant_7(self) ((acc((self).claimed) && (acc((self).count) && (
+  acc((self).count) && ((((self).claimed && (!(-1 >= (self).count))) && (-42 < 
+  (self).count)) || true)))))
 define invariant_8(self) ((acc((self).count) && ((self).count > 0)))
 method claim($Self: Ref) 
   requires invariant_7($Self)

--- a/test/viper/ok/invariant.vpr.ok
+++ b/test/viper/ok/invariant.vpr.ok
@@ -1,7 +1,8 @@
 field claimed: Bool
 field count: Int
-define invariant_7(self) (((((self).claimed && (!(-1 == -1))) && (-42 == -42)) || true))
-define invariant_8(self) (((self).count > 0))
+define invariant_7(self) ((acc(self.claimed) && ((((self).claimed && 
+  (!(-1 == -1))) && (-42 == -42)) || true)))
+define invariant_8(self) ((acc(self.claimed) && ((self).count > 0)))
 method claim($Self: Ref) 
   requires invariant_7($Self)
   requires invariant_8($Self)

--- a/test/viper/ok/invariant.vpr.ok
+++ b/test/viper/ok/invariant.vpr.ok
@@ -1,6 +1,8 @@
-method __init__($Self: Ref)  
+method __init__($Self: Ref) 
+  requires (acc(($Self).claimed) && (acc(($Self).count) && true))
   ensures invariant_7($Self)
   ensures invariant_8($Self)
+  ensures (acc(($Self).claimed) && (acc(($Self).count) && true))
    { 
      ($Self).claimed := false
      ($Self).count := 0 

--- a/test/viper/ok/invariant.vpr.ok
+++ b/test/viper/ok/invariant.vpr.ok
@@ -1,8 +1,8 @@
 field claimed: Bool
 field count: Int
-define invariant_7(self) ((acc(self.claimed) && ((((self).claimed && 
+define invariant_7(self) ((acc((self).claimed) && ((((self).claimed && 
   (!(-1 == -1))) && (-42 == -42)) || true)))
-define invariant_8(self) ((acc(self.claimed) && ((self).count > 0)))
+define invariant_8(self) ((acc((self).count) && ((self).count > 0)))
 method claim($Self: Ref) 
   requires invariant_7($Self)
   requires invariant_8($Self)

--- a/test/viper/ok/invariant.vpr.ok
+++ b/test/viper/ok/invariant.vpr.ok
@@ -14,7 +14,9 @@ define invariant_8(self) ((acc((self).count) && ((self).count > 0)))
 method claim($Self: Ref) 
   requires invariant_7($Self)
   requires invariant_8($Self)
+  requires true
   ensures invariant_7($Self)
-  ensures invariant_8($Self)  { 
-                                 
-                              }
+  ensures invariant_8($Self)
+  ensures true  { 
+                   
+                }


### PR DESCRIPTION
EXPERIMENTAL, but hey, it's a start!

TODO:
- [ ] `pp_perm`
- [ ] remove duplicates (optimise conjunction expressions)
- [x] harvest `perm`s from statement lists (`write` and _read_)
  - [x] apply to methods
  - [x] apply to `__init__`
- [ ] deduplicate perms and eliminate the trailing `true`.