### PR TITLE
chore: fix make base target

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -17,7 +17,7 @@ overview-slides.html : overview-slides.md
 	  # # -V maxScale=2
 
 base:
-	mo-doc --source $(MOTOKO_BASE) --output $(OUT)/base --format plain
+	mo-doc --source $(MOTOKO_BASE)/src --output $(OUT)/base --format plain
 
 html:
         # TODO: perhaps use node and remark-cli to compile out remark plugins first or use docusaurus to build site properly


### PR DESCRIPTION
I notice that doc/make base tried to produce docs for the motoko-base test dir too, and complained.

Fixed the base target to only produce doc for motoko-base src dir, not the root dir.

I wonder how this ever worked in the past, especially since it used by our release instructions...
