### PR TITLE
fix #3993

### DIFF
--- a/src/ir_def/check_ir.ml
+++ b/src/ir_def/check_ir.ml
@@ -1017,8 +1017,8 @@ and check_pat env pat : val_env =
   | AltP (pat1, pat2) ->
     let ve1 = check_pat env pat1 in
     let ve2 = check_pat env pat2 in
-    t <: pat1.note;
-    t <: pat2.note;
+    pat1.note <: t;
+    pat2.note <: t;
     check env pat.at (T.Env.is_empty ve1 && T.Env.is_empty ve2)
       "variables are not allowed in pattern alternatives";
     T.Env.empty

--- a/test/run/or-pattern-three.mo
+++ b/test/run/or-pattern-three.mo
@@ -1,1 +1,1 @@
-func three(#a () or #b () or #c ()) {};
+func three(#a or #b or #c) {};

--- a/test/run/or-pattern-three.mo
+++ b/test/run/or-pattern-three.mo
@@ -1,0 +1,1 @@
+func three(#a () or #b () or #c ()) {};

--- a/test/run/or-pattern-three.mo
+++ b/test/run/or-pattern-three.mo
@@ -1,1 +1,2 @@
 func three(#a or #b or #c) {};
+func nums(1 or (_ : Int)) {};


### PR DESCRIPTION
Update: The IR check was correct.

--------
The subtype check for `or`-patterns was backwards.

The full pattern can have more alternatives than the individual branches, thus the `or`-pattern should be a _supertype_ of the types of the branches.

Another test case would be
``` Motoko
func nums(1 or (_ : Int)) {};
```
Which used to fail with:
```
Ill-typed intermediate code after Desugaring (use -v to see dumped IR):
or-pattern-three.mo:2.10-2.26: IR type error [M0000], subtype violation:
  Int
  Nat
```