### PR TITLE
Fix `let-else` capturing `else` block from an `if`

### DIFF
--- a/test/run/let-else-if.mo
+++ b/test/run/let-else-if.mo
@@ -6,3 +6,10 @@ func foo() {
 };
 
 foo();
+
+func bar() {
+    if false let _ = 4 else return;
+    assert false;
+};
+
+bar();


### PR DESCRIPTION
#3864

```
if false let _ = 4 else return;
assert false;
```

This snippet returns on the old version of `let` but fails on the new version.