### PR TITLE
GC Adjustments for Stable Regions

### DIFF
--- a/rts/motoko-rts/src/region.rs
+++ b/rts/motoko-rts/src/region.rs
@@ -35,7 +35,9 @@ pub(crate) static mut REGION_MEM_SIZE_INIT: bool = false;
 // Mirrored field from stable memory, for handling upgrade logic.
 pub(crate) static mut REGION_TOTAL_ALLOCATED_BLOCKS: u16 = 0;
 
-pub(crate) const NO_REGION: Value = Value::from_ptr(0);
+// Scalar sentinel value recognized in the GC as "no root", i.e. (!`is_ptr()`).
+// Same design like `continuation_table::TABLE`.
+pub(crate) const NO_REGION: Value = Value::from_scalar(0);
 
 // Region 0 -- classic API for stable memory, as a dedicated region.
 pub(crate) static mut REGION_0: Value = NO_REGION;

--- a/rts/motoko-rts/src/region.rs
+++ b/rts/motoko-rts/src/region.rs
@@ -34,8 +34,10 @@ pub(crate) static mut REGION_MEM_SIZE_INIT: bool = false;
 // Mirrored field from stable memory, for handling upgrade logic.
 pub(crate) static mut REGION_TOTAL_ALLOCATED_BLOCKS: u16 = 0;
 
+pub(crate) const NO_REGION: Value = Value::from_ptr(0);
+
 // Region 0 -- classic API for stable memory, as a dedicated region.
-pub(crate) static mut REGION_0: Option<Value> = None;
+pub(crate) static mut REGION_0: Value = NO_REGION;
 
 // This impl encapsulates encoding of optional region IDs within a u16.
 // Used by block-region table to encode the (optional) region ID of a block.
@@ -469,7 +471,7 @@ pub(crate) unsafe fn region_migration_from_v0_into_v2<M: Memory>(mem: &mut M) {
         let _ = crate::ic0_stable::nicer::grow(meta_data::size::STATIC_MEM_IN_PAGES as u64);
 
         // Region 0 -- classic API for stable memory, as a dedicated region.
-        REGION_0 = Some(region_new(mem));
+        REGION_0 = region_new(mem);
 
         // Regions 1 through 15, reserved for future use by future Motoko compiler-RTS features.
         region_reserve_id_span(mem, Some(RegionId(1)), RegionId(15));
@@ -553,7 +555,7 @@ pub(crate) unsafe fn region_migration_from_v1_into_v2<M: Memory>(mem: &mut M) {
         );
     }
     /* "Recover" the region data into a heap object. */
-    crate::region::REGION_0 = Some(region_recover(mem, &RegionId(0)));
+    REGION_0 = region_recover(mem, &RegionId(0));
 
     // Ensure that regions 2 through 15 are already reserved for
     // future use by future Motoko compiler-RTS features.
@@ -568,7 +570,7 @@ pub(crate) unsafe fn region_migration_from_v2_into_v2<M: Memory>(mem: &mut M) {
     if false {
         println!(80, "region_init -- recover region 0, and reserve 1--15.");
     }
-    REGION_0 = Some(region_recover(mem, &RegionId(0)));
+    REGION_0 = region_recover(mem, &RegionId(0));
 
     // Ensure that regions 2 through 15 are already reserved for
     // future use by future Motoko compiler-RTS features.

--- a/rts/motoko-rts/src/region.rs
+++ b/rts/motoko-rts/src/region.rs
@@ -1,3 +1,4 @@
+use crate::barriers::{init_with_barrier, write_with_barrier};
 use crate::memory::{alloc_blob, Memory};
 use crate::rts_trap_with;
 use crate::types::{size_of, Blob, Bytes, Region, Value, TAG_REGION};
@@ -341,7 +342,7 @@ unsafe fn alloc_region<M: Memory>(
     // The padding must be initialized with zero because it is read by the compiler-generated code.
     (*region).zero_padding = 0;
     (*region).page_count = page_count;
-    (*region).vec_pages = vec_pages;
+    init_with_barrier(mem, &mut (*region).vec_pages, vec_pages);
 
     r_ptr
 }
@@ -734,7 +735,7 @@ pub unsafe fn region_grow<M: Memory>(mem: &mut M, r: Value, new_pages: u64, max_
         println!(80, " region_grow id={} done.", (*r).id,);
     }
 
-    (*r).vec_pages = new_vec_pages;
+    write_with_barrier(mem, &mut (*r).vec_pages, new_vec_pages);
     old_page_count.into()
 }
 

--- a/rts/motoko-rts/src/region0.rs
+++ b/rts/motoko-rts/src/region0.rs
@@ -1,23 +1,24 @@
 //use crate::region::Region;
 use crate::memory::Memory;
 use crate::region::{region_grow, region_size};
-use crate::types::{Blob, Value};
+use crate::types::Value;
+use core::ptr::null_mut;
 
 use motoko_rts_macros::ic_mem_fn;
 
 unsafe fn region0_load<M: Memory>(mem: &mut M, offset: u64, dst: &mut [u8]) {
-    let r = crate::region::REGION_0;
+    let r = crate::region::REGION_0.unwrap();
     crate::region::region_load(mem, r, offset, dst)
 }
 
 unsafe fn region0_store<M: Memory>(mem: &mut M, offset: u64, src: &[u8]) {
-    let r = crate::region::REGION_0;
+    let r = crate::region::REGION_0.unwrap();
     crate::region::region_store(mem, r, offset, src)
 }
 
 #[ic_mem_fn]
 pub unsafe fn region0_get<M: Memory>(_mem: &mut M) -> Value {
-    let v = crate::region::REGION_0;
+    let v = crate::region::REGION_0.unwrap();
     if false {
         println!(80, "region0_get() ~> {:?}", v);
     }
@@ -28,17 +29,20 @@ pub unsafe fn region0_get<M: Memory>(_mem: &mut M) -> Value {
 #[allow(dead_code)]
 #[cfg(feature = "ic")]
 pub(crate) unsafe fn region0_get_ptr_loc() -> *mut Value {
-    &mut crate::region::REGION_0
+    match &mut crate::region::REGION_0 {
+        None => null_mut::<Value>(),
+        Some(region0) => region0,
+    }
 }
 
 #[ic_mem_fn]
 pub unsafe fn region0_size<M: Memory>(mem: &mut M) -> u64 {
-    region_size(mem, crate::region::REGION_0)
+    region_size(mem, crate::region::REGION_0.unwrap())
 }
 
 #[ic_mem_fn]
 pub unsafe fn region0_grow<M: Memory>(mem: &mut M, new_pages: u64, max_pages: u64) -> u64 {
-    region_grow(mem, crate::region::REGION_0, new_pages, max_pages)
+    region_grow(mem, crate::region::REGION_0.unwrap(), new_pages, max_pages)
 }
 
 // -- Region0 load operations.
@@ -108,7 +112,7 @@ pub unsafe fn region0_store_float64<M: Memory>(mem: &mut M, offset: u64, val: f6
 
 #[ic_mem_fn]
 pub unsafe fn region0_store_blob<M: Memory>(mem: &mut M, offset: u64, blob: Value) {
-    let blob: *const Blob = blob.as_blob();
+    let blob = blob.as_blob();
     let len = blob.len();
     let bytes = blob.payload_const();
     let bytes: &[u8] = core::slice::from_raw_parts(bytes, len.0 as usize);

--- a/rts/motoko-rts/src/region0.rs
+++ b/rts/motoko-rts/src/region0.rs
@@ -1,24 +1,24 @@
 //use crate::region::Region;
 use crate::memory::Memory;
-use crate::region::{region_grow, region_size};
+use crate::region::{region_grow, region_size, NO_REGION, REGION_0};
 use crate::types::Value;
-use core::ptr::null_mut;
 
 use motoko_rts_macros::ic_mem_fn;
 
 unsafe fn region0_load<M: Memory>(mem: &mut M, offset: u64, dst: &mut [u8]) {
-    let r = crate::region::REGION_0.unwrap();
-    crate::region::region_load(mem, r, offset, dst)
+    assert_ne!(REGION_0, NO_REGION);
+    crate::region::region_load(mem, REGION_0, offset, dst)
 }
 
 unsafe fn region0_store<M: Memory>(mem: &mut M, offset: u64, src: &[u8]) {
-    let r = crate::region::REGION_0.unwrap();
-    crate::region::region_store(mem, r, offset, src)
+    assert_ne!(REGION_0, NO_REGION);
+    crate::region::region_store(mem, REGION_0, offset, src)
 }
 
 #[ic_mem_fn]
 pub unsafe fn region0_get<M: Memory>(_mem: &mut M) -> Value {
-    let v = crate::region::REGION_0.unwrap();
+    assert_ne!(REGION_0, NO_REGION);
+    let v = REGION_0;
     if false {
         println!(80, "region0_get() ~> {:?}", v);
     }
@@ -29,20 +29,19 @@ pub unsafe fn region0_get<M: Memory>(_mem: &mut M) -> Value {
 #[allow(dead_code)]
 #[cfg(feature = "ic")]
 pub(crate) unsafe fn region0_get_ptr_loc() -> *mut Value {
-    match &mut crate::region::REGION_0 {
-        None => null_mut::<Value>(),
-        Some(region0) => region0,
-    }
+    &mut REGION_0
 }
 
 #[ic_mem_fn]
 pub unsafe fn region0_size<M: Memory>(mem: &mut M) -> u64 {
-    region_size(mem, crate::region::REGION_0.unwrap())
+    assert_ne!(REGION_0, NO_REGION);
+    region_size(mem, REGION_0)
 }
 
 #[ic_mem_fn]
 pub unsafe fn region0_grow<M: Memory>(mem: &mut M, new_pages: u64, max_pages: u64) -> u64 {
-    region_grow(mem, crate::region::REGION_0.unwrap(), new_pages, max_pages)
+    assert_ne!(REGION_0, NO_REGION);
+    region_grow(mem, REGION_0, new_pages, max_pages)
 }
 
 // -- Region0 load operations.

--- a/rts/motoko-rts/src/types.rs
+++ b/rts/motoko-rts/src/types.rs
@@ -348,11 +348,12 @@ impl Value {
         self.forward().get_ptr() as *mut Array
     }
 
-    /// Get the pointer as `Region`. In debug mode panics if the value is not a pointer or the
+    /// Get the pointer as `Region` using forwarding. In debug mode panics if the value is not a pointer or the
     /// pointed object is not an `Region`.
     pub unsafe fn as_region(self) -> *mut Region {
         debug_assert_eq!(self.tag(), TAG_REGION);
-        self.get_ptr() as *mut Region
+        self.check_forwarding_pointer();
+        self.forward().get_ptr() as *mut Region
     }
 
     /// Get the pointer as `Concat` using forwarding. In debug mode panics if the value is not a pointer or the
@@ -572,7 +573,8 @@ impl Array {
 pub struct Region {
     pub header: Obj,
     pub id: u16,
-    pub padding: u16,
+    // Note: Must initialize this part as it is read by the compiler-generated code.
+    pub zero_padding: u16, 
     pub page_count: u32,
     pub vec_pages: Value, // Blob of u16's (each a page block ID).
 }


### PR DESCRIPTION
Some GC- and memory-specific adjustments for stable memory regions:
* Using the forwarding pointer of the incremental GC in the compiler and runtime system.
* Checking whether `region0` is defined before access (since dereferencing address 0 would not trap in release mode).
* Initializing the 16-bit `padding` field in the region as it is read by the compiler-generated code.
* Applying write barriers when assigning `Region.vec_pages`.