### PR TITLE
experiment: syntactic sugar for pipes

### DIFF
--- a/doc/md/examples/grammar.txt
+++ b/doc/md/examples/grammar.txt
@@ -184,7 +184,7 @@
     <exp_bin> 'and' <exp_bin>
     <exp_bin> 'or' <exp_bin>
     <exp_bin> ':' <typ_nobin>
-    <exp_bin> PIPE <exp_post> ('<' <list(<typ>, ',')> '>')? '(' <list(<exp>, ',')> ')'
+    <exp_bin> '|>' <exp_post> ('<' <list(<typ>, ',')> '>')? '(' <list(<exp>, ',')> ')'
 
 <exp_nondec> ::= 
     <exp_bin>

--- a/doc/md/examples/grammar.txt
+++ b/doc/md/examples/grammar.txt
@@ -184,6 +184,7 @@
     <exp_bin> 'and' <exp_bin>
     <exp_bin> 'or' <exp_bin>
     <exp_bin> ':' <typ_nobin>
+    <exp_bin> PIPE <exp_post> ('<' <list(<typ>, ',')> '>')? '(' <list(<exp>, ',')> ')'
 
 <exp_nondec> ::= 
     <exp_bin>

--- a/src/gen-grammar/grammar.sed
+++ b/src/gen-grammar/grammar.sed
@@ -72,6 +72,7 @@ s/RBRACKET/\']\'/g
 s/QUEST/\'?\'/g
 s/BANG/\'!\'/g
 s/QUERY/\'query\'/g
+s/PIPE/\'|>\'/g
 s/PUBLIC/\'public\'/g
 s/PRIVATE/\'private\'/g
 s/POWOP/\'**\'/g

--- a/src/mo_frontend/error_reporting.ml
+++ b/src/mo_frontend/error_reporting.ml
@@ -131,3 +131,4 @@ let terminal2token (type a) (symbol : a terminal) : token =
       | T_WRAPSUBASSIGN -> WRAPSUBASSIGN
       | T_WRAPMULASSIGN -> WRAPMULASSIGN
       | T_WRAPPOWASSIGN -> WRAPPOWASSIGN
+      | T_PIPE -> PIPE

--- a/src/mo_frontend/parser.mly
+++ b/src/mo_frontend/parser.mly
@@ -233,6 +233,7 @@ and objblock s dec_fields =
 %token<bool> BOOL
 %token<string> ID
 %token<string> TEXT
+%token PIPE
 %token PRIM
 %token UNDERSCORE
 
@@ -252,6 +253,7 @@ and objblock s dec_fields =
 %left XOROP
 %nonassoc SHLOP SHROP ROTLOP ROTROP
 %left POWOP WRAPPOWOP
+%left PIPE
 
 %type<Mo_def.Syntax.exp> exp(ob) exp_nullary(ob) exp_plain exp_obj exp_nest
 %type<Mo_def.Syntax.typ_item> typ_item
@@ -641,6 +643,9 @@ exp_un(B) :
     { OrE(e1, e2) @? at $sloc }
   | e=exp_bin(B) COLON t=typ_nobin
     { AnnotE(e, t) @? at $sloc }
+  | e1=exp_bin(B) PIPE f = exp_post(B) inst=inst LPAR es=seplist(exp(ob), COMMA) RPAR
+    { let e2 = match es with [] -> e1 | _ -> TupE(e1::es) @? at $sloc in
+      CallE(f, inst, e2) @? at $sloc }
 
 %public exp_nondec(B) :
   | e=exp_bin(B)

--- a/src/mo_frontend/printers.ml
+++ b/src/mo_frontend/printers.ml
@@ -138,6 +138,7 @@ let string_of_symbol = function
   | X (T T_ADDOP) -> unop "+"
   | X (T T_ACTOR) -> "actor"
   | X (T T_INVARIANT) -> "invariant"
+  | X (T T_PIPE) -> "|>"
   (* non-terminals *)
   | X (N N_bl) -> "<bl>"
   | X (N N_case) -> "<case>"

--- a/src/mo_frontend/source_lexer.mll
+++ b/src/mo_frontend/source_lexer.mll
@@ -139,6 +139,7 @@ rule token mode = parse
   | "**" { POWOP }
   | "&" { ANDOP }
   | "|" { OROP }
+  | "|>" { PIPE }
   | "^" { XOROP }
   | "<<" { SHLOP }
   | "<<>" { ROTLOP }

--- a/src/mo_frontend/source_token.ml
+++ b/src/mo_frontend/source_token.ml
@@ -125,6 +125,7 @@ type token =
   | SPACE of int
   | TAB of int (* shudders *)
   | COMMENT of string
+  | PIPE
 
 let to_parser_token :
     token -> (Parser.token, line_feed trivia) result = function
@@ -246,6 +247,7 @@ let to_parser_token :
   | PRIM -> Ok Parser.PRIM
   | UNDERSCORE -> Ok Parser.UNDERSCORE
   | INVARIANT -> Ok Parser.INVARIANT
+  | PIPE -> Ok Parser.PIPE
   (*Trivia *)
   | SINGLESPACE -> Error (Space 1)
   | SPACE n -> Error (Space n)
@@ -376,6 +378,7 @@ let string_of_parser_token = function
   | Parser.INVARIANT -> "INVARIANT"
   | Parser.IMPLIES -> "IMPLIES"
   | Parser.OLD -> "OLD"
+  | Parser.PIPE -> "PIPE"
 
 let is_lineless_trivia : token -> void trivia option = function
   | SINGLESPACE -> Some (Space 1)

--- a/test/fail/ok/syntax2.tc.ok
+++ b/test/fail/ok/syntax2.tc.ok
@@ -18,3 +18,4 @@ syntax2.mo:2.1-2.4: syntax error [M0001], unexpected token 'let', expected one o
   <unop> <exp_bin(ob)>
   <inst> <exp_nullary(ob)>
   [ <exp(ob)> ]
+  |> <exp_post(ob)> <inst> ( seplist(<exp(ob)>,,) )

--- a/test/fail/ok/syntax3.tc.ok
+++ b/test/fail/ok/syntax3.tc.ok
@@ -17,3 +17,4 @@ syntax3.mo:1.3-1.4: syntax error [M0001], unexpected token ';', expected one of 
   <unop> <exp_bin(ob)>
   <inst> <exp_nullary(ob)>
   [ <exp(ob)> ]
+  |> <exp_post(ob)> <inst> ( seplist(<exp(ob)>,,) )

--- a/test/fail/ok/syntax5.tc.ok
+++ b/test/fail/ok/syntax5.tc.ok
@@ -17,3 +17,4 @@ syntax5.mo:3.1: syntax error [M0001], unexpected end of input, expected one of t
   <unop> <exp_bin(ob)>
   <inst> <exp_nullary(ob)>
   [ <exp(ob)> ]
+  |> <exp_post(ob)> <inst> ( seplist(<exp(ob)>,,) )


### PR DESCRIPTION
Defines pipes as syntactic sugar for supplying the receiver as the first argument.

```
e |> f <inst> ()  --> f <inst> e

e |> f <inst> (e1, ...,en) --> f<inst>(e, e1, ..., en), n>=1
```

TODO:
- [ ] preserve left-to-right evaluation order by let-binding e on rhs
- [ ] actually lower precedence of `|>` (TIL lowest comes first in Menhir) to just above ':'

Caveat: argument must be a manifest tuple for this work. A type directed solution using a dedicated AST node could probably do better and allow first-class tuple arguments.

Example:
```
[nix-shell:~/motoko/src]$ rlwrap moc --package base $MOTOKO_BASE
Motoko compiler (source 0.8.7-16-gae7dd1da1-dirty)
> import C = "mo:base/Char";
let C : module {...}
> import I = "mo:base/Iter";
let I : module {...}
> import L = "mo:base/List";
let L : module {...}
> "hello".chars() |> I.map(C.toNat32) |> I.toList() |> L.reverse();
?(111, ?(108, ?(108, ?(101, ?(104, null))))) : List<Nat32>
```

The last line is equivalent to:
```
> L.reverse(I.toList(I.map("hello".chars(), C.toNat32)));
?(111, ?(108, ?(108, ?(101, ?(104, null))))) : List<Nat32>
```

