### PR TITLE
WIP: find a testcase that fails with higher-order argument passing

### DIFF
--- a/src/mo_frontend/bi_match.ml
+++ b/src/mo_frontend/bi_match.ml
@@ -67,13 +67,13 @@ let bi_match_subs scope_opt tbs subs typ_opt =
   let mentions typ ce = not (ConSet.is_empty (ConSet.inter (Type.cons typ) ce)) in
 
   let rec bi_match_list p rel eq inst any xs1 xs2 =
-    match (xs1, xs2) with
+    match xs1, xs2 with
     | x1::xs1, x2::xs2 ->
       (match p rel eq inst any x1 x2 with
-      | Some inst -> bi_match_list p rel eq inst any xs1 xs2
-      | None -> None)
+       | Some inst -> bi_match_list p rel eq inst any xs1 xs2
+       | None -> None)
     | [], [] -> Some inst
-    | _, _ -> None
+    | _ -> None
   in
 
   let update binop c t ce =
@@ -161,19 +161,18 @@ let bi_match_subs scope_opt tbs subs typ_opt =
       bi_match_list bi_match_typ rel eq inst any ts1 ts2
     | Func (s1, c1, tbs1, t11, t12), Func (s2, c2, tbs2, t21, t22) ->
       if s1 = s2 && c1 = c2 then
-      (match bi_match_binds rel eq inst any tbs1 tbs2 with
-       | Some (inst, ts) ->
-         let any' = List.fold_right
-           (fun t -> ConSet.add (fst (as_con t))) ts any
-         in
-         (match
-           bi_match_list bi_match_typ rel eq inst any' (List.map (open_ ts) t21) (List.map (open_ ts) t11)
-          with
-         | Some inst ->
-           bi_match_list bi_match_typ rel eq inst any' (List.map (open_ ts) t12) (List.map (open_ ts) t22)
-         | None -> None)
-       | None -> None
-      )
+        match bi_match_binds rel eq inst any tbs1 tbs2 with
+        | Some (inst, ts) ->
+           let any' = List.fold_right
+                        (fun t -> ConSet.add (fst (as_con t))) ts any
+           in
+           (match
+              bi_match_list bi_match_typ rel eq inst any' (List.map (open_ ts) t21) (List.map (open_ ts) t11)
+            with
+            | Some inst ->
+               bi_match_list bi_match_typ rel eq inst any' (List.map (open_ ts) t12) (List.map (open_ ts) t22)
+            | None -> None)
+        | None -> None
       else None
     | Async (s1, t11, t12), Async (s2, t21, t22) ->
       if s1 = s2 then
@@ -225,16 +224,16 @@ let bi_match_subs scope_opt tbs subs typ_opt =
         (match bi_match_typ rel eq inst any tf1.typ tf2.typ with
          | Some inst -> bi_match_tags rel eq inst any tfs1' tfs2'
          | None -> None)
-      | +1  when rel != eq->
+      | +1 when rel != eq ->
         bi_match_tags rel eq inst any tfs1 tfs2'
       | _ -> None
       )
-    | _, _ -> None
+    | _ -> None
 
   and bi_match_binds rel eq inst any tbs1 tbs2 =
     let ts = open_binds tbs2 in
     match bi_match_list (bi_match_bind ts) rel eq inst any tbs2 tbs1 with
-    | Some inst -> Some (inst,ts)
+    | Some inst -> Some (inst, ts)
     | None -> None
 
   and bi_match_bind ts rel eq inst any tb1 tb2 =

--- a/src/mo_frontend/bi_match.ml
+++ b/src/mo_frontend/bi_match.ml
@@ -128,18 +128,20 @@ let bi_match_subs scope_opt tbs subs typ_opt =
       | _ -> None
       )
     | Con (con1, ts1), t2 ->
-      (match Cons.kind con1, t2 with
-      | Def (tbs, t), _ -> (* TBR this may fail to terminate *)
-        bi_match_typ rel eq inst any (open_ ts1 t) t2
-      | Abs (tbs, t), _ when rel != eq ->
-        bi_match_typ rel eq inst any (open_ ts1 t) t2
-      | _ -> None
+      (match Cons.kind con1(*, t2*) with
+       | Def (tbs, t)(*, _*) -> (* TBR this may fail to terminate *)
+         bi_match_typ rel eq inst any (open_ ts1 t) t2
+       | Abs (tbs, t)(*, _*) when rel != eq ->
+         bi_match_typ rel eq inst any (open_ ts1 t) t2
+       | _ -> None
       )
     | t1, Con (con2, ts2) ->
       (match Cons.kind con2 with
-      | Def (tbs, t) -> (* TBR this may fail to terminate *)
-        bi_match_typ rel eq inst any t1 (open_ ts2 t)
-      | _ -> None
+       | Def (tbs, t) -> (* TBR this may fail to terminate *)
+         bi_match_typ rel eq inst any t1 (open_ ts2 t)
+       | Abs (tbs, t) when rel != eq ->
+         bi_match_typ rel eq inst any t1 (open_ ts2 t) (* Like above? ????? *)
+       | _ -> None
       )
     | Prim p1, Prim p2 when p1 = p2 ->
       Some inst

--- a/test/run/higher-order.mo
+++ b/test/run/higher-order.mo
@@ -12,4 +12,5 @@ func caller(pair : (Nat, Char), pairs : [(Int, Char)], f : (Int, Char) -> ()) {
   callee (pairs[0].0, pairs[0].1);
 };
 
-caller((42, 'H'), [(25, 'G')], callee)
+caller((42, 'H'), [(25, 'G')], callee);
+caller((42, 'H'), [(25, 'G')], func (42 or 25, 'G' or 'H') {});

--- a/test/run/higher-order.mo
+++ b/test/run/higher-order.mo
@@ -1,4 +1,5 @@
 func callee(i : Int, c : Char) {};
+func poly_callee<T <: Int>(i : T, c : Char) {};
 
 func caller(pair : (Nat, Char), pairs : [(Int, Char)], f : (Int, Char) -> ()) {
   f pair;
@@ -14,3 +15,8 @@ func caller(pair : (Nat, Char), pairs : [(Int, Char)], f : (Int, Char) -> ()) {
 
 caller((42, 'H'), [(25, 'G')], callee);
 caller((42, 'H'), [(25, 'G')], func (42 or 25, 'G' or 'H') {});
+caller((42, 'H'), [(25, 'G')], poly_callee);
+
+
+func poly_caller<A>(arg : A -> Text) {};
+poly_caller(func(_ : Int, _ : Char) : Text = "YO");

--- a/test/run/higher-order.mo
+++ b/test/run/higher-order.mo
@@ -1,0 +1,15 @@
+func callee(i : Int, c : Char) {};
+
+func caller(pair : (Nat, Char), pairs : [(Int, Char)], f : (Int, Char) -> ()) {
+  f pair;
+  f (pair.0, pair.1);
+  callee pair;
+  callee (pair.0, pair.1);
+
+  f (pairs[0]);
+  f (pairs[0].0, pairs[0].1);
+  callee (pairs[0]);
+  callee (pairs[0].0, pairs[0].1);
+};
+
+caller((42, 'H'), [(25, 'G')], callee)

--- a/test/run/higher-order.mo
+++ b/test/run/higher-order.mo
@@ -20,3 +20,4 @@ caller((42, 'H'), [(25, 'G')], poly_callee);
 
 func poly_caller<A>(arg : A -> Text) {};
 poly_caller(func(_ : Int, _ : Char) : Text = "YO");
+poly_caller(func() : Text = "YOW");

--- a/test/run/higher-order.mo
+++ b/test/run/higher-order.mo
@@ -15,7 +15,7 @@ func caller(pair : (Nat, Char), pairs : [(Int, Char)], f : (Int, Char) -> ()) {
 
 caller((42, 'H'), [(25, 'G')], callee);
 caller((42, 'H'), [(25, 'G')], func (42 or 25, 'G' or 'H') {});
-caller((42, 'H'), [(25, 'G')], poly_callee);
+//caller((42, 'H'), [(25, 'G')], poly_callee);
 
 
 func poly_caller<A>(arg : A -> Text) {};

--- a/test/run/ok/higher-order.tc.ok
+++ b/test/run/ok/higher-order.tc.ok
@@ -1,0 +1,16 @@
+higher-order.mo:17.37-17.59: warning [M0145], this pattern of type
+  (Int, Char)
+does not cover value
+  (42, '\u{00}' or '\u{01}' or _) or
+  (25, '\u{00}' or '\u{01}' or _) or
+  (0 or 1 or _, _)
+higher-order.mo:18.32-18.43: type error [M0096], expression of type
+  <T <: Int>(T, Char) -> ()
+cannot produce expected type
+  (Int, Char) -> ()
+higher-order.mo:22.1-22.51: type error [M0098], cannot implicitly instantiate function of type
+  <A>(A -> Text) -> ()
+to argument of type
+  (Int, Char) -> Text
+because no instantiation of A__10 makes
+  (Int, Char) -> Text  <:  A__10 -> Text

--- a/test/run/ok/higher-order.tc.ok
+++ b/test/run/ok/higher-order.tc.ok
@@ -4,21 +4,19 @@ does not cover value
   (42, '\u{00}' or '\u{01}' or _) or
   (25, '\u{00}' or '\u{01}' or _) or
   (0 or 1 or _, _)
-higher-order.mo:18.32-18.43: type error [M0096], expression of type
-  <T <: Int>(T, Char) -> ()
-cannot produce expected type
-  (Int, Char) -> ()
 higher-order.mo:22.1-22.51: type error [M0098], cannot implicitly instantiate function of type
   <A>(A -> Text) -> ()
 to argument of type
   (Int, Char) -> Text
 to produce result of type
   ()
-because no instantiation of A__10 makes
-  (Int, Char) -> Text  <:  A__10 -> Text
+because bug: inferred bad instantiation
+  <None>
+please report this error message and, for now, supply an explicit instantiation instead
 higher-order.mo:23.1-23.35: type error [M0098], cannot implicitly instantiate function of type
   <A>(A -> Text) -> ()
 to argument of type
   () -> Text
-because no instantiation of A__11 makes
-  () -> Text  <:  A__11 -> Text
+because bug: inferred bad instantiation
+  <None>
+please report this error message and, for now, supply an explicit instantiation instead

--- a/test/run/ok/higher-order.tc.ok
+++ b/test/run/ok/higher-order.tc.ok
@@ -12,5 +12,13 @@ higher-order.mo:22.1-22.51: type error [M0098], cannot implicitly instantiate fu
   <A>(A -> Text) -> ()
 to argument of type
   (Int, Char) -> Text
+to produce result of type
+  ()
 because no instantiation of A__10 makes
   (Int, Char) -> Text  <:  A__10 -> Text
+higher-order.mo:23.1-23.35: type error [M0098], cannot implicitly instantiate function of type
+  <A>(A -> Text) -> ()
+to argument of type
+  () -> Text
+because no instantiation of A__11 makes
+  () -> Text  <:  A__11 -> Text

--- a/test/run/ok/higher-order.tc.ret.ok
+++ b/test/run/ok/higher-order.tc.ret.ok
@@ -1,0 +1,1 @@
+Return code 1


### PR DESCRIPTION
Explore the problems described by https://dfinity.atlassian.net/browse/LANG-40

Here is another case:

``` Motoko
            func correlate(movement : Types.Movement) : (Types.Movement, ?Hash) {
                (movement, null)
            };
            ignore Array.map<Types.Movement, (Types.Movement, ?Hash)>(stmt, correlate);
```
for which I get
```
/Users/ggreif/veronica/src/backend/main.mo:519.71-519.80: type error [M0096], expression of type
  Movement -> (Movement, ?Hash__2)
cannot produce expected type
  Movement -> ((Movement, ?Hash__2))
```