### PR TITLE
feat: region serialization

### DIFF
--- a/rts/motoko-rts/src/idl.rs
+++ b/rts/motoko-rts/src/idl.rs
@@ -41,6 +41,7 @@ const IDL_CON_func: i32 = -22;
 const IDL_CON_service: i32 = -23;
 
 const IDL_REF_principal: i32 = -24;
+const IDL_EXT_region: i32 = -128;
 
 const IDL_CON_alias: i32 = 1;
 
@@ -51,7 +52,7 @@ pub unsafe fn leb128_decode_ptr(buf: *mut Buf) -> (u32, *mut u8) {
 }
 
 unsafe fn is_primitive_type(ty: i32) -> bool {
-    ty < 0 && (ty >= IDL_PRIM_lowest || ty == IDL_REF_principal)
+    ty < 0 && (ty >= IDL_PRIM_lowest || ty == IDL_REF_principal || ty == IDL_EXT_region)
 }
 
 // TBR; based on Text.text_compare
@@ -356,6 +357,10 @@ unsafe extern "C" fn skip_any(buf: *mut Buf, typtbl: *mut *mut u8, t: i32, depth
                 if read_byte_tag(buf) != 0 {
                     skip_blob(buf);
                 }
+            }
+            IDL_EXT_region => {
+                buf.advance(8);
+                skip_blob(buf);
             }
             _ => {
                 idl_trap_with("skip_any: unknown prim");

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -6311,12 +6311,12 @@ module MakeSerialization (Strm : Stream) = struct
           begin
           get_arg_typ ^^
           compile_eq_const (Int32.neg (Option.get (to_idl_prim (Prim Region)))) ^^
-          E.else_trap_with env "read_alias unexpected idl_typ" ^^ (* FAILS! *)
+          E.else_trap_with env "read_alias unexpected idl_typ" ^^
           Region.alloc env (compile_unboxed_const 0l) (compile_unboxed_const 0l) (Blob.lit env "") ^^ set_region ^^
           on_alloc get_region ^^
           get_region ^^ ReadBuf.read_word32 env get_data_buf ^^ Heap.store_field Region.id_field ^^
           get_region ^^ ReadBuf.read_word32 env get_data_buf ^^ Heap.store_field Region.page_count_field ^^
-          get_region ^^ (* with_blob_typ env*) (read_blob ()) ^^ Heap.store_field Region.vec_pages_field ^^
+          get_region ^^ read_blob () ^^ Heap.store_field Region.vec_pages_field ^^
           get_region ^^ Region.check_region "read_alias" env
           end
         )

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -5257,7 +5257,7 @@ module MakeSerialization (Strm : Stream) = struct
           | Func (s, c, tbs, ts1, ts2) ->
             List.iter go ts1; List.iter go ts2
           | Prim Blob -> ()
-          | Prim Region -> () (* crusso: delete me? Region is primitive*)
+          | Prim Region -> assert false (* crusso: delete me? Region is primitive*)
           | Mut t -> go t
           | _ ->
             Printf.eprintf "type_desc: unexpected type %s\n" (string_of_typ t);
@@ -5542,7 +5542,7 @@ module MakeSerialization (Strm : Stream) = struct
         E.trap_with env "buffer_size called on value of type None"
       | Prim Region ->
         size_alias (fun () ->
-          inc_data_size (compile_unboxed_const 9l) ^^ (* one byte tag + |(padded) id| + |page_count| *)
+          inc_data_size (compile_unboxed_const 8l) ^^ (* |(padded) id| + |page_count| *)
           get_x ^^ Heap.load_field Region.vec_pages_field ^^ size env (Prim Blob))
       | Mut t ->
         size_alias (fun () -> get_x ^^ Heap.load_field MutBox.field ^^ size env t)

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -6293,8 +6293,8 @@ module MakeSerialization (Strm : Stream) = struct
          read_alias env (Prim Region) (fun get_arg_typ on_alloc ->
           let (set_region, get_region) = new_local env "region" in
           get_arg_typ ^^
-          compile_eq_const (Int32.neg (Option.get (to_idl_prim t))) ^^
-          E.else_trap_with env "WTF" ^^
+          compile_eq_const (Int32.neg (Option.get (to_idl_prim (Prim Region)))) ^^
+          E.else_trap_with env "read_alias unexpected idl_typ" ^^ (* FAILS! *)
           Region.alloc env (compile_unboxed_const 0l) (compile_unboxed_const 0l) (Blob.lit env "") ^^ set_region ^^
           on_alloc get_region ^^
           get_region ^^ ReadBuf.read_word32 env get_data_buf ^^ Heap.store_field Region.id_field ^^

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -6050,6 +6050,7 @@ module MakeSerialization (Strm : Stream) = struct
             with_composite_arg_typ get_arg_typ idl_alias (ReadBuf.read_sleb128 env)
         end
         begin
+          (* sanity check *)
           get_arg_typ ^^
           compile_eq_const (Int32.neg (Option.get (to_idl_prim (Prim Region)))) ^^
           E.else_trap_with env "IDL error: unexpecting primitive alias type" ^^
@@ -6306,10 +6307,10 @@ module MakeSerialization (Strm : Stream) = struct
           )
           )
       | Prim Region ->
-         read_alias env (Prim Region) (fun get_arg_typ on_alloc ->
+         read_alias env (Prim Region) (fun get_region_typ on_alloc ->
           let (set_region, get_region) = new_local env "region" in
-          begin
-          get_arg_typ ^^
+          (* sanity check *)
+          get_region_typ ^^
           compile_eq_const (Int32.neg (Option.get (to_idl_prim (Prim Region)))) ^^
           E.else_trap_with env "read_alias unexpected idl_typ" ^^
           Region.alloc env (compile_unboxed_const 0l) (compile_unboxed_const 0l) (Blob.lit env "") ^^ set_region ^^
@@ -6318,7 +6319,6 @@ module MakeSerialization (Strm : Stream) = struct
           get_region ^^ ReadBuf.read_word32 env get_data_buf ^^ Heap.store_field Region.page_count_field ^^
           get_region ^^ read_blob () ^^ Heap.store_field Region.vec_pages_field ^^
           get_region ^^ Region.check_region "read_alias" env
-          end
         )
       | Array t ->
         let (set_len, get_len) = new_local env "len" in

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -1616,7 +1616,13 @@ module Tagged = struct
   let can_have_tag ty tag =
     let open Mo_types.Type in
     match (tag : tag) with
-    | Region -> false (* ??? *)
+    | Region ->
+      begin match normalize ty with
+      | (Con _ | Any) -> true
+      | (Prim Region) -> true
+      | (Prim _ | Obj _ | Array _ | Tup _ | Opt _ | Variant _ | Func _ | Non) -> false
+      | (Pre | Async _ | Mut _ | Var _ | Typ _) -> assert false
+      end
     | Array ->
       begin match normalize ty with
       | (Con _ | Any) -> true

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -6320,7 +6320,7 @@ module MakeSerialization (Strm : Stream) = struct
           (* sanity check *)
           get_region_typ ^^
           compile_eq_const (Int32.neg (Option.get (to_idl_prim (Prim Region)))) ^^
-          E.else_trap_with env "read_alias unexpected idl_typ" ^^
+          E.else_trap_with env "deserialize_go (Region): unexpected idl_typ" ^^
           Region.alloc env (compile_unboxed_const 0l) (compile_unboxed_const 0l) (Blob.lit env "") ^^ set_region ^^
           on_alloc get_region ^^
           get_region ^^ ReadBuf.read_word32 env get_data_buf ^^ Heap.store_field Region.id_field ^^

--- a/test/run-drun/stable-region0-danger.mo
+++ b/test/run-drun/stable-region0-danger.mo
@@ -1,0 +1,34 @@
+import P "mo:⛔";
+import Region "stable-region/Region";
+import Region0 "stable-mem/StableMemory";
+
+// test shows why we can't expose region0 without further steps to ensure
+// correct aliasing of all region0 objects, pre and post upgrade
+actor {
+
+  stable let r0 = Region0.region();
+  ignore Region.grow(r0, 1);
+
+  P.debugPrint "grow three big regions: done.";
+
+  system func preupgrade() {
+  };
+
+  public func sanityTest() {
+    let r01 = Region0.region();
+    P.debugPrint(debug_show {s0 = Region.size(r0);  s01 = Region.size(r01)});
+    assert Region.size(r0) == Region.size(r01);
+    ignore Region.grow(r0, 1);
+    P.debugPrint(debug_show {s0 = Region.size(r0);  s01 = Region.size(r01)});
+    assert Region.size(r0) == Region.size(r01);
+  };
+}
+
+//SKIP run
+//SKIP run-low
+//SKIP run-ir
+// too slow on ic-ref-run:
+//SKIP comp-ref
+//CALL ingress sanityTest "DIDL\x00\x00"
+//CALL upgrade ""
+//CALL ingress sanityTest "DIDL\x00\x00"

--- a/test/run-drun/stable-regions-one.mo
+++ b/test/run-drun/stable-regions-one.mo
@@ -5,21 +5,21 @@ import Region0 "stable-mem/StableMemory";
 actor {
   stable var r1 = Region.new();
   stable var id : Nat32 = 0xFFFF;
-  stable var size : Nat32 = 0xFFFF;
-  ignore Region.grow(r1, 8);
+  stable var size : Nat64 = 0xFFFF_FFFF;
 
   system func preupgrade() {
+    ignore Region.grow(r1, 8);
     P.debugPrint("pre");
     id := Region.id(r1);
-    size := Region.id(r1);
+    size := Region.size(r1);
     P.debugPrint(debug_show (#pre{id;size}));
   };
 
   system func postupgrade() {
+    P.debugPrint(debug_show (#post{id;size;reg_size=Region.size(r1);region_id=Region.id(r1)}));
     assert Region.size(r1) == size;
     assert Region.id(r1) == id;
     assert Region.id(Region.new()) != id;
-    P.debugPrint(debug_show (#post{id;size}));
   };
 
   public func sanityTest() {

--- a/test/run-drun/stable-regions-one.mo
+++ b/test/run-drun/stable-regions-one.mo
@@ -1,0 +1,28 @@
+import P "mo:⛔";
+import Region "stable-region/Region";
+import Region0 "stable-mem/StableMemory";
+
+actor {
+  stable var r0 = Region0.region();
+  stable var r1 = Region.new();
+
+  system func preupgrade() {
+    P.debugPrint("pre");
+  };
+
+  system func postupgrade() {
+    P.debugPrint("post");
+  };
+
+  public func sanityTest() {
+  };
+}
+
+//SKIP run
+//SKIP run-low
+//SKIP run-ir
+// too slow on ic-ref-run:
+//SKIP comp-ref
+//CALL ingress sanityTest "DIDL\x00\x00"
+//CALL upgrade ""
+//CALL ingress sanityTest "DIDL\x00\x00"

--- a/test/run-drun/stable-regions-one.mo
+++ b/test/run-drun/stable-regions-one.mo
@@ -3,15 +3,23 @@ import Region "stable-region/Region";
 import Region0 "stable-mem/StableMemory";
 
 actor {
-  stable var r0 = Region0.region();
   stable var r1 = Region.new();
+  stable var id : Nat32 = 0xFFFF;
+  stable var size : Nat32 = 0xFFFF;
+  ignore Region.grow(r1, 8);
 
   system func preupgrade() {
     P.debugPrint("pre");
+    id := Region.id(r1);
+    size := Region.id(r1);
+    P.debugPrint(debug_show (#pre{id;size}));
   };
 
   system func postupgrade() {
-    P.debugPrint("post");
+    assert Region.size(r1) == size;
+    assert Region.id(r1) == id;
+    assert Region.id(Region.new()) != id;
+    P.debugPrint(debug_show (#post{id;size}));
   };
 
   public func sanityTest() {

--- a/test/run-drun/stable-regions-one.mo
+++ b/test/run-drun/stable-regions-one.mo
@@ -4,11 +4,15 @@ import Region0 "stable-mem/StableMemory";
 
 actor {
   stable var r1 = Region.new();
+  stable var aliases = [r1, r1];
   stable var id : Nat32 = 0xFFFF;
   stable var size : Nat64 = 0xFFFF_FFFF;
 
   system func preupgrade() {
     ignore Region.grow(r1, 8);
+    assert Region.size(r1) == 8;
+    assert Region.size(r1) == Region.size(aliases[0]);
+    assert Region.size(r1) == Region.size(aliases[1]);
     P.debugPrint("pre");
     id := Region.id(r1);
     size := Region.size(r1);
@@ -20,6 +24,10 @@ actor {
     assert Region.size(r1) == size;
     assert Region.id(r1) == id;
     assert Region.id(Region.new()) != id;
+    ignore Region.grow(r1, 8);
+    assert Region.size(r1) == 16;
+    assert Region.size(r1) == Region.size(aliases[0]);
+    assert Region.size(r1) == Region.size(aliases[1]);
   };
 
   public func sanityTest() {


### PR DESCRIPTION
Tries to implement stable serialization of stateful Region objects consisting of three words
-  id: unboxed word 16 (padded to word32) (immutable)
- page_count: unboxed word 32 (mutable)
- vanilla Blob (mutable) (holding an array of allocated block ids)

These region objects are stateful descriptors of stable memory isolated regions. 

Unfortunately, the simplest example fails to upgrade properly.

```
[nix-shell:~/motoko/test/run-drun]$ more stable-regions-one.mo
import P "mo:⛔";
import Region "stable-region/Region";
import Region0 "stable-mem/StableMemory";

actor {
  stable var r0 = Region0.region();
  stable var r1 = Region.new();

  system func preupgrade() {
    P.debugPrint("pre");
  };

  system func postupgrade() {
    P.debugPrint("post");
  };

  public func sanityTest() {
  };
}

//SKIP run
//SKIP run-low
//SKIP run-ir
// too slow on ic-ref-run:
//SKIP comp-ref
//CALL ingress sanityTest "DIDL\x00\x00"
//CALL upgrade ""
//CALL ingress sanityTest "DIDL\x00\x00"
```

Produces:

```
[nix-shell:~/motoko/test/run-drun]$ ../run.sh -d stable-regions-one.mo
WARNING: Could not run ic-ref-run, will skip running some tests
stable-regions-one: [tc] [comp] [valid] [drun-run]
--- stable-regions-one.drun-run (expected)
+++ stable-regions-one.drun-run (actual)
@@ -0,0 +1,6 @@
+ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
+ingress Completed: Reply: 0x4449444c0000
+ingress Completed: Reply: 0x4449444c0000
+debug.print: pre
+ingress Err: IC0503: Canister rwlgt-iiaaa-aaaaa-aaaaa-cai trapped explicitly: read_alias unexpected idl_typ
+ingress Completed: Reply: 0x4449444c0000
Some tests failed:
stable-regions-one.mo
```
@nomeata any clue what I'm doing wrong here?