### PR TITLE
experiment: attempt to fix `or`-pattern inference

### DIFF
--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -1835,8 +1835,8 @@ and infer_pat env pat : T.typ * Scope.val_env * (T.typ -> unit) =
   if not env.pre then
     pat.note <- T.normalize t;
   let widen = match pat.it with
-    | TagP (id, _) -> fun t -> if not env.pre then (Printf.printf "YEAH: %s\n" id.it; pat.note <- T.normalize t)
-    | ParP _ | AltP _ -> fun t -> (if not env.pre then (Printf.printf "ZOOM\n"; pat.note <- T.normalize t); match w with Some f -> f t | _ -> assert false)
+    | TagP (id, _) -> fun t -> if not env.pre then pat.note <- T.normalize t
+    | ParP _ | AltP _ -> fun t -> (if not env.pre then pat.note <- T.normalize t; match w with Some f -> f t | _ -> assert false)
     | _ -> fun t -> (match w with Some f -> f t | _ -> ()) in
   t, ve, widen
 
@@ -1879,7 +1879,7 @@ and infer_pat' env pat : T.typ * Scope.val_env * (T.typ -> unit) option =
     if ve1 <> T.Env.empty || ve2 <> T.Env.empty then
       error env pat.at "M0105" "variables are not allowed in pattern alternatives";
     w1 t; w2 t;
-    t, T.Env.empty, Some (fun t -> if not env.pre then Printf.printf "XXXX\n"; w1 t; w2 t)
+    t, T.Env.empty, Some (fun t -> w1 t; w2 t)
   | AnnotP (pat1, typ) ->
     let t = check_typ env typ in
     t, check_pat env t pat1, None

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -1836,7 +1836,7 @@ and infer_pat env pat : T.typ * Scope.val_env * (T.typ -> unit) =
     pat.note <- T.normalize t;
   let widen = match pat.it with
     | TagP (id, _) -> fun t -> if not env.pre then (Printf.printf "YEAH: %s\n" id.it; pat.note <- T.normalize t)
-    | AltP _ -> fun t -> (if not env.pre then (Printf.printf "ZOOM\n"; pat.note <- T.normalize t); match w with Some f -> f t | _ -> assert false)
+    | ParP _ | AltP _ -> fun t -> (if not env.pre then (Printf.printf "ZOOM\n"; pat.note <- T.normalize t); match w with Some f -> f t | _ -> assert false)
     | _ -> fun t -> (match w with Some f -> f t | _ -> ()) in
   t, ve, widen
 

--- a/test/run/pat-subtyping.mo
+++ b/test/run/pat-subtyping.mo
@@ -1,4 +1,4 @@
-func magic() : None = magic();             func three(#a or #b) {};
+func magic() : None = magic();             func three(#a or #b or #c) {};
 
 if false {
 

--- a/test/run/pat-subtyping.mo
+++ b/test/run/pat-subtyping.mo
@@ -1,4 +1,4 @@
-func magic() : None = magic();
+func magic() : None = magic();             func three(#a or #b) {};
 
 if false {
 

--- a/test/run/pat-subtyping.mo
+++ b/test/run/pat-subtyping.mo
@@ -1,4 +1,4 @@
-func magic() : None = magic();             func three(#a or #b or #c) {};
+func magic() : None = magic();             func three((#a or #b) or #c) {};
 
 if false {
 


### PR DESCRIPTION
When inferring a pattern, simultaneously return a type-setter function that `AltP` can call to propagate the supertype down into the nodes comprising it.

TODO:
- [ ] literals
- [ ] non-sum types (e.g. `(_,_) : (Nat,Int) or (_,_) : (Int,Nat)`)