### PR TITLE
Generate method specs in Motoko to Viper translation

### DIFF
--- a/src/viper/pretty.ml
+++ b/src/viper/pretty.ml
@@ -119,8 +119,7 @@ and pp_exp ppf exp =
      fprintf ppf "(%a %s %a)" pp_exp e1 op pp_exp e2
   | PermE p -> pp_perm ppf p
   | AccE (fldacc, perm) -> fprintf ppf "@[acc(%a,%a)@]" pp_fldacc fldacc pp_exp perm
-     (* fprintf ppf "@[acc(%a.%s,%a)@]" (pp_exp exp) it (pp_exp perm) *)
-  | _ -> fprintf ppf "@[// pretty printer not implemneted for node at %s@]" (string_of_region exp.at)
+  | _ -> fprintf ppf "@[// pretty printer not implemented for node at %s@]" (string_of_region exp.at)
 
 and pp_perm ppf perm =
   match perm.it with
@@ -129,7 +128,7 @@ and pp_perm ppf perm =
   | WildcardP -> fprintf ppf "wildcard"
   | FractionalP (a, b) -> fprintf ppf "@[(%a/%a)@]" pp_exp a pp_exp b
 
-  and pp_stmt ppf stmt =
+and pp_stmt ppf stmt =
   marks := stmt.at :: !marks;
   fprintf ppf "\017%a\019"
     pp_stmt' stmt.it

--- a/src/viper/pretty.ml
+++ b/src/viper/pretty.ml
@@ -33,8 +33,8 @@ and pp_item ppf i =
       pp_pres pres
       pp_posts posts
       pp_block_opt bo
-  | InvariantI (s, e) -> (* TODO: srcloc mapping *)
-    fprintf ppf "@[<2>define %s(self) (%a)@]" s pp_exp e
+  | InvariantI (inv_name, e) -> (* TODO: srcloc mapping *)
+    fprintf ppf "@[<2>define %s($Self) (%a)@]" inv_name pp_exp e
 
 and pp_block_opt ppf = function
   | None -> ()
@@ -117,8 +117,19 @@ and pp_exp ppf exp =
        | Implies _ -> "==>" | OrE _ -> "||" | AndE _ -> "&&"
        | _ -> failwith "not a binary operator" in
      fprintf ppf "(%a %s %a)" pp_exp e1 op pp_exp e2
+  | PermE p -> pp_perm ppf p
+  | AccE (fldacc, perm) -> fprintf ppf "@[acc(%a,%a)@]" pp_fldacc fldacc pp_exp perm
+     (* fprintf ppf "@[acc(%a.%s,%a)@]" (pp_exp exp) it (pp_exp perm) *)
+  | _ -> fprintf ppf "@[// pretty printer not implemneted for node at %s@]" (string_of_region exp.at)
 
-and pp_stmt ppf stmt =
+and pp_perm ppf perm =
+  match perm.it with
+  | NoP -> fprintf ppf "none"
+  | FullP -> fprintf ppf "write"
+  | WildcardP -> fprintf ppf "wildcard"
+  | FractionalP (a, b) -> fprintf ppf "@[(%a/%a)@]" pp_exp a pp_exp b
+
+  and pp_stmt ppf stmt =
   marks := stmt.at :: !marks;
   fprintf ppf "\017%a\019"
     pp_stmt' stmt.it

--- a/src/viper/syntax.ml
+++ b/src/viper/syntax.ml
@@ -42,18 +42,17 @@ and exp' =
   | OrE of exp * exp
   | Implies of exp * exp
   | FldAcc of fldacc
-  | PermExp of perm
+  | PermE of perm          (* perm_amount *)
+  | AccE of fldacc * exp   (* acc((rcvr: exp).field, (exp: perm_amount)) *)
   | MacroCall of string * exp
 
 and perm = (perm', info) Source.annotated_phrase
 
 and perm' =
-  | WildcardP
-  | FullP
-  | NoP
-  | EpsilonP
-(* | FractionalP of exp * exp | ...*)
-
+  | NoP                       (* 0 / 1 *)
+  | FullP                     (* 1 / 1 *)
+  | WildcardP                 (* 1 / N for some N *)
+  | FractionalP of exp * exp  (* (a: exp) / (b: exp) *)
 
 and invariants = exp list
 

--- a/src/viper/trans.ml
+++ b/src/viper/trans.ml
@@ -108,7 +108,7 @@ let rec unit (u : M.comp_unit) : prog =
       match it with
       | MethodI (id, ins, outs, pres, posts, body) ->
         { at;
-          it = MethodI(id, ins, outs, List.append pres invs, List.append posts invs, body);
+          it = MethodI(id, ins, outs, (if id.it = init_id.it then pres else List.append pres invs), List.append posts invs, body);
           note
         }
         | _ -> {it; at; note}

--- a/src/viper/trans.ml
+++ b/src/viper/trans.ml
@@ -63,14 +63,14 @@ let rec unit (u : M.comp_unit) : prog =
       { at;
         it = List.fold_left
         (fun pexp -> fun p_fn -> AndE(
-            { at;
+          { at;
             it = pexp;
             note = NoInfo
-            },
-            { at;
+          },
+          { at;
             it = (p_fn at);
             note = NoInfo
-            }))
+          }))
           (BoolLitE true)
           perms;
           note = NoInfo

--- a/src/viper/trans.ml
+++ b/src/viper/trans.ml
@@ -36,16 +36,6 @@ let rec extract_invariants : item list -> (par -> invariants -> invariants) = fu
         ; note = NoInfo } :: extract_invariants p self es
   | _ :: p -> extract_invariants p
 
-let rec adorn_invariants (is : par -> invariants -> invariants) = function
-  | [] -> []
-  | { it = MethodI (d, (self :: _ as i), o, r, e, b); _ } as m :: p ->
-    let pre_is = function
-      | "__init__" -> fun _ l -> l
-      | _ -> is in
-    let m = { m with it = MethodI (d, i, o, pre_is d.it self r, is self e, b) } in
-    m :: adorn_invariants is p
-  | i :: p -> i :: adorn_invariants is p
-
 let rec unit (u : M.comp_unit) : prog =
   let { M.imports; M.body } = u.it in
   match body.it with
@@ -55,7 +45,37 @@ let rec unit (u : M.comp_unit) : prog =
     let is' = List.map (fun mk_i -> mk_i ctxt') mk_is in
     let init_id = id_at "__init__" Source.no_region in
     let self_id = id_at "$Self" Source.no_region in
+    let self_typ = { it = RefT; at = self_id.at; note = NoInfo } in
     let ctxt'' = { ctxt' with self = Some self_id.it } in
+    let perms = List.map (fun (id, _) -> fun (at : region) ->
+      AccE(
+        (self ctxt'' at, id),
+        { at;
+          it = PermE {
+            at;
+            it = FullP;
+            note = NoInfo
+          };
+          note = NoInfo
+        }
+      )) inits in
+    let perm = fun (at : region) ->
+      { at;
+        it = List.fold_left
+        (fun pexp -> fun p_fn -> AndE(
+            { at;
+            it = pexp;
+            note = NoInfo
+            },
+            { at;
+            it = (p_fn at);
+            note = NoInfo
+            }))
+          (BoolLitE true)
+          perms;
+          note = NoInfo
+        } in
+    (* Add initializer *)
     let init_list = List.map (fun (id, init) -> 
       { at = { left = id.at.left; right = init.at.right };
         it = FieldAssignS((self ctxt'' init.at, id), exp ctxt'' init);
@@ -66,19 +86,37 @@ let rec unit (u : M.comp_unit) : prog =
         it = [], init_list;
         note = NoInfo
       } in
-    let m = 
-      { it = MethodI(init_id, [
-          self_id, { it = RefT; at = self_id.at; note = NoInfo }
-        ], [], [], [], Some init_body);
+    let init_m =
+      { it = MethodI(init_id, [self_id, self_typ], [], [], [], Some init_body);
         at = no_region;
         note = NoInfo
       } in
-    let is = m :: is' in
-    let invs = extract_invariants is in
-      { it = adorn_invariants invs is;
-        at = body.at;
-        note = NoInfo
-      }
+    let is'' = init_m :: is' in
+    (* Add permissions *)
+    let is''' = List.map (fun {it; at; note: info} -> (
+      match it with
+      | MethodI (id, ins, outs, pres, posts, body) ->
+        { at;
+          it = MethodI (id, ins, outs, (perm at)::pres, (perm at)::posts, body);
+          note
+        }
+        | _ -> {it; at; note}
+    )) is'' in
+    (* Add functional invariants *)
+    let invs = extract_invariants is''' (self_id, self_typ) [] in
+    let is = List.map (fun {it; at; note: info} ->
+      match it with
+      | MethodI (id, ins, outs, pres, posts, body) ->
+        { at;
+          it = MethodI(id, ins, outs, List.append pres invs, List.append posts invs, body);
+          note
+        }
+        | _ -> {it; at; note}
+    ) is''' in
+    { it = is;
+      at = body.at;
+      note = NoInfo
+    }
   | _ -> assert false
 
 and dec_fields (ctxt : ctxt) (ds : M.dec_field list) =
@@ -125,7 +163,7 @@ and dec_field' ctxt d =
 	    ctxt,
       None,
 	    fun ctxt' ->
-	      InvariantI (Printf.sprintf "invariant_%d" at.left.line, exp { ctxt' with self = Some "self" }  e), NoInfo
+	      InvariantI (Printf.sprintf "invariant_%d" at.left.line, exp { ctxt' with self = Some "$Self" }  e), NoInfo
   | _ -> fail (Mo_def.Arrange.dec d.M.dec)
 
 (*

--- a/test/viper/ok/claim-broken.silicon.ok
+++ b/test/viper/ok/claim-broken.silicon.ok
@@ -1,2 +1,0 @@
-  [0] Assignment might fail. There might be insufficient permission to access $Self.claimed (claim-broken.vpr@3.6--3.30)
-  [1] Conditional statement might fail. There might be insufficient permission to access $Self.claimed (claim-broken.vpr@10.10--10.26)

--- a/test/viper/ok/claim-broken.silicon.ret.ok
+++ b/test/viper/ok/claim-broken.silicon.ret.ok
@@ -1,1 +1,0 @@
-Return code 1

--- a/test/viper/ok/claim-broken.vpr.ok
+++ b/test/viper/ok/claim-broken.vpr.ok
@@ -1,11 +1,15 @@
-method __init__($Self: Ref)   
+method __init__($Self: Ref) 
+  requires ((true && acc(($Self).claimed,write)) && acc(($Self).count,write))
+  ensures ((true && acc(($Self).claimed,write)) && acc(($Self).count,write))
    { 
      ($Self).claimed := false
      ($Self).count := 0 
    }
 field claimed: Bool
 field count: Int
-method claim($Self: Ref)   
+method claim($Self: Ref) 
+  requires ((true && acc(($Self).claimed,write)) && acc(($Self).count,write))
+  ensures ((true && acc(($Self).claimed,write)) && acc(($Self).count,write))
    { 
      if (!($Self).claimed)
         { 

--- a/test/viper/ok/claim-simple.silicon.ok
+++ b/test/viper/ok/claim-simple.silicon.ok
@@ -1,2 +1,0 @@
-  [0] Assignment might fail. There might be insufficient permission to access $Self.claimed (claim-simple.vpr@3.6--3.30)
-  [1] Conditional statement might fail. There might be insufficient permission to access $Self.claimed (claim-simple.vpr@10.10--10.26)

--- a/test/viper/ok/claim-simple.silicon.ret.ok
+++ b/test/viper/ok/claim-simple.silicon.ret.ok
@@ -1,1 +1,0 @@
-Return code 1

--- a/test/viper/ok/claim-simple.vpr.ok
+++ b/test/viper/ok/claim-simple.vpr.ok
@@ -1,11 +1,15 @@
-method __init__($Self: Ref)   
+method __init__($Self: Ref) 
+  requires ((true && acc(($Self).claimed,write)) && acc(($Self).count,write))
+  ensures ((true && acc(($Self).claimed,write)) && acc(($Self).count,write))
    { 
      ($Self).claimed := false
      ($Self).count := 0 
    }
 field claimed: Bool
 field count: Int
-method claim($Self: Ref)   
+method claim($Self: Ref) 
+  requires ((true && acc(($Self).claimed,write)) && acc(($Self).count,write))
+  ensures ((true && acc(($Self).claimed,write)) && acc(($Self).count,write))
    { 
      if (!($Self).claimed)
         { 

--- a/test/viper/ok/claim.silicon.ok
+++ b/test/viper/ok/claim.silicon.ok
@@ -1,2 +1,0 @@
-  [0] Assignment might fail. There might be insufficient permission to access $Self.claimed (claim.vpr@3.6--3.30)
-  [1] Conditional statement might fail. There might be insufficient permission to access $Self.claimed (claim.vpr@10.10--10.26)

--- a/test/viper/ok/claim.silicon.ret.ok
+++ b/test/viper/ok/claim.silicon.ret.ok
@@ -1,1 +1,0 @@
-Return code 1

--- a/test/viper/ok/claim.vpr.ok
+++ b/test/viper/ok/claim.vpr.ok
@@ -1,11 +1,15 @@
-method __init__($Self: Ref)   
+method __init__($Self: Ref) 
+  requires ((true && acc(($Self).claimed,write)) && acc(($Self).count,write))
+  ensures ((true && acc(($Self).claimed,write)) && acc(($Self).count,write))
    { 
      ($Self).claimed := false
      ($Self).count := 0 
    }
 field claimed: Bool
 field count: Int
-method claim($Self: Ref)   
+method claim($Self: Ref) 
+  requires ((true && acc(($Self).claimed,write)) && acc(($Self).count,write))
+  ensures ((true && acc(($Self).claimed,write)) && acc(($Self).count,write))
    { 
      if (!($Self).claimed)
         { 

--- a/test/viper/ok/invariant.silicon.ok
+++ b/test/viper/ok/invariant.silicon.ok
@@ -1,1 +1,1 @@
-  [0] Postcondition of __init__ might not hold. Assertion $Self.count > 0 might not hold. (invariant.vpr@7.11--7.29)
+  [0] Postcondition of __init__ might not hold. Assertion $Self.count > 0 might not hold. (invariant.vpr@5.11--5.29)

--- a/test/viper/ok/invariant.silicon.ok
+++ b/test/viper/ok/invariant.silicon.ok
@@ -1,2 +1,1 @@
-  [0] Contract might not be well-formed. There might be insufficient permission to access $Self.claimed (invariant.vpr@2.11--2.29)
-  [1] Contract might not be well-formed. There might be insufficient permission to access $Self.claimed (invariant.vpr@13.12--13.30)
+  [0] Postcondition of __init__ might not hold. Assertion $Self.count > 0 might not hold. (invariant.vpr@7.11--7.29)

--- a/test/viper/ok/invariant.vpr.ok
+++ b/test/viper/ok/invariant.vpr.ok
@@ -1,7 +1,5 @@
 method __init__($Self: Ref) 
   requires ((true && acc(($Self).claimed,write)) && acc(($Self).count,write))
-  requires invariant_7($Self)
-  requires invariant_8($Self)
   ensures ((true && acc(($Self).claimed,write)) && acc(($Self).count,write))
   ensures invariant_7($Self)
   ensures invariant_8($Self)

--- a/test/viper/ok/invariant.vpr.ok
+++ b/test/viper/ok/invariant.vpr.ok
@@ -1,4 +1,8 @@
-method __init__($Self: Ref)  
+method __init__($Self: Ref) 
+  requires ((true && acc(($Self).claimed,write)) && acc(($Self).count,write))
+  requires invariant_7($Self)
+  requires invariant_8($Self)
+  ensures ((true && acc(($Self).claimed,write)) && acc(($Self).count,write))
   ensures invariant_7($Self)
   ensures invariant_8($Self)
    { 
@@ -7,11 +11,13 @@ method __init__($Self: Ref)
    }
 field claimed: Bool
 field count: Int
-define invariant_7(self) (((((self).claimed && (!(-1 == -1))) && (-42 == -42)) || true))
-define invariant_8(self) (((self).count > 0))
+define invariant_7($Self) ((((($Self).claimed && (!(-1 == -1))) && (-42 == -42)) || true))
+define invariant_8($Self) ((($Self).count > 0))
 method claim($Self: Ref) 
+  requires ((true && acc(($Self).claimed,write)) && acc(($Self).count,write))
   requires invariant_7($Self)
   requires invariant_8($Self)
+  ensures ((true && acc(($Self).claimed,write)) && acc(($Self).count,write))
   ensures invariant_7($Self)
   ensures invariant_8($Self)  { 
                                  


### PR DESCRIPTION
This PR enables method specs in Motoko to Viper translation (including both access permissions to all actor private fields and canister invariant).