### PR TITLE
experiment: add stack probe on small allocations

### DIFF
--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -1196,7 +1196,6 @@ module Stack = struct
     else if n > 0l then begin
       (* force read of last word *)
       get_stack_ptr env ^^
-      get_stack_ptr env ^^
       G.i (Load {ty = I32Type; align = 2; offset = -4l; sz = None})
       end
     else

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -1186,12 +1186,19 @@ module Stack = struct
     set_stack_ptr env ^^
     get_stack_ptr env ^^
     (* check for stack overflow, if necessary *)
-    if n_bytes >= page_size then
+    if n_bytes >= page_size then begin
       get_stack_ptr env ^^
       G.i (Unary (Wasm.Values.I32 I32Op.Clz)) ^^
       G.if0
         G.nop (* we found leading zeros, i.e. no wraparound *)
         (stack_overflow env)
+      end
+    else if n > 0l then begin
+      (* force read of last word *)
+      get_stack_ptr env ^^
+      get_stack_ptr env ^^
+      G.i (Load {ty = I32Type; align = 2; offset = -4l; sz = None})
+      end
     else
       G.nop
 

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -1196,7 +1196,8 @@ module Stack = struct
     else if n > 0l then begin
       (* force read of last word *)
       get_stack_ptr env ^^
-      G.i (Load {ty = I32Type; align = 2; offset = -4l; sz = None})
+      G.i (Load {ty = I32Type; align = 2; offset = -4l; sz = None}) ^^
+      G.i Drop
       end
     else
       G.nop


### PR DESCRIPTION
In https://github.com/dfinity/motoko/pull/3794#discussion_r1111655007 Luc notes that relying on the access violation for small allocations only works if we are guaranteed to access the stack slot before the next allocation. Otherwise one could sneak past the guard using many little allocations.

This PR introduces a redundant read from just below the stack pointer on small allocations, to force the overflow error. I thought it would be very expensive but it doesn't seem to affect our benchmarks. Perhaps because those don't actually do very much RTS stack allocation, I expect. I think it mostly happens during deserialization.

@luc-blaeser @ggreif 

The other option is to manually specify in Stack.with_words whether to add or omit the check, e.g. `Stack.with_words (Checked|Unchecked)`, and review all call-sites to see if we can omit the check due to an imminent stack access.