### PR TITLE
Array slicing adjustments

### DIFF
--- a/rts/motoko-rts/src/types.rs
+++ b/rts/motoko-rts/src/types.rs
@@ -791,7 +791,7 @@ impl FreeSpace {
 /// Handles both objects with header and forwarding pointer
 /// and special blocks such as `OneWordFiller`, `FwdPtr`, and `FreeSpace`
 /// that do not have a forwarding pointer.
-/// Note: Does not support array slicing, not to be called during the 
+/// Note: Does not support array slicing, not to be called during the
 /// mark phase of the compacting, generational, or incremental GC.
 pub(crate) unsafe fn block_size(address: usize) -> Words<u32> {
     let tag = *(address as *mut Tag);

--- a/rts/motoko-rts/src/types.rs
+++ b/rts/motoko-rts/src/types.rs
@@ -791,6 +791,8 @@ impl FreeSpace {
 /// Handles both objects with header and forwarding pointer
 /// and special blocks such as `OneWordFiller`, `FwdPtr`, and `FreeSpace`
 /// that do not have a forwarding pointer.
+/// Note: Does not support array slicing, not to be called during the 
+/// mark phase of the compacting, generational, or incremental GC.
 pub(crate) unsafe fn block_size(address: usize) -> Words<u32> {
     let tag = *(address as *mut Tag);
     match tag {
@@ -802,7 +804,8 @@ pub(crate) unsafe fn block_size(address: usize) -> Words<u32> {
 
         TAG_OBJ_IND => size_of::<ObjInd>(),
 
-        TAG_ARRAY | TAG_ARRAY_SLICE_MIN.. => {
+        // Array slicing is not supported in this function.
+        TAG_ARRAY => {
             let array = address as *mut Array;
             let size = array.len();
             size_of::<Array>() + Words(size)

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -5657,7 +5657,7 @@ module MakeSerialization (Strm : Stream) = struct
         G.i (Compare (Wasm.Values.I32 I32Op.Ne)) ^^
         G.i (Binary (Wasm.Values.I32 I32Op.And)) ^^
         get_temp ^^ compile_unboxed_const Tagged.(int_of_tag ArraySliceMinimum) ^^
-        G.i (Compare (Wasm.Values.I32 I32Op.GeU)) ^^ (*crusso: why signed? *)
+        G.i (Compare (Wasm.Values.I32 I32Op.GeU)) ^^
         G.i (Binary (Wasm.Values.I32 I32Op.And)) ^^
         G.if1 I32Type begin
           (compile_unboxed_const Tagged.(int_of_tag Array))

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -5657,7 +5657,7 @@ module MakeSerialization (Strm : Stream) = struct
         G.i (Compare (Wasm.Values.I32 I32Op.Ne)) ^^
         G.i (Binary (Wasm.Values.I32 I32Op.And)) ^^
         get_temp ^^ compile_unboxed_const Tagged.(int_of_tag ArraySliceMinimum) ^^
-        G.i (Compare (Wasm.Values.I32 I32Op.GeS)) ^^ (*crusso: why signed? *)
+        G.i (Compare (Wasm.Values.I32 I32Op.GeU)) ^^ (*crusso: why signed? *)
         G.i (Binary (Wasm.Values.I32 I32Op.And)) ^^
         G.if1 I32Type begin
           (compile_unboxed_const Tagged.(int_of_tag Array))
@@ -5824,12 +5824,7 @@ module MakeSerialization (Strm : Stream) = struct
           get_tag ^^ compile_eq_const Tagged.(int_of_tag ObjInd) ^^
           E.then_trap_with env "unvisited mutable data in serialize_go (ObjInd)" ^^
           get_tag ^^ compile_eq_const Tagged.(int_of_tag Array) ^^
-            E.then_trap_with env "unvisited mutable data in serialize_go (Array)" ^^
-          (if !Flags.gc_strategy = Flags.Incremental then
-            get_tag ^^ compile_unboxed_const Tagged.(int_of_tag ArraySliceMinimum) ^^
-            G.i (Compare (Wasm.Values.I32 I32Op.GeS)) ^^ (* crusso: why signed? *)
-            E.then_trap_with env "unvisited mutable data in serialize_go (ArraySliceMinimum)"
-           else G.nop) ^^
+          E.then_trap_with env "unvisited mutable data in serialize_go (Array)" ^^
           (* Second time we see this *)
           (* Calculate relative offset *)
           let set_offset, get_offset = new_local env "offset" in


### PR DESCRIPTION
Some refinements for: https://github.com/dfinity/motoko/pull/3927
* Unsigned comparison for `ArraySliceMinimum` in `clear_array_slicing`.
* Omit `ArraySlicing` sanity check in `write_alias` (since the tag already encodes a stream offset).
* `block_size()` is not intended to be called during (incremental) mark phase.