### PR TITLE
Test CI Build (Previous Nix Version)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v20
+      with:
+        install_url: https://releases.nixos.org/nix/nix-2.13.3/install
     - uses: cachix/cachix-action@v12
       if: startsWith(github.ref, 'refs/heads/')
       with:
@@ -75,6 +77,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v20
+      with:
+        install_url: https://releases.nixos.org/nix/nix-2.13.3/install
     - uses: cachix/cachix-action@v12
       with:
         name: ic-hs-test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
         # fetch PR commit, not predicted merge commit
         ref: ${{ github.event.pull_request.head.sha }}
     - uses: cachix/install-nix-action@v20
+      with:
+        install_url: https://releases.nixos.org/nix/nix-2.13.3/install
 
     # We are using the ic-hs-test cachix cache that is also used by
     # dfinity/ic-hs. This is partly laziness (on need to set up a separate
@@ -83,6 +85,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v20
+      with:
+        install_url: https://releases.nixos.org/nix/nix-2.13.3/install
     - uses: cachix/cachix-action@v12
       with:
         name: ic-hs-test

--- a/.github/workflows/update-hash.yml
+++ b/.github/workflows/update-hash.yml
@@ -18,6 +18,8 @@ jobs:
         token: ${{ secrets.NIV_UPDATER_TOKEN }}
     - uses: cachix/install-nix-action@v20
       with:
+        install_url: https://releases.nixos.org/nix/nix-2.13.3/install
+      with:
         nix_path: nixpkgs=channel:nixos-22.11
     - uses: cachix/cachix-action@v12
       with:


### PR DESCRIPTION
Explicitly set the nix version to `2.13.3` to run the CI builds and tests again.