### PR TITLE
Incremental GC Tuning: Allow collecting the allocation partition

### DIFF
--- a/rts/motoko-rts-tests/src/gc/incremental/partitioned_heap.rs
+++ b/rts/motoko-rts-tests/src/gc/incremental/partitioned_heap.rs
@@ -28,7 +28,7 @@ pub unsafe fn test() {
 }
 
 unsafe fn test_normal_size_scenario() {
-    let mut heap: PartitionedTestHeap = create_test_heap();
+    let mut heap = create_test_heap();
     let occupied_partitions = 2 + heap.heap_pointer() / PARTITION_SIZE;
     test_allocation_partitions(&heap.inner, occupied_partitions);
     test_iteration(&heap.inner, 1024);

--- a/rts/motoko-rts-tests/src/gc/incremental/partitioned_heap.rs
+++ b/rts/motoko-rts-tests/src/gc/incremental/partitioned_heap.rs
@@ -28,7 +28,7 @@ pub unsafe fn test() {
 }
 
 unsafe fn test_normal_size_scenario() {
-    let mut heap = create_test_heap();
+    let mut heap: PartitionedTestHeap = create_test_heap();
     let occupied_partitions = 2 + heap.heap_pointer() / PARTITION_SIZE;
     test_allocation_partitions(&heap.inner, occupied_partitions);
     test_iteration(&heap.inner, 1024);
@@ -115,7 +115,7 @@ unsafe fn iterate_partition(
 unsafe fn test_evacuation_plan(heap: &mut PartitionedTestHeap, occupied_partitions: usize) {
     println!("    Test evacuation plan...");
     unmark_all_objects(heap);
-    heap.inner.plan_evacuations();
+    heap.inner.plan_evacuations(&mut heap.memory);
     let mut iterator = PartitionedHeapIterator::new(&heap.inner);
     while iterator.has_partition() {
         let partition = iterator.current_partition(&heap.inner);
@@ -274,7 +274,7 @@ unsafe fn test_allocation_sizes(sizes: &[usize], number_of_partitions: usize) {
     );
     iterate_large_objects(&heap.inner, sizes);
     unmark_all_objects(&mut heap);
-    heap.inner.plan_evacuations();
+    heap.inner.plan_evacuations(&mut heap.memory);
     heap.inner.collect_large_objects();
     heap.inner.complete_collection();
     heap.inner.start_collection(&mut heap.memory, &mut time);

--- a/rts/motoko-rts/src/gc/incremental.rs
+++ b/rts/motoko-rts/src/gc/incremental.rs
@@ -256,7 +256,7 @@ impl<'a, M: Memory + 'a> IncrementalGC<'a, M> {
         debug_assert!(self.mark_completed());
         MarkIncrement::<M>::complete_phase(self.state);
         self.state.phase = Phase::Evacuate;
-        EvacuationIncrement::<M>::start_phase(self.state);
+        EvacuationIncrement::<M>::start_phase(self.mem, self.state);
     }
 
     unsafe fn evacuation_completed(&self) -> bool {

--- a/rts/motoko-rts/src/gc/incremental.rs
+++ b/rts/motoko-rts/src/gc/incremental.rs
@@ -104,8 +104,7 @@ unsafe fn record_gc_stop<M: Memory>() {
     let static_size = Bytes(ic::get_aligned_heap_base());
     debug_assert!(heap_size >= static_size);
     let dynamic_size = heap_size - static_size;
-    let live_set = dynamic_size;
-    ic::MAX_LIVE = ::core::cmp::max(ic::MAX_LIVE, live_set);
+    ic::MAX_LIVE = ::core::cmp::max(ic::MAX_LIVE, dynamic_size);
 }
 
 /// GC phases per run. Each of the following phases is performed in potentially multiple increments.

--- a/rts/motoko-rts/src/gc/incremental.rs
+++ b/rts/motoko-rts/src/gc/incremental.rs
@@ -100,15 +100,11 @@ unsafe fn record_gc_start<M: Memory>() {
 unsafe fn record_gc_stop<M: Memory>() {
     use crate::memory::ic::{self, partitioned_memory};
 
-    let current_allocations = partitioned_memory::get_total_allocations();
-    debug_assert!(current_allocations >= LAST_ALLOCATIONS);
-    let growth_during_gc = current_allocations - LAST_ALLOCATIONS;
     let heap_size = partitioned_memory::get_heap_size();
     let static_size = Bytes(ic::get_aligned_heap_base());
     debug_assert!(heap_size >= static_size);
     let dynamic_size = heap_size - static_size;
-    debug_assert!(growth_during_gc.0 <= dynamic_size.as_usize() as u64);
-    let live_set = dynamic_size - Bytes(growth_during_gc.0 as u32);
+    let live_set = dynamic_size;
     ic::MAX_LIVE = ::core::cmp::max(ic::MAX_LIVE, live_set);
 }
 

--- a/rts/motoko-rts/src/gc/incremental/partitioned_heap.rs
+++ b/rts/motoko-rts/src/gc/incremental/partitioned_heap.rs
@@ -657,7 +657,7 @@ impl PartitionedHeap {
         Value::from_ptr(heap_pointer)
     }
 
-    // GC heuristics to decide whether the new objects in the currrent allocation partition
+    // GC heuristics to decide whether the new objects in the current allocation partition
     // should be collectable by opening a new allocation partition. This is a tradeoff between
     // allocating a new partition and retaining young objects in the current GC run.
     unsafe fn should_evacuate_allocation_partition(&mut self) -> bool {

--- a/rts/motoko-rts/src/gc/incremental/phases/evacuation_increment.rs
+++ b/rts/motoko-rts/src/gc/incremental/phases/evacuation_increment.rs
@@ -17,11 +17,11 @@ pub struct EvacuationIncrement<'a, M: Memory> {
 }
 
 impl<'a, M: Memory + 'a> EvacuationIncrement<'a, M> {
-    pub unsafe fn start_phase(state: &mut State) {
+    pub unsafe fn start_phase(mem: &mut M, state: &mut State) {
         debug_assert!(state.iterator_state.is_none());
         let heap = &mut state.partitioned_heap;
         state.iterator_state = Some(PartitionedHeapIterator::new(heap));
-        heap.plan_evacuations();
+        heap.plan_evacuations(mem);
     }
 
     pub unsafe fn complete_phase(state: &mut State) {


### PR DESCRIPTION
This is another minor optimization for the incremental GC.

This GC heuristics decides whether the new objects in the current allocation partition should be collectable by opening a new allocation partition. This is a tradeoff between allocating a new partition and retaining young objects in the current GC run. 

The current configuration releases the allocation partition when it is an evacuation candidate and it is nearly full, > 95% occupied. 

This saves memory only for a specific scenario, while the average gain is very small. 

Allocated WASM memory:
Case | Unoptimized | Optimized | Saving
-----|------------|----------|-------
asset-storage | 160 MB | 96 MB | 40%
average | 298 MB | 296 MB | 0.6%

This change has no relevant impact on the runtime performance in the benchmark. 

I am not sure whether this optimization is worth it.

Tuning:
* Decreasing the occupation threshold (e.g. to 75%) only reduces memory a little bit (<1%), while increasing runtime costs.
* Too low occupation thresholds (<50%) even increase memory again because of too eager partition switches. 