### PR TITLE
experiment: allow non-shared `async*` types (only)

### DIFF
--- a/src/ir_def/check_ir.ml
+++ b/src/ir_def/check_ir.ml
@@ -228,7 +228,7 @@ let rec check_typ env typ : unit =
     check_typ env typ2;
     check env no_region env.flavor.Ir.has_async_typ "async in non-async flavor";
     let t' = T.promote typ2 in
-    check_shared env no_region t'
+    if s == T.Fut then check_shared env no_region t'
   | T.Obj (sort, fields) ->
     List.iter (check_typ_field env (Some sort)) fields;
     check_field_hashes env "object" no_region fields;

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -515,7 +515,7 @@ and check_typ' env typ : T.typ =
   | AsyncT (s, typ0, typ) ->
     let t0 = check_typ env typ0 in
     let t = check_typ env typ in
-    if not env.pre && not (T.shared t) then
+    if not env.pre && s = T.Fut && not (T.shared t) then
       error_shared env t typ.at
         "M0033" "async has non-shared content type%a"
         display_typ_expand t;

--- a/test/run-drun/async-star.mo
+++ b/test/run-drun/async-star.mo
@@ -1,0 +1,32 @@
+//MOC-FLAG --package base $MOTOKO_BASE
+import Debug "mo:base/Debug";
+import Array "mo:base/Array";
+
+actor a {
+
+  func expect<T>(a : () -> async* T) : async* T {
+    await* a();
+  };
+
+
+  func mapPar<A,B>(args : [A], f : A -> async* B) : async* [B] {
+     let vs = Array.init<?B>(args.size(), null);
+     for (i in args.keys()) {
+        vs[i] := ?(await* f(args[i]));
+     };
+     Array.tabulate<B>(args.size(), func i { let ?v = vs[i]; v });
+  };
+
+  public func f(a : Nat) : async Text { debug_show(a) };
+
+  public func go() : async () {
+     let x = await* expect<Nat>(func () : async* Nat {await async 1});
+     assert x == 1;
+
+     let vs = await* mapPar([0,1,2], func (a : Nat) : async* Text { await f(a) });
+
+     Debug.print(debug_show vs);
+  }
+};
+
+//CALL ingress go "DIDL\x00\x00"

--- a/test/run-drun/async-star.mo
+++ b/test/run-drun/async-star.mo
@@ -1,6 +1,4 @@
-//MOC-FLAG --package base $MOTOKO_BASE
-import Debug "mo:base/Debug";
-import Array "mo:base/Array";
+import Prim "mo:prim";
 
 actor a {
 
@@ -10,11 +8,11 @@ actor a {
 
 
   func mapPar<A,B>(args : [A], f : A -> async* B) : async* [B] {
-     let vs = Array.init<?B>(args.size(), null);
+     let vs = Prim.Array_init<?B>(args.size(), null);
      for (i in args.keys()) {
         vs[i] := ?(await* f(args[i]));
      };
-     Array.tabulate<B>(args.size(), func i { let ?v = vs[i]; v });
+     Prim.Array_tabulate<B>(args.size(), func i { let ?v = vs[i]; v });
   };
 
   public func f(a : Nat) : async Text { debug_show(a) };
@@ -25,7 +23,7 @@ actor a {
 
      let vs = await* mapPar([0,1,2], func (a : Nat) : async* Text { await f(a) });
 
-     Debug.print(debug_show vs);
+     Prim.debugPrint(debug_show vs);
   }
 };
 

--- a/test/run-drun/do-async-poly-bug.mo
+++ b/test/run-drun/do-async-poly-bug.mo
@@ -1,0 +1,22 @@
+import P "mo:prim";
+// test polymorphic async compilation
+
+// If we (in future) allow type parameters in async types, then we should enforce that  `T` in async* `T` is a manifest tuple
+// so that async arity is invariant under substition. TBR
+actor a {
+
+  private func doUnit<T>(t : T) : async* T {
+    return t;
+  };
+
+
+  private func go() : async* () {
+    let a_star = doUnit<()>(());
+    let _ = await* a_star;
+
+  }
+
+};
+
+
+//CALL ingress go "DIDL\x00\x00"

--- a/test/run-drun/do-async-poly.mo
+++ b/test/run-drun/do-async-poly.mo
@@ -1,8 +1,8 @@
 import P "mo:prim";
 // test polymorphic async compilation
-// Currently rejected because type parameters aren't shared.
+
 // If we (in future) allow type parameters in async types, then we should enforce that  `T` in async* `T` is a manifest tuple
-// so that async arity is invariant under substition.
+// so that async arity is invariant under substition. TBR
 actor a {
 
   private func doUnit<T>(t : T) : async* T {

--- a/test/run-drun/ok/async-star.drun-run.ok
+++ b/test/run-drun/ok/async-star.drun-run.ok
@@ -1,0 +1,4 @@
+ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
+ingress Completed: Reply: 0x4449444c0000
+debug.print: ["0", "1", "2"]
+ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/ok/async-star.ic-ref-run.ok
+++ b/test/run-drun/ok/async-star.ic-ref-run.ok
@@ -1,0 +1,7 @@
+=> update provisional_create_canister_with_cycles(record {settings = null; qgqjpK = null; amount = null})
+<= replied: (record {hymijyo = principal "rwlgt-iiaaa-aaaaa-aaaaa-cai"})
+=> update install_code(record {arg = blob ""; kca_xin = blob "\00asm\01\00\00\00\0...
+<= replied: ()
+=> update go()
+debug.print: ["0", "1", "2"]
+<= replied: ()

--- a/test/run-drun/ok/async-star.tc.ok
+++ b/test/run-drun/ok/async-star.tc.ok
@@ -1,4 +1,4 @@
-async-star.mo:17.50-17.52: warning [M0145], this pattern of type
-  ?B__4
+async-star.mo:15.55-15.57: warning [M0145], this pattern of type
+  ?B
 does not cover value
   null

--- a/test/run-drun/ok/async-star.tc.ok
+++ b/test/run-drun/ok/async-star.tc.ok
@@ -1,0 +1,4 @@
+async-star.mo:17.50-17.52: warning [M0145], this pattern of type
+  ?B__4
+does not cover value
+  null

--- a/test/run-drun/ok/do-async-poly.tc.ok
+++ b/test/run-drun/ok/do-async-poly.tc.ok
@@ -1,10 +1,8 @@
-do-async-poly.mo:8.42-8.43: type error [M0033], async has non-shared content type
+do-async-poly.mo:10.12-10.13: type error [M0096], expression of type
+  Null
+cannot produce expected type
   T__20
-do-async-poly.mo:13.42-13.43: type error [M0033], async has non-shared content type
-  T__21
-do-async-poly.mo:18.44-18.45: type error [M0033], async has non-shared content type
-  T__22
-do-async-poly.mo:22.42-22.43: type error [M0033], async has non-shared content type
+do-async-poly.mo:23.5-23.9: type error [M0050], literal of type
+  Null
+does not have expected type
   T__23
-do-async-poly.mo:26.43-26.44: type error [M0033], async has non-shared content type
-  T__24


### PR DESCRIPTION
So that we can write parametric abstractions, in the absence of a shared type constraint.

By popular demand. Fixes (part of) #3892.

Example:
```
import Debug "mo:base/Debug";
import Array "mo:base/Array";

actor a {

  func expect<T>(a : () -> async* T) : async* T {
    await* a();
  };


  func mapPar<A,B>(args : [A], f : A -> async* B) : async* [B] {
     let vs = Array.init<?B>(args.size(), null);
     for (i in args.keys()) {
        vs[i] := ?(await* f(args[i]));
     };
     Array.tabulate<B>(args.size(), func i { let ?v = vs[i]; v });
  };

  public func f(a : Nat) : async Text { debug_show(a) };

  public func go() : async () {
     let x = await* expect<Nat>(func () : async* Nat {await async 1});
     assert x == 1;

     let vs = await* mapPar([0,1,2], func (a : Nat) : async* Text { await f(a) });

     Debug.print(debug_show vs);
  }
};
```

Pros: just a minor tweak

Cons:
* still requires ugly eta-expansion of `shared` functions calls.
* can't just abstract over `async* T` (must be a function ` U -> async* T`) to avoid scope violations.
  (Perhaps `async* T` should be implicitly scope-polymorphic (since the computation is delayed anyway)).
* can't use implicit lambda arguments because we don't insert scope parameters for those (a separate, but annoying, issue: our sugar to do so is (syntactically) type driven, which obviously doesn't work when types are omitted.
 
TODO
- [ ] test run-drun/do-async-poly.mo needs revisiting
- [ ] actually implement `mapPar` with parallel waiting. This version ain't that.
