### PR TITLE
test: unit test `bitrel.rs`, fixing bug

### DIFF
--- a/rts/motoko-rts-tests/src/bitrel.rs
+++ b/rts/motoko-rts-tests/src/bitrel.rs
@@ -1,82 +1,57 @@
-use motoko_rts::bitrel::{
-    BitRel,//
-};
+use motoko_rts::bitrel::BitRel;
 use motoko_rts::types::{Value, Words};
 
 pub unsafe fn test() {
     println!("Testing bitrel ...");
 
-    const N : usize = 1024;
+    const K: u32 = 128;
 
-    let mut cache: [u32; N] = [0; N];
+    const N: usize = (2 * K * K * 2 / usize::BITS) as usize;
 
-    const K : u32 = 64;
+    let mut cache: [u32; N] = [0xFFFFFFF; N];
 
-    assert_eq! (usize::BITS,32);
-    for size1 in 1..K {
-        for size2 in 1..K {
+    assert_eq!(usize::BITS, 32);
+    for size1 in 0..K {
+        for size2 in 0..K {
             let w = BitRel::words(size1, size2);
-            let bitrel = BitRel { ptr: &mut cache[0], end: &mut cache[w as usize], size1: size1, size2: size2 };
+            let bitrel = BitRel {
+                ptr: &mut cache[0],
+                end: &mut cache[w as usize],
+                size1: size1,
+                size2: size2,
+            };
             bitrel.init();
             for i in 0..size1 {
                 for j in 0..size2 {
-                    assert_eq!(bitrel.visited(true, i, j), false);
-                    assert_eq!(bitrel.visited(false, j, i), false);
-                    assert_eq!(bitrel.related(true, i, j), true);
-                    assert_eq!(bitrel.related(false, j, i), true);
-                    /*
-                    bitrel.visit(true, i, j);
-                    assert_eq!(bitrel.visited(true, i, j), true);
+                    // initially unvisited
+                    assert!(!bitrel.visited(true, i, j)); // co
+                    assert!(!bitrel.visited(false, j, i)); // contra
 
-                    assert_eq!(bitrel.visited(false, j, i), false);
+                    // initially related
+                    assert!(bitrel.related(true, i, j)); // co
+                    assert!(bitrel.related(false, j, i)); // contra
+
+                    // test visiting
+                    // co
+                    bitrel.visit(true, i, j);
+                    assert!(bitrel.visited(true, i, j));
+                    // contra
                     bitrel.visit(false, j, i);
-                    assert_eq!(bitrel.visited(false, j, i), true);
-                    
-                    assert_eq!(bitrel.related(true, i, j), true);
+                    assert!(bitrel.visited(false, j, i));
+
+                    // test refutation
+                    // co
                     bitrel.assume(true, i, j);
-                    assert_eq!(bitrel.related(true, i, j), true);
+                    assert!(bitrel.related(true, i, j));
                     bitrel.disprove(true, i, j);
-                    assert_eq!(bitrel.related(true, i, j), false);
-*/
+                    assert!(!bitrel.related(true, i, j));
+                    // contra
+                    bitrel.assume(false, j, i);
+                    assert!(bitrel.related(false, j, i));
+                    bitrel.disprove(false, j, i);
+                    assert!(!bitrel.related(false, j, i));
                 }
             }
-
         }
-
     }
-
-    /*
-    let mut heap = TestMemory::new(Words(3848));
-
-    let mut references: [u32; N] = [0; N];
-    for i in 0..N {
-        references[i] = remember_continuation(
-            &mut heap,
-            Value::from_raw(((i as u32) << 2).wrapping_sub(1)),
-        );
-        assert_eq!(continuation_count(), (i + 1) as u32);
-    }
-
-    for i in 0..N / 2 {
-        let c = recall_continuation(references[i]);
-        assert_eq!(c.get_raw(), (i << 2).wrapping_sub(1) as u32);
-        assert_eq!(continuation_count(), (N - i - 1) as u32);
-    }
-
-    for i in 0..N / 2 {
-        references[i] = remember_continuation(
-            &mut heap,
-            Value::from_raw(((i as u32) << 2).wrapping_sub(1)),
-        );
-        assert_eq!(continuation_count(), (N / 2 + i + 1) as u32);
-    }
-
-    for i in (0..N).rev() {
-        assert_eq!(
-            recall_continuation(references[i]).get_raw(),
-            (i << 2).wrapping_sub(1) as u32,
-        );
-        assert_eq!(continuation_count(), i as u32);
-    }
-     */
 }

--- a/rts/motoko-rts-tests/src/bitrel.rs
+++ b/rts/motoko-rts-tests/src/bitrel.rs
@@ -1,0 +1,82 @@
+use motoko_rts::bitrel::{
+    BitRel,//
+};
+use motoko_rts::types::{Value, Words};
+
+pub unsafe fn test() {
+    println!("Testing bitrel ...");
+
+    const N : usize = 1024;
+
+    let mut cache: [u32; N] = [0; N];
+
+    const K : u32 = 64;
+
+    assert_eq! (usize::BITS,32);
+    for size1 in 1..K {
+        for size2 in 1..K {
+            let w = BitRel::words(size1, size2);
+            let bitrel = BitRel { ptr: &mut cache[0], end: &mut cache[w as usize], size1: size1, size2: size2 };
+            bitrel.init();
+            for i in 0..size1 {
+                for j in 0..size2 {
+                    assert_eq!(bitrel.visited(true, i, j), false);
+                    assert_eq!(bitrel.visited(false, j, i), false);
+                    assert_eq!(bitrel.related(true, i, j), true);
+                    assert_eq!(bitrel.related(false, j, i), true);
+                    /*
+                    bitrel.visit(true, i, j);
+                    assert_eq!(bitrel.visited(true, i, j), true);
+
+                    assert_eq!(bitrel.visited(false, j, i), false);
+                    bitrel.visit(false, j, i);
+                    assert_eq!(bitrel.visited(false, j, i), true);
+                    
+                    assert_eq!(bitrel.related(true, i, j), true);
+                    bitrel.assume(true, i, j);
+                    assert_eq!(bitrel.related(true, i, j), true);
+                    bitrel.disprove(true, i, j);
+                    assert_eq!(bitrel.related(true, i, j), false);
+*/
+                }
+            }
+
+        }
+
+    }
+
+    /*
+    let mut heap = TestMemory::new(Words(3848));
+
+    let mut references: [u32; N] = [0; N];
+    for i in 0..N {
+        references[i] = remember_continuation(
+            &mut heap,
+            Value::from_raw(((i as u32) << 2).wrapping_sub(1)),
+        );
+        assert_eq!(continuation_count(), (i + 1) as u32);
+    }
+
+    for i in 0..N / 2 {
+        let c = recall_continuation(references[i]);
+        assert_eq!(c.get_raw(), (i << 2).wrapping_sub(1) as u32);
+        assert_eq!(continuation_count(), (N - i - 1) as u32);
+    }
+
+    for i in 0..N / 2 {
+        references[i] = remember_continuation(
+            &mut heap,
+            Value::from_raw(((i as u32) << 2).wrapping_sub(1)),
+        );
+        assert_eq!(continuation_count(), (N / 2 + i + 1) as u32);
+    }
+
+    for i in (0..N).rev() {
+        assert_eq!(
+            recall_continuation(references[i]).get_raw(),
+            (i << 2).wrapping_sub(1) as u32,
+        );
+        assert_eq!(continuation_count(), i as u32);
+    }
+     */
+}

--- a/rts/motoko-rts-tests/src/main.rs
+++ b/rts/motoko-rts-tests/src/main.rs
@@ -2,6 +2,7 @@
 
 mod bigint;
 mod bitmap;
+mod bitrel;
 mod continuation_table;
 mod crc32;
 mod gc;
@@ -24,6 +25,7 @@ fn main() {
     unsafe {
         bigint::test();
         bitmap::test();
+        bitrel::test();
         continuation_table::test();
         crc32::test();
         gc::test();

--- a/rts/motoko-rts/src/bitrel.rs
+++ b/rts/motoko-rts/src/bitrel.rs
@@ -38,26 +38,16 @@ impl BitRel {
     unsafe fn locate_ptr_bit(&self, p: bool, i_j: u32, j_i: u32, bit: u32) -> (*mut u32, u32) {
         let size1 = self.size1;
         let size2 = self.size2;
-        let (base, i, j) = if p {
-            (0, i_j, j_i)
-        } else {
-            (size1 * size2 * BITS, j_i, i_j)
-        };
-        if i >= size1 {
-            idl_trap_with("BitRel i out of bounds");
-        };
-        if j >= size2 {
-            idl_trap_with("BitRel j out of bounds");
-        };
-        if bit >= BITS {
-            idl_trap_with("BitRel bit out of bounds");
-        };
-        let k = base + (i * size2 + j) * BITS + bit;
+        let (base, i, j) = if p { (0, i_j, j_i) } else { (size1, j_i, i_j) };
+        debug_assert!(i < size1);
+        debug_assert!(j < size2);
+        debug_assert!(bit < BITS);
+        let k = ((base + i) * size2 + j) * BITS + bit;
         let word = (k / usize::BITS) as usize;
         let bit = (k % usize::BITS) as u32;
         let ptr = self.ptr.add(word);
         if ptr > self.end {
-            idl_trap_with("BitRel ptr out of bounds");
+            idl_trap_with("BitRel indices out of bounds");
         };
         return (ptr, bit);
     }

--- a/rts/motoko-rts/src/bitrel.rs
+++ b/rts/motoko-rts/src/bitrel.rs
@@ -52,7 +52,7 @@ impl BitRel {
         if bit >= BITS {
             idl_trap_with("BitRel bit out of bounds");
         };
-        let k = base + i * size2 * BITS + j * BITS + bit;
+        let k = base + (i * size2 + j) * BITS + bit;
         let word = (k / usize::BITS) as usize;
         let bit = (k % usize::BITS) as u32;
         let ptr = self.ptr.add(word);

--- a/rts/motoko-rts/src/bitrel.rs
+++ b/rts/motoko-rts/src/bitrel.rs
@@ -1,7 +1,5 @@
 //! This module implements a simple subtype cache used by the compiler (in generated code)
 
-//TODO: add unit test and remove #[allow(dead_code)] on tested functions
-
 use crate::constants::WORD_SIZE;
 use crate::idl_trap_with;
 use crate::mem_utils::memzero;
@@ -21,12 +19,10 @@ pub struct BitRel {
 }
 
 impl BitRel {
-    #[allow(dead_code)]
     pub fn words(size1: u32, size2: u32) -> u32 {
         return ((2 * size1 * size2 * BITS) + (usize::BITS - 1)) / usize::BITS;
     }
 
-    #[allow(dead_code)]
     pub unsafe fn init(&self) {
         if (self.end as usize) < (self.ptr as usize) {
             idl_trap_with("BitRel invalid fields");
@@ -39,7 +35,6 @@ impl BitRel {
         memzero(self.ptr as usize, Words(bytes / WORD_SIZE));
     }
 
-    #[allow(dead_code)]
     unsafe fn locate_ptr_bit(&self, p: bool, i_j: u32, j_i: u32, bit: u32) -> (*mut u32, u32) {
         let size1 = self.size1;
         let size2 = self.size2;
@@ -57,7 +52,7 @@ impl BitRel {
         if bit >= BITS {
             idl_trap_with("BitRel bit out of bounds");
         };
-        let k = base + i * size2 * BITS + j + bit;
+        let k = base + i * size2 * BITS + j * BITS + bit;
         let word = (k / usize::BITS) as usize;
         let bit = (k % usize::BITS) as u32;
         let ptr = self.ptr.add(word);
@@ -82,12 +77,10 @@ impl BitRel {
         return *ptr & mask == mask;
     }
 
-    #[allow(dead_code)]
     pub unsafe fn visited(&self, p: bool, i_j: u32, j_i: u32) -> bool {
         self.get(p, i_j, j_i, 0)
     }
 
-    #[allow(dead_code)]
     pub unsafe fn visit(&self, p: bool, i_j: u32, j_i: u32) {
         self.set(p, i_j, j_i, 0, true)
     }
@@ -99,12 +92,10 @@ impl BitRel {
         debug_assert!(!self.get(p, i_j, j_i, 1));
     }
 
-    #[allow(dead_code)]
     pub unsafe fn related(&self, p: bool, i_j: u32, j_i: u32) -> bool {
         !self.get(p, i_j, j_i, 1)
     }
 
-    #[allow(dead_code)]
     pub unsafe fn disprove(&self, p: bool, i_j: u32, j_i: u32) {
         self.set(p, i_j, j_i, 1, true)
     }

--- a/rts/motoko-rts/src/bitrel.rs
+++ b/rts/motoko-rts/src/bitrel.rs
@@ -22,12 +22,12 @@ pub struct BitRel {
 
 impl BitRel {
     #[allow(dead_code)]
-    pub(crate) fn words(size1: u32, size2: u32) -> u32 {
+    pub fn words(size1: u32, size2: u32) -> u32 {
         return ((2 * size1 * size2 * BITS) + (usize::BITS - 1)) / usize::BITS;
     }
 
     #[allow(dead_code)]
-    pub(crate) unsafe fn init(&self) {
+    pub unsafe fn init(&self) {
         if (self.end as usize) < (self.ptr as usize) {
             idl_trap_with("BitRel invalid fields");
         };
@@ -83,29 +83,29 @@ impl BitRel {
     }
 
     #[allow(dead_code)]
-    pub(crate) unsafe fn visited(&self, p: bool, i_j: u32, j_i: u32) -> bool {
+    pub unsafe fn visited(&self, p: bool, i_j: u32, j_i: u32) -> bool {
         self.get(p, i_j, j_i, 0)
     }
 
     #[allow(dead_code)]
-    pub(crate) unsafe fn visit(&self, p: bool, i_j: u32, j_i: u32) {
+    pub unsafe fn visit(&self, p: bool, i_j: u32, j_i: u32) {
         self.set(p, i_j, j_i, 0, true)
     }
 
     #[allow(dead_code)]
     // NB: we store related bits in negated form to avoid setting on assumption
     // This code is a nop in production code.
-    pub(crate) unsafe fn assume(&self, p: bool, i_j: u32, j_i: u32) {
+    pub unsafe fn assume(&self, p: bool, i_j: u32, j_i: u32) {
         debug_assert!(!self.get(p, i_j, j_i, 1));
     }
 
     #[allow(dead_code)]
-    pub(crate) unsafe fn related(&self, p: bool, i_j: u32, j_i: u32) -> bool {
+    pub unsafe fn related(&self, p: bool, i_j: u32, j_i: u32) -> bool {
         !self.get(p, i_j, j_i, 1)
     }
 
     #[allow(dead_code)]
-    pub(crate) unsafe fn disprove(&self, p: bool, i_j: u32, j_i: u32) {
+    pub unsafe fn disprove(&self, p: bool, i_j: u32, j_i: u32) {
         self.set(p, i_j, j_i, 1, true)
     }
 }

--- a/rts/motoko-rts/src/lib.rs
+++ b/rts/motoko-rts/src/lib.rs
@@ -10,7 +10,7 @@ mod print;
 pub mod debug;
 
 pub mod bigint;
-mod bitrel;
+pub mod bitrel;
 #[cfg(feature = "ic")]
 mod blob_iter;
 pub mod buf;


### PR DESCRIPTION
Fixes bug in #3171  

 * add unit test for BitRel.rs
 * fix insidious bug revealed by test - conversion to bit position was broken, failing to account for all bits and leading to confusion of BitRel entries.
 * optimize indexing arithmetic and sanity checks

Why wasn't this caught by the moc tests? Probably because the bitrels used by candid subtype checking are actually sparse so the interference was never observed.