### PR TITLE
experiment: remove Debug traits from region rts to reduce rts size

### DIFF
--- a/rts/motoko-rts/src/gc/generational.rs
+++ b/rts/motoko-rts/src/gc/generational.rs
@@ -105,7 +105,7 @@ unsafe fn update_statistics(old_limits: &Limits, new_limits: &Limits) {
     linear_memory::RECLAIMED += Bytes(old_limits.free as u64 - new_limits.free as u64);
 }
 
-#[derive(PartialEq, Clone, Copy, Debug)]
+#[derive(PartialEq, Clone, Copy)]
 pub enum Strategy {
     Young,
     Full,

--- a/rts/motoko-rts/src/region.rs
+++ b/rts/motoko-rts/src/region.rs
@@ -5,13 +5,13 @@ use crate::types::{size_of, Blob, Bytes, Region, Value, TAG_REGION};
 
 use motoko_rts_macros::ic_mem_fn;
 
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct BlockId(pub u16);
 
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct RegionId(pub u16);
 
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct RegionSizeInPages(pub u64);
 
 // Note: Use this type only in local variables, as it contains raw pointers
@@ -380,7 +380,7 @@ pub unsafe fn region_set_mem_size<M: Memory>(_mem: &mut M, size: u64) {
 unsafe fn region_reserve_id_span<M: Memory>(_mem: &mut M, first: Option<RegionId>, last: RegionId) {
     if let Some(first) = first {
         let next_id = meta_data::total_allocated_regions::get() as u16;
-        assert_eq!(first.0, next_id);
+        assert!(first.0 == next_id);
         assert!(first.0 <= last.0);
         meta_data::total_allocated_regions::set((last.0 + 1) as u64);
     } else {
@@ -402,7 +402,7 @@ pub unsafe fn region_new<M: Memory>(mem: &mut M) -> Value {
         let r_id = RegionId::from_id(next_id);
         let c = meta_data::region_table::get(&r_id);
         // sanity check: Region table says that this region is available.
-        assert_eq!(c, None);
+        assert!(c == None);
         meta_data::region_table::set(&r_id, Some(RegionSizeInPages(0)));
     }
     r_ptr
@@ -437,7 +437,7 @@ pub unsafe fn region_recover<M: Memory>(mem: &mut M, rid: &RegionId) -> Value {
             }
         }
     }
-    assert_eq!(recovered_blocks, block_count);
+    assert!(recovered_blocks == block_count);
     r_ptr
 }
 
@@ -559,7 +559,7 @@ pub(crate) unsafe fn region_migration_from_v2_into_v2<M: Memory>(mem: &mut M) {
 #[ic_mem_fn]
 pub(crate) unsafe fn region_init<M: Memory>(mem: &mut M, from_version: i32) {
     // Recall that we've done this later, without asking ic0_stable::size.
-    assert_eq!(crate::region::REGION_MEM_SIZE_INIT, false);
+    assert!(crate::region::REGION_MEM_SIZE_INIT == false);
     crate::region::REGION_MEM_SIZE_INIT = true;
 
     match from_version {
@@ -618,7 +618,7 @@ pub unsafe fn region_grow<M: Memory>(mem: &mut M, r: Value, new_pages: u64, max_
         let c = meta_data::region_table::get(&r_id);
 
         // Region table agrees with heap object's field.
-        assert_eq!(c, Some(RegionSizeInPages(old_page_count.into())));
+        assert!(c == Some(RegionSizeInPages(old_page_count.into())));
 
         // Increase both:
         (*r).page_count += new_pages_;

--- a/test/bench/ok/heap-32.drun-run-opt.ok
+++ b/test/bench/ok/heap-32.drun-run-opt.ok
@@ -1,5 +1,5 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-debug.print: (50_227, +30_261_252, 620_394_274)
-debug.print: (50_070, +32_992_212, 671_304_501)
+debug.print: (50_227, +30_261_252, 620_394_300)
+debug.print: (50_070, +32_992_212, 671_304_566)
 ingress Completed: Reply: 0x4449444c0000

--- a/test/bench/ok/heap-32.drun-run.ok
+++ b/test/bench/ok/heap-32.drun-run.ok
@@ -1,5 +1,5 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-debug.print: (50_227, +30_261_252, 667_797_438)
-debug.print: (50_070, +32_992_212, 720_521_385)
+debug.print: (50_227, +30_261_252, 667_797_488)
+debug.print: (50_070, +32_992_212, 720_521_510)
 ingress Completed: Reply: 0x4449444c0000


### PR DESCRIPTION
Remove Debug traits from RTS, replacing handfull of assert_eq! by assert!.
```
< -rwxr-xr-x 1 crusso crusso 2717540 Jul 20 14:55 mo-rts-debug.wasm
< -rwxr-xr-x 1 crusso crusso 2885372 Jul 20 14:55 mo-rts-incremental-debug.wasm
< -rwxr-xr-x 1 crusso crusso  165883 Jul 20 14:55 mo-rts-incremental.wasm
< -rwxr-xr-x 1 crusso crusso  163350 Jul 20 14:54 mo-rts.wasm
---
> -rwxr-xr-x 1 crusso crusso 2698430 Jul 20 16:05 mo-rts-debug.wasm
> -rwxr-xr-x 1 crusso crusso 2866281 Jul 20 16:05 mo-rts-incremental-debug.wasm
> -rwxr-xr-x 1 crusso crusso  163155 Jul 20 16:05 mo-rts-incremental.wasm
> -rwxr-xr-x 1 crusso crusso  160804 Jul 20 16:05 mo-rts.wasm
```

Perhaps not worth the effort.