### PR TITLE
rts: selective GC features

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -257,9 +257,9 @@ rec {
 
       installPhase = ''
         mkdir -p $out/rts
-        ln mo-rts.wasm $out/rts
-        ln mo-rts-generational.wasm $out/rts
-        ln mo-rts-debug.wasm $out/rts
+        cp mo-rts.wasm $out/rts
+        cp mo-rts-generational.wasm $out/rts
+        cp mo-rts-debug.wasm $out/rts
       '';
 
       # This needs to be self-contained. Remove mention of nix path in debug

--- a/default.nix
+++ b/default.nix
@@ -257,8 +257,9 @@ rec {
 
       installPhase = ''
         mkdir -p $out/rts
-        cp mo-rts.wasm $out/rts
-        cp mo-rts-debug.wasm $out/rts
+        ln mo-rts.wasm $out/rts
+        ln mo-rts-generational.wasm $out/rts
+        ln mo-rts-debug.wasm $out/rts
       '';
 
       # This needs to be self-contained. Remove mention of nix path in debug

--- a/default.nix
+++ b/default.nix
@@ -257,9 +257,7 @@ rec {
 
       installPhase = ''
         mkdir -p $out/rts
-        cp mo-rts.wasm $out/rts
-        cp mo-rts-generational.wasm $out/rts
-        cp mo-rts-debug.wasm $out/rts
+        cp mo-rts*.wasm $out/rts
       '';
 
       # This needs to be self-contained. Remove mention of nix path in debug

--- a/default.nix
+++ b/default.nix
@@ -269,7 +269,7 @@ rec {
           -t ${nixpkgs.rustc-nightly} \
           -t ${rtsDeps} \
           -t ${rustStdDeps} \
-          $out/rts/mo-rts.wasm $out/rts/mo-rts-debug.wasm
+          $out/rts/mo-rts*.wasm
       '';
 
       allowedRequisites = [];

--- a/rts/.gitignore
+++ b/rts/.gitignore
@@ -1,3 +1,2 @@
-mo-rts.wasm
-mo-rts-debug.wasm
+mo-rts*.wasm
 _build

--- a/rts/Makefile
+++ b/rts/Makefile
@@ -111,7 +111,7 @@ CLANG_FLAGS = \
 
 .PHONY: all
 
-all: mo-rts.wasm mo-rts-debug.wasm
+all: mo-rts.wasm mo-rts-generational.wasm mo-rts-debug.wasm
 
 _build:
 	mkdir -p $@

--- a/rts/Makefile
+++ b/rts/Makefile
@@ -111,7 +111,7 @@ CLANG_FLAGS = \
 
 .PHONY: all
 
-all: mo-rts.wasm mo-rts-generational.wasm mo-rts-debug.wasm
+all: mo-rts.wasm mo-rts-copying.wasm mo-rts-generational.wasm mo-rts-debug.wasm
 
 _build:
 	mkdir -p $@
@@ -173,6 +173,7 @@ $(MUSL_WASM_A): $(MUSL_WASM_O)
 #
 
 RTS_RUST_WASM_A=_build/wasm/libmotoko_rts.a
+RTS_RUST_COPYING_WASM_A=_build/wasm/libmotoko_copying_rts.a
 RTS_RUST_GENERATIONAL_WASM_A=_build/wasm/libmotoko_generational_rts.a
 RTS_RUST_DEBUG_WASM_A=_build/wasm/libmotoko_rts_debug.a
 
@@ -224,15 +225,19 @@ $(TOMMATH_BINDINGS_RS): | _build
 
 
 $(RTS_RUST_WASM_A): $(TOMMATH_BINDINGS_RS) $(RTS_RUST_FILES) $(RTS_CARGO_FILES) | _build/wasm
-	cd motoko-rts && cargo build --release --target=wasm32-unknown-emscripten -Zbuild-std=core,alloc
+	cd motoko-rts && cargo build --features=ic --release --target=wasm32-unknown-emscripten -Zbuild-std=core,alloc
 	ln -f motoko-rts/target/wasm32-unknown-emscripten/release/libmotoko_rts.a $@
+
+$(RTS_RUST_COPYING_WASM_A): $(TOMMATH_BINDINGS_RS) $(RTS_RUST_FILES) $(RTS_CARGO_FILES) | _build/wasm
+	cd motoko-rts && cargo build --features=copying --release --target=wasm32-unknown-emscripten -Zbuild-std=core,alloc -Z unstable-options --out-dir=target/wasm32-unknown-emscripten/copying
+	ln -f motoko-rts/target/wasm32-unknown-emscripten/copying/libmotoko_rts.a $@
 
 $(RTS_RUST_GENERATIONAL_WASM_A): $(TOMMATH_BINDINGS_RS) $(RTS_RUST_FILES) $(RTS_CARGO_FILES) | _build/wasm
 	cd motoko-rts && cargo build --features=generational --release --target=wasm32-unknown-emscripten -Zbuild-std=core,alloc -Z unstable-options --out-dir=target/wasm32-unknown-emscripten/generational
 	ln -f motoko-rts/target/wasm32-unknown-emscripten/generational/libmotoko_rts.a $@
 
 $(RTS_RUST_DEBUG_WASM_A): $(TOMMATH_BINDINGS_RS) $(RTS_RUST_FILES) $(RTS_CARGO_FILES) | _build/wasm
-	cd motoko-rts && cargo build --target=wasm32-unknown-emscripten -Zbuild-std=core,alloc
+	cd motoko-rts && cargo build --features=ic --target=wasm32-unknown-emscripten -Zbuild-std=core,alloc
 	ln -f motoko-rts/target/wasm32-unknown-emscripten/debug/libmotoko_rts.a $@
 
 #
@@ -266,6 +271,13 @@ EXPORTED_SYMBOLS=\
   log \
 
 mo-rts.wasm: $(TOMMATH_WASM_A) $(MUSL_WASM_A) $(RTS_RUST_WASM_A)
+	$(WASM_LD) -o $@ \
+		--import-memory --shared --no-entry --gc-sections \
+                $(EXPORTED_SYMBOLS:%=--export=%) \
+		--whole-archive \
+		$+
+
+mo-rts-copying.wasm: $(TOMMATH_WASM_A) $(MUSL_WASM_A) $(RTS_RUST_COPYING_WASM_A)
 	$(WASM_LD) -o $@ \
 		--import-memory --shared --no-entry --gc-sections \
                 $(EXPORTED_SYMBOLS:%=--export=%) \

--- a/rts/Makefile
+++ b/rts/Makefile
@@ -173,6 +173,7 @@ $(MUSL_WASM_A): $(MUSL_WASM_O)
 #
 
 RTS_RUST_WASM_A=_build/wasm/libmotoko_rts.a
+RTS_RUST_GENERATIONAL_WASM_A=_build/wasm/libmotoko_generational_rts.a
 RTS_RUST_DEBUG_WASM_A=_build/wasm/libmotoko_rts_debug.a
 
 # This relies on bash and globstar, see https://stackoverflow.com/questions/2483182/recursive-wildcards-in-gnu-make
@@ -224,11 +225,15 @@ $(TOMMATH_BINDINGS_RS): | _build
 
 $(RTS_RUST_WASM_A): $(TOMMATH_BINDINGS_RS) $(RTS_RUST_FILES) $(RTS_CARGO_FILES) | _build/wasm
 	cd motoko-rts && cargo build --release --target=wasm32-unknown-emscripten -Zbuild-std=core,alloc
-	cp motoko-rts/target/wasm32-unknown-emscripten/release/libmotoko_rts.a $@
+	ln -f motoko-rts/target/wasm32-unknown-emscripten/release/libmotoko_rts.a $@
+
+$(RTS_RUST_GENERATIONAL_WASM_A): $(TOMMATH_BINDINGS_RS) $(RTS_RUST_FILES) $(RTS_CARGO_FILES) | _build/wasm
+	cd motoko-rts && cargo build --features=generational --release --target=wasm32-unknown-emscripten -Zbuild-std=core,alloc -Z unstable-options --out-dir=target/wasm32-unknown-emscripten/generational
+	ln -f motoko-rts/target/wasm32-unknown-emscripten/generational/libmotoko_rts.a $@
 
 $(RTS_RUST_DEBUG_WASM_A): $(TOMMATH_BINDINGS_RS) $(RTS_RUST_FILES) $(RTS_CARGO_FILES) | _build/wasm
 	cd motoko-rts && cargo build --target=wasm32-unknown-emscripten -Zbuild-std=core,alloc
-	cp motoko-rts/target/wasm32-unknown-emscripten/debug/libmotoko_rts.a $@
+	ln -f motoko-rts/target/wasm32-unknown-emscripten/debug/libmotoko_rts.a $@
 
 #
 # The test suite
@@ -267,6 +272,13 @@ mo-rts.wasm: $(TOMMATH_WASM_A) $(MUSL_WASM_A) $(RTS_RUST_WASM_A)
 		--whole-archive \
 		$+
 
+mo-rts-generational.wasm: $(TOMMATH_WASM_A) $(MUSL_WASM_A) $(RTS_RUST_GENERATIONAL_WASM_A)
+	$(WASM_LD) -o $@ \
+		--import-memory --shared --no-entry --gc-sections \
+                $(EXPORTED_SYMBOLS:%=--export=%) \
+		--whole-archive \
+		$+
+
 mo-rts-debug.wasm: $(RTS_RUST_DEBUG_WASM_A) $(TOMMATH_WASM_A) $(MUSL_WASM_A)
 	$(WASM_LD) -o $@ \
 		--import-memory --shared --no-entry --gc-sections \
@@ -282,8 +294,7 @@ format:
 clean:
 	rm -rf \
 	  _build \
-	  mo-rts.wasm \
-	  mo-rts-debug.wasm \
+	  mo-rts*.wasm \
 	  motoko-rts/target \
 	  motoko-rts-tests/target \
 	  motoko-rts/cargo-home

--- a/rts/motoko-rts-tests/Cargo.toml
+++ b/rts/motoko-rts-tests/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 byteorder = "1.4.3"
 fxhash = "0.2.1"
 libc = { version = "0.2.139", default_features = false }
-motoko-rts = { path = "../motoko-rts/native" }
+motoko-rts = { path = "../motoko-rts/native", features = ["ic"] }
 oorandom = "11.1.3"
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }

--- a/rts/motoko-rts/Cargo.toml
+++ b/rts/motoko-rts/Cargo.toml
@@ -14,9 +14,15 @@ crate-type = ["staticlib"]
 # is used in RTS tests.
 default = ["ic"]
 
+# The following features select a GC strategy
+copying = []
+compacting = []
+generational = ["compacting"]
+incremental = []
+
 # This feature is used to enable stuff needed for the RTS linked with
 # moc-generated code, but not when testing the RTS
-ic = []
+ic = ["copying", "compacting", "generational", "incremental"]
 
 [dependencies]
 libc = { version = "0.2.139", default_features = false }

--- a/rts/motoko-rts/Cargo.toml
+++ b/rts/motoko-rts/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["staticlib"]
 # This file is used to build the RTS to be linked with moc-generated code, so
 # we enable the "ic" feature. `native/Cargo.toml` doesn't have this feature and
 # is used in RTS tests.
-default = ["ic"]
+#default = ["ic"]
 
 # The following features select a GC strategy
 copying = []

--- a/rts/motoko-rts/Cargo.toml
+++ b/rts/motoko-rts/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["staticlib"]
 # This file is used to build the RTS to be linked with moc-generated code, so
 # we enable the "ic" feature. `native/Cargo.toml` doesn't have this feature and
 # is used in RTS tests.
-#default = ["ic"]
+# default = ["ic"]
 
 # The following features select a GC strategy
 copying = []

--- a/rts/motoko-rts/src/gc.rs
+++ b/rts/motoko-rts/src/gc.rs
@@ -1,5 +1,8 @@
+#[cfg(feature = "copying")]
 pub mod copying;
+#[cfg(feature = "generational")]
 pub mod generational;
+#[cfg(feature = "compacting")]
 pub mod mark_compact;
 
 #[cfg(feature = "ic")]

--- a/rts/motoko-rts/src/gc/generational.rs
+++ b/rts/motoko-rts/src/gc/generational.rs
@@ -76,7 +76,7 @@ unsafe fn generational_gc<M: Memory>(mem: &mut M) {
     write_barrier::init_write_barrier(gc.heap.mem);
 }
 
-#[cfg(feature = "ic")]
+#[cfg(feature = "generational")]
 unsafe fn get_limits() -> Limits {
     assert!(ic::LAST_HP >= ic::get_aligned_heap_base());
     use crate::memory::ic;
@@ -87,14 +87,14 @@ unsafe fn get_limits() -> Limits {
     }
 }
 
-#[cfg(feature = "ic")]
+#[cfg(feature = "generational")]
 unsafe fn set_limits(limits: &Limits) {
     use crate::memory::ic;
     ic::HP = limits.free as u32;
     ic::LAST_HP = limits.free as u32;
 }
 
-#[cfg(feature = "ic")]
+#[cfg(feature = "generational")]
 unsafe fn update_statistics(old_limits: &Limits, new_limits: &Limits) {
     use crate::memory::ic;
     let live_size = Bytes(new_limits.free as u32 - new_limits.base as u32);
@@ -108,16 +108,16 @@ pub enum Strategy {
     Full,
 }
 
-#[cfg(feature = "ic")]
+#[cfg(feature = "generational")]
 static mut OLD_GENERATION_THRESHOLD: usize = 32 * 1024 * 1024;
 
-#[cfg(feature = "ic")]
+#[cfg(feature = "generational")]
 static mut PASSED_CRITICAL_LIMIT: bool = false;
 
-#[cfg(feature = "ic")]
+#[cfg(feature = "generational")]
 const CRITICAL_MEMORY_LIMIT: usize = (4096 - 512) * 1024 * 1024;
 
-#[cfg(feature = "ic")]
+#[cfg(feature = "generational")]
 unsafe fn decide_strategy(limits: &Limits) -> Option<Strategy> {
     const YOUNG_GENERATION_THRESHOLD: usize = 8 * 1024 * 1024;
 
@@ -138,7 +138,7 @@ unsafe fn decide_strategy(limits: &Limits) -> Option<Strategy> {
     }
 }
 
-#[cfg(feature = "ic")]
+#[cfg(feature = "generational")]
 unsafe fn update_strategy(strategy: Strategy, limits: &Limits) {
     const GROWTH_RATE: f64 = 2.0;
     if strategy == Strategy::Full {

--- a/rts/motoko-rts/src/lib.rs
+++ b/rts/motoko-rts/src/lib.rs
@@ -92,7 +92,7 @@ pub(crate) unsafe fn rts_trap_with(msg: &str) -> ! {
     trap_with_prefix("RTS error: ", msg)
 }
 
-#[cfg(feature = "ic")]
+#[cfg(any(feature = "copying", feature = "compacting", feature = "incremental"))]
 #[panic_handler]
 fn panic(info: &core::panic::PanicInfo) -> ! {
     unsafe {

--- a/rts/motoko-rts/src/memory.rs
+++ b/rts/motoko-rts/src/memory.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "ic")]
+#[cfg(any(feature = "copying", feature = "compacting", feature = "incremental"))]
 pub mod ic;
 
 use crate::constants::WASM_HEAP_SIZE;

--- a/rts/motoko-rts/src/types.rs
+++ b/rts/motoko-rts/src/types.rs
@@ -19,6 +19,7 @@
 // [1]: https://github.com/rust-lang/reference/blob/master/src/types/struct.md
 // [2]: https://doc.rust-lang.org/stable/reference/type-layout.html#the-c-representation
 
+#[cfg(feature = "generational")]
 use crate::gc::generational::write_barrier::write_barrier;
 use crate::memory::Memory;
 use crate::tommath_bindings::{mp_digit, mp_int};
@@ -431,6 +432,7 @@ impl Array {
         debug_assert!(value.is_ptr());
         let slot_addr = self.element_address(idx);
         *(slot_addr as *mut Value) = value;
+        #[cfg(feature = "generational")]
         write_barrier(mem, slot_addr as u32);
     }
 

--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -660,7 +660,7 @@ let ir_passes mode prog_ir name =
 (* Compilation *)
 
 let load_as_rts () =
-  let rts = switch !Flags.sanity, !Flags.gc_strategy with
+  let rts = match !Flags.sanity, !Flags.gc_strategy with
   | true, _ -> Rts.wasm_debug
   | _, Generational -> Rts.wasm_generational
   | _, _ -> Rts.wasm (* for now *)

--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -660,7 +660,12 @@ let ir_passes mode prog_ir name =
 (* Compilation *)
 
 let load_as_rts () =
-  let rts = if !Flags.sanity then Rts.wasm_debug else Rts.wasm in
+  let rts = switch !Flags.sanity, !Flags.gc_strategy with
+  | true, _ -> Rts.wasm_debug
+  | _, Generational -> Rts.wasm_generational
+  | _, _ -> Rts.wasm (* for now *)
+
+  if !Flags.sanity then  else  in
   Wasm_exts.CustomModuleDecode.decode "rts.wasm" (Lazy.force rts)
 
 type compile_result = (Idllib.Syntax.prog * Wasm_exts.CustomModule.extended_module) Diag.result

--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -662,10 +662,8 @@ let ir_passes mode prog_ir name =
 let load_as_rts () =
   let rts = match !Flags.sanity, !Flags.gc_strategy with
   | true, _ -> Rts.wasm_debug
-  | _, Generational -> Rts.wasm_generational
-  | _, _ -> Rts.wasm (* for now *)
-
-  if !Flags.sanity then  else  in
+  | _, Mo_config.Flags.Generational -> Rts.wasm_generational
+  | _, _ -> Rts.wasm (* for now *) in
   Wasm_exts.CustomModuleDecode.decode "rts.wasm" (Lazy.force rts)
 
 type compile_result = (Idllib.Syntax.prog * Wasm_exts.CustomModule.extended_module) Diag.result

--- a/src/rts/gen.sh
+++ b/src/rts/gen.sh
@@ -12,6 +12,6 @@ if [ -z "$1" ]; then
 fi
 
 perl -0777 -ne 'print "let wasm = lazy \""; printf "\\x%02x", $_ for unpack("C*", $_); print "\"\n";' "$1/mo-rts.wasm" > "$file"
-perl -0777 -ne 'print "let wasm_generational = lazy \""; printf "\\x%02x", $_ for unpack("C*", $_); print "\"\n";' "$1/mo-rts-generational.wasm" > "$file"
+perl -0777 -ne 'print "let wasm_generational = lazy \""; printf "\\x%02x", $_ for unpack("C*", $_); print "\"\n";' "$1/mo-rts-generational.wasm" >> "$file"
 
 perl -0777 -ne 'print "let wasm_debug = lazy \""; printf "\\x%02x", $_ for unpack("C*", $_); print "\"";' "$1/mo-rts-debug.wasm" >> "$file"

--- a/src/rts/gen.sh
+++ b/src/rts/gen.sh
@@ -12,4 +12,6 @@ if [ -z "$1" ]; then
 fi
 
 perl -0777 -ne 'print "let wasm = lazy \""; printf "\\x%02x", $_ for unpack("C*", $_); print "\"\n";' "$1/mo-rts.wasm" > "$file"
+perl -0777 -ne 'print "let wasm_generational = lazy \""; printf "\\x%02x", $_ for unpack("C*", $_); print "\"\n";' "$1/mo-rts-generational.wasm" > "$file"
+
 perl -0777 -ne 'print "let wasm_debug = lazy \""; printf "\\x%02x", $_ for unpack("C*", $_); print "\"";' "$1/mo-rts-debug.wasm" >> "$file"

--- a/src/rts/rts.ml
+++ b/src/rts/rts.ml
@@ -20,5 +20,6 @@ let load_file env =
     exit 1
 
 let wasm : string Lazy.t = lazy (load_file "MOC_RTS")
+let wasm_generational : string Lazy.t = wasm
 
 let wasm_debug : string Lazy.t = lazy (load_file "MOC_DEBUG_RTS")

--- a/src/rts/rts.mli
+++ b/src/rts/rts.mli
@@ -1,2 +1,3 @@
 val wasm : string Lazy.t
+val wasm_generational : string Lazy.t
 val wasm_debug : string Lazy.t


### PR DESCRIPTION
This fixes #3795. The idea is that a selected GC strategy should only pull in RTS code for exactly that strategy, thus avoiding dead code.

