### PR TITLE
Disable extensive memory sanity checks in CI

### DIFF
--- a/rts/motoko-rts/Cargo.toml
+++ b/rts/motoko-rts/Cargo.toml
@@ -13,10 +13,15 @@ crate-type = ["staticlib"]
 # we enable the "ic" feature. `native/Cargo.toml` doesn't have this feature and
 # is used in RTS tests.
 default = ["ic"]
+# default = ["ic", "memory_check"]
+
 
 # This feature is used to enable stuff needed for the RTS linked with
 # moc-generated code, but not when testing the RTS
 ic = []
+
+# This feature enables extensive memory sanity checks in the generational GC
+memory_check = []
 
 [dependencies]
 libc = { version = "0.2.112", default_features = false }

--- a/rts/motoko-rts/src/gc/generational.rs
+++ b/rts/motoko-rts/src/gc/generational.rs
@@ -7,7 +7,7 @@
 
 pub mod mark_stack;
 pub mod remembered_set;
-#[cfg(debug_assertions)]
+#[cfg(feature = "memory_check")]
 mod sanity_checks;
 pub mod write_barrier;
 
@@ -51,13 +51,13 @@ unsafe fn generational_gc<M: Memory>(mem: &mut M) {
     };
     let strategy = decide_strategy(&heap.limits);
 
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "memory_check")]
     let forced_gc = strategy.is_none();
 
     let strategy = strategy.unwrap_or(Strategy::Young);
     let mut gc = GenerationalGC::new(heap, strategy);
 
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "memory_check")]
     sanity_checks::verify_snapshot(&gc.heap, false);
 
     gc.run();
@@ -67,7 +67,7 @@ unsafe fn generational_gc<M: Memory>(mem: &mut M) {
     update_statistics(&old_limits, new_limits);
     update_strategy(strategy, new_limits);
 
-    #[cfg(debug_assertions)]
+    #[cfg(feature = "memory_check")]
     if !forced_gc {
         sanity_checks::check_memory(&gc.heap.limits, &gc.heap.roots);
         sanity_checks::take_snapshot(&mut gc.heap);


### PR DESCRIPTION
Introducing a switch for extensive memory sanity checks as used in the generational GC. 

Disable these checks in CI, as they otherwise take too long with `ic-ref-run`.

To enable the checks during engineering or testing, manually set the features in `Cargo.toml` as follows:
```
[features]
default = ["ic", "memory_check"]
```