### PR TITLE
Support static assertions as `assert:system` in Motoko to Viper translation

### DIFF
--- a/src/mo_def/arrange.ml
+++ b/src/mo_def/arrange.ml
@@ -59,6 +59,7 @@ let rec exp e = match e.it with
   | AsyncE (tb, e)      -> "AsyncE"  $$ [typ_bind tb; exp e]
   | AwaitE e            -> "AwaitE"  $$ [exp e]
   | AssertE (Runtime, e)       -> "AssertE" $$ [exp e]
+  | AssertE (Static, e)        -> "Static_AssertE" $$ [exp e]
   | AssertE (Invariant, e)     -> "Invariant" $$ [exp e]
   | AssertE (Precondition, e)  -> "Precondition" $$ [exp e]
   | AssertE (Postcondition, e) -> "Postcondition" $$ [exp e]

--- a/src/mo_def/syntax.ml
+++ b/src/mo_def/syntax.ml
@@ -197,7 +197,7 @@ and exp' =
 *)
 
 and assert_kind =
-  | Runtime | Invariant | Precondition | Postcondition | Concurrency of string | Loop_entry | Loop_continue | Loop_exit
+  | Runtime | Static | Invariant | Precondition | Postcondition | Concurrency of string | Loop_entry | Loop_continue | Loop_exit
 
 and dec_field = dec_field' Source.phrase
 and dec_field' = {dec : dec; vis : vis; stab: stab option}

--- a/src/mo_frontend/assertions.mly
+++ b/src/mo_frontend/assertions.mly
@@ -13,6 +13,8 @@ when I write this here (instead of in parser.mly)
     { ImpliesE(e1, e2) @? at $sloc }
 
 %public exp_nondec(B) :
+  | ASSERT COLON SYSTEM e=exp_nest
+    { AssertE(Static, e) @? at $sloc }
   | ASSERT COLON INVARIANT e=exp_nest
     { AssertE(Invariant, e) @? at $sloc }
   | ASSERT COLON FUNC e=exp_nest

--- a/src/viper/pretty.ml
+++ b/src/viper/pretty.ml
@@ -162,6 +162,9 @@ and pp_stmt' ppf = function
   | AssumeS exp ->
     fprintf ppf "@[<v 2>assume %a@]"
       pp_exp exp
+  | AssertS exp ->
+    fprintf ppf "@[<v 2>assert %a@]"
+      pp_exp exp
   | PreconditionS exp ->
     fprintf ppf "@[<v 2>/*requires %a*/@]"
       pp_exp exp

--- a/src/viper/trans.ml
+++ b/src/viper/trans.ml
@@ -382,6 +382,9 @@ and stmt ctxt (s : M.exp) : seqn =
   | M.AssertE (M.Concurrency n, e) ->
     !!([],
        [ !!(ConcurrencyS (n, exp ctxt e, !! ((|>) e))) ])
+  | M.AssertE (M.Static, e) ->
+    !!([],
+       [ !!(AssertS (exp ctxt e)) ])
   | M.AssertE (M.Runtime, e) ->
     !!([],
        [ !!(AssumeS (exp ctxt e)) ])

--- a/test/viper/assertions.mo
+++ b/test/viper/assertions.mo
@@ -1,0 +1,26 @@
+// @verify
+
+// This example should demonstrate all static assertions that are currently 
+// supported.
+
+actor {
+
+  var u = false;
+  var v = 0 : Int;
+
+  assert:invariant u;                 // canister invariant
+
+  public shared func claim() : async () {
+      assert:func v >= 0;             // function precondition
+      
+      assert:system u implies v > 0;  // static assertion
+      assert u implies v > 0;         // dynamic assertion
+
+      await async {
+        assert:1:async true;          // concurrency constraints
+      };
+
+      assert:return v >= 0;           // function postcondition
+  };
+
+}

--- a/test/viper/ok/assertions.silicon.ok
+++ b/test/viper/ok/assertions.silicon.ok
@@ -1,0 +1,2 @@
+  [0] Postcondition of __init__ might not hold. Assertion $Self.u might not hold. (assertions.vpr@10.13--10.24)
+  [1] Assert might fail. Assertion $Self.u ==> $Self.v > 0 might not hold. (assertions.vpr@28.15--28.44)

--- a/test/viper/ok/assertions.silicon.ret.ok
+++ b/test/viper/ok/assertions.silicon.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/viper/ok/assertions.vpr.ok
+++ b/test/viper/ok/assertions.vpr.ok
@@ -1,0 +1,41 @@
+field $message_async: Int
+define $Perm($Self) ((((true && acc(($Self).u,write)) && acc(($Self).v,write)) && 
+  acc(($Self).$message_async,write)))
+define $Inv($Self) ((invariant_11($Self) && (((0 <= ($Self).$message_async) && (
+  ($Self).$message_async <= 1)) && ((($Self).$message_async == 1) ==> true))))
+method __init__($Self: Ref)
+    
+    requires $Perm($Self)
+    ensures $Perm($Self)
+    ensures $Inv($Self)
+    { 
+      ($Self).u := false
+      ($Self).v := 0
+      ($Self).$message_async := 0 
+    }
+field u: Bool
+field v: Int
+define invariant_11($Self) (($Self).u)
+method claim($Self: Ref)
+    
+    requires $Perm($Self)
+    requires (($Self).v >= 0)
+    requires $Inv($Self)
+    ensures $Perm($Self)
+    ensures (($Self).v >= 0)
+    ensures $Inv($Self)
+    { 
+      assert (($Self).u ==> (($Self).v > 0))
+      assume (($Self).u ==> (($Self).v > 0))
+      ($Self).$message_async := (($Self).$message_async + 1)
+      exhale ($Perm($Self) && $Inv($Self))
+      { 
+         inhale ($Perm($Self) && ($Inv($Self) && (($Self).$message_async > 0)))
+         ($Self).$message_async := (($Self).$message_async - 1)
+         { 
+             
+          }
+         exhale ($Perm($Self) && $Inv($Self)) 
+       }
+      inhale ($Perm($Self) && $Inv($Self)) 
+    }


### PR DESCRIPTION
Why this is needed:
- Peace of mind assertion that Viper can derive what you think should hold.
- Smoke testing soundness of the verification technique or proving that code is unreachable via assert:system false.
- One can use static assertions to introspect a program that fails to verify. 
- There’s also the possibility to replace dynamic assertion with static ones (e.g., to have stronger guarantees or simply save some cycles)
- In case the proof search is undecidable, user-defined static assertions can guide the quantifier instantiation heuristics. 