### PR TITLE
Fix unaligned dereferencing issue in `rustc` upgrade

### DIFF
--- a/rts/motoko-rts-tests/Cargo.lock
+++ b/rts/motoko-rts-tests/Cargo.lock
@@ -59,12 +59,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
-name = "libm"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
-
-[[package]]
 name = "motoko-rts"
 version = "0.1.0"
 dependencies = [
@@ -100,7 +94,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]

--- a/rts/motoko-rts-tests/src/stream.rs
+++ b/rts/motoko-rts-tests/src/stream.rs
@@ -52,7 +52,10 @@ pub unsafe fn test() {
         }
     }
     let stream = alloc_stream(&mut mem, Bytes(6000));
-    (*stream).outputter = just_count;
+    assert_eq!(stream.read_ptr64(), 0);
+    assert_eq!(stream.read_start64(), 0);
+    assert_eq!(stream.read_limit64(), 0);
+    stream.write_outputter(just_count);
     let place = stream.reserve(Bytes(20));
     *place = 'a' as u8;
     *place.add(1) = 'b' as u8;

--- a/rts/motoko-rts/src/types.rs
+++ b/rts/motoko-rts/src/types.rs
@@ -550,14 +550,16 @@ impl Blob {
     }
 }
 
+// Note: The 64-bit fields must be accessed by dedicated read and write functions to avoid misaligned access errors.
+// Moreover, the latest Rust versions seems to require the function-typed field `outputter` to be 64-bit aligned too.
 #[repr(C)] // See the note at the beginning of this module
 pub struct Stream {
     pub header: Blob,
-    pub ptr64: u64,
-    pub start64: u64,
-    pub limit64: u64,
-    pub outputter: fn(*mut Self, *const u8, Bytes<u32>) -> (),
-    pub filled: Bytes<u32>, // cache data follows ..
+    pub ptr64: u64,   // Use `ptr64_read()` and `ptr64_write()` to access.
+    pub start64: u64, // Use `start64_read()` and `start64_write()` to access.
+    pub limit64: u64, // Use `limit64_read()` and `limit64_write()` to access.
+    pub outputter: fn(*mut Self, *const u8, Bytes<u32>) -> (), // Use `outputter_read()` and `outputter_write()` to access.
+    pub filled: Bytes<u32>,                                    // cache data follows ..
 }
 
 /// A forwarding pointer placed by the GC in place of an evacuated object.

--- a/test/bench/ok/heap-32.drun-run.ok
+++ b/test/bench/ok/heap-32.drun-run.ok
@@ -1,5 +1,5 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-debug.print: (50_227, +91_377_860, 1_433_598_654)
-debug.print: (50_070, +102_586_000, 1_505_530_278)
+debug.print: (50_227, +91_377_860, 1_435_279_156)
+debug.print: (50_070, +102_586_000, 1_507_362_422)
 ingress Completed: Reply: 0x4449444c0000


### PR DESCRIPTION
Analysis:
* Unaligned pointer dereferencing has undefined behavior in Rust: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
* Accessing the `64-bit` fields in `Stream` are potentially unaligned because allocation granularity is 4 byte. However, no error occurred until now.
* Accessing the function pointer `Stream.outputter` seems to assume 8-byte alignment since the last Rust compiler version (why?) and thus need to be safely accessed if unaligned.

May be a fix for `https://github.com/dfinity/motoko/pull/3947`.