### PR TITLE
(CI Test) Timer tests with slower GC

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -493,9 +493,6 @@ rec {
   in fix_names ({
       run        = test_subdir "run"        [ moc ] ;
       run-dbg    = snty_subdir "run"        [ moc ] ;
-      ic-ref-run = test_subdir "run-drun"   [ moc ic-ref-run ];
-      ic-ref-run-compacting-gc = compacting_gc_subdir "run-drun" [ moc ic-ref-run ] ;
-      ic-ref-run-generational-gc = generational_gc_subdir "run-drun" [ moc ic-ref-run ] ;
       drun       = test_subdir "run-drun"   [ moc nixpkgs.drun ];
       drun-dbg   = snty_subdir "run-drun"   [ moc nixpkgs.drun ];
       drun-compacting-gc = snty_compacting_gc_subdir "run-drun" [ moc nixpkgs.drun ] ;

--- a/rts/motoko-rts/src/gc/copying.rs
+++ b/rts/motoko-rts/src/gc/copying.rs
@@ -21,6 +21,8 @@ unsafe fn schedule_copying_gc<M: Memory>(mem: &mut M) {
 unsafe fn copying_gc<M: Memory>(mem: &mut M) {
     use crate::memory::ic;
 
+    slow_down();
+
     copying_gc_internal(
         mem,
         ic::get_heap_base(),
@@ -37,6 +39,15 @@ unsafe fn copying_gc<M: Memory>(mem: &mut M) {
     );
 
     ic::LAST_HP = ic::HP;
+}
+
+#[cfg(feature = "ic")]
+fn slow_down() {
+    let mut value = f64::MAX;
+    for _ in 0..5_000_000 {
+        value /= 2.0;
+    }
+    assert!(!value.is_nan());
 }
 
 pub unsafe fn copying_gc_internal<

--- a/rts/motoko-rts/src/gc/copying.rs
+++ b/rts/motoko-rts/src/gc/copying.rs
@@ -44,7 +44,7 @@ unsafe fn copying_gc<M: Memory>(mem: &mut M) {
 #[cfg(feature = "ic")]
 fn slow_down() {
     let mut value = f64::MAX;
-    for _ in 0..5_000_000 {
+    for _ in 0..2_000_000 {
         value /= 2.0;
     }
     assert!(!value.is_nan());


### PR DESCRIPTION
Test whether `timer.mo` and `timer-cancel.mo` occasionally fail with slower GC. Copying GC artificially slowed down.