### PR TITLE
More Conservative Incremental GC Scheduling

### DIFF
--- a/rts/motoko-rts/src/gc/incremental.rs
+++ b/rts/motoko-rts/src/gc/incremental.rs
@@ -77,12 +77,12 @@ unsafe fn should_start() -> bool {
         return false;
     }
 
-    const ABSOLUT_GROWTH_THRESHOLD: Bytes<u64> = Bytes(512 * 1024 * 1024);
+    const ABSOLUTE_GROWTH_THRESHOLD: Bytes<u64> = Bytes(512 * 1024 * 1024);
 
     let current_allocations = partitioned_memory::get_total_allocations();
     debug_assert!(current_allocations >= LAST_ALLOCATIONS);
     let absolute_growth = current_allocations - LAST_ALLOCATIONS;
-    if absolute_growth > ABSOLUT_GROWTH_THRESHOLD {
+    if absolute_growth > ABSOLUTE_GROWTH_THRESHOLD {
         return true;
     }
 

--- a/rts/motoko-rts/src/gc/incremental.rs
+++ b/rts/motoko-rts/src/gc/incremental.rs
@@ -134,7 +134,7 @@ unsafe fn record_gc_stop<M: Memory>() {
 /// The limit on the GC increment has a fix base with a linear increase depending on the number of
 /// allocations that were performed during a running GC. The allocation-proportional term adapts
 /// to the allocation rate and helps the GC to reduce reclamation latency.
-const INCREMENT_BASE_LIMIT: usize = 7_000_000; // Increment limit without concurrent allocations.
+const INCREMENT_BASE_LIMIT: usize = 5_000_000; // Increment limit without concurrent allocations.
 const INCREMENT_ALLOCATION_FACTOR: usize = 10; // Additional time factor per concurrent allocation.
 
 // Performance note: Storing the phase-specific state in the enum would be nicer but it is much slower.

--- a/rts/motoko-rts/src/gc/incremental.rs
+++ b/rts/motoko-rts/src/gc/incremental.rs
@@ -134,7 +134,7 @@ unsafe fn record_gc_stop<M: Memory>() {
 /// The limit on the GC increment has a fix base with a linear increase depending on the number of
 /// allocations that were performed during a running GC. The allocation-proportional term adapts
 /// to the allocation rate and helps the GC to reduce reclamation latency.
-const INCREMENT_BASE_LIMIT: usize = 5_000_000; // Increment limit without concurrent allocations.
+const INCREMENT_BASE_LIMIT: usize = 3_500_000; // Increment limit without concurrent allocations.
 const INCREMENT_ALLOCATION_FACTOR: usize = 10; // Additional time factor per concurrent allocation.
 
 // Performance note: Storing the phase-specific state in the enum would be nicer but it is much slower.


### PR DESCRIPTION
# More Conservative Incremental GC Scheduling

The existing incremental GC scheduling is reclaiming memory effectively up to 4GB according to the tests, the GC benchmark, and also other analyzed user programs so far.
However, it could also make sense, to schedule the GC a little bit more conservatively to reduce the allocated memory size, the reclamation latency, and the memory pressure. 

## Scheduling Refinement
The GC is **additionally** scheduled on every absolute heap growth of 500 MB or more.

## GC benchmark results:

Aspect | Difference
-------- | ----------
Runtime | (none)
Allocated Memory | -6%
Scalability | +28% (*)

(*) The scalability improvement is mostly due to the `scalable-buffer` benchmark case that scales much higher with this more conservative scheduling. For other cases, the scalability is slightly lower. This heavily depends on when GC is scheduled when the memory is nearly full and the mark bitmaps may no longer be allocated.