### PR TITLE
chore: exercise in `nix` overlays

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,8 @@ jobs:
         nix-build --max-jobs 1 -A drun
         nix-store --gc --print-roots | grep /motoko/
 
+    - run: nix-store -q --tree $(nix-instantiate -A shell)
+
     - name: "nix-build"
       run: nix-build-uncached --max-jobs 4 -A all-systems-go -build-flags -L
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -36,9 +36,12 @@ let
            sources = import sourcesnix { sourcesFile = ./sources.json; pkgs = super; };
         })
 
-        # Selecting the ocaml version
+        # Selecting the ocaml version while disabling `jsoo` for `logs`
         # Also update ocaml-version in src/*/.ocamlformat!
-        (self: super: { ocamlPackages = self.ocaml-ng.ocamlPackages_4_12; })
+        (self: _: { ocamlPackages = self.ocaml-ng.ocamlPackages_4_12.overrideScope' (_: super: {
+                      logs = super.logs.override { jsooSupport = false; };
+                    });
+                  })
 
         (self: super: {
             # Additional ocaml package
@@ -65,12 +68,6 @@ let
 
                 meta = builtins.removeAttrs js_of_ocaml-compiler.meta [ "mainProgram" ];
               };
-
-              logs = super.ocamlPackages.logs.override { jsooSupport = false; };
-
-              utop = super.ocamlPackages.utop.overrideAttrs (_: rec {
-                propagatedBuildInputs = with super.ocamlPackages; [ findlib lambda-term zed logs ];
-              });
 
               # downgrade wasm until we have support for 2.0.0
               # (https://github.com/dfinity/motoko/pull/3364)

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -66,6 +66,10 @@ let
                 meta = builtins.removeAttrs js_of_ocaml-compiler.meta [ "mainProgram" ];
               };
 
+              logs = super.ocamlPackages.logs.overrideAttrs (_: rec {
+                jsooSupport = false;
+              });
+
               # downgrade wasm until we have support for 2.0.0
               # (https://github.com/dfinity/motoko/pull/3364)
               wasm = super.ocamlPackages.wasm.overrideAttrs (_: rec {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -66,8 +66,10 @@ let
                 meta = builtins.removeAttrs js_of_ocaml-compiler.meta [ "mainProgram" ];
               };
 
-              logs = super.ocamlPackages.logs.overrideAttrs (_: rec {
-                jsooSupport = false;
+              logs = super.ocamlPackages.logs.override { jsooSupport = false; };
+
+              utop = super.ocamlPackages.utop.overrideAttrs (_: rec {
+                propagatedBuildInputs = with super.ocamlPackages; [ findlib lambda-term zed logs ];
               });
 
               # downgrade wasm until we have support for 2.0.0


### PR DESCRIPTION
This is mostly a (learning) experiment about how to use overlays and scoped package substitutions. Actually it is not that complicated :-)

Here I customise the `logs` package globally to _not_ use `js_of_ocaml`.

But still I think that this can go in, so that we have a "tutorial" for future modifications.