### PR TITLE
regions: reduce metadata overhead of code using Regions before ESM from 8MB to 1MB (16 pages)

### DIFF
--- a/rts/motoko-rts/src/region.rs
+++ b/rts/motoko-rts/src/region.rs
@@ -245,14 +245,14 @@ mod meta_data {
         pub const BLOCK_IN_BYTES: u64 = PAGE_IN_BYTES * (PAGES_IN_BLOCK as u64);
 
         // Static memory footprint, ignoring any dynamically-allocated pages.
-        pub unsafe fn STATIC_MEM_IN_PAGES(block_base: u64) -> u64 {
+        pub unsafe fn static_mem_in_pages(block_base: u64) -> u64 {
             debug_assert!(block_base % PAGE_IN_BYTES as u64 == 0);
             debug_assert!(block_base != 0);
             block_base / PAGE_IN_BYTES as u64 /* meta data plus slack for future use */
         }
 
         pub unsafe fn total_required_pages(block_base: u64, total_allocated_blocks: u64) -> u64 {
-            STATIC_MEM_IN_PAGES(block_base) + (total_allocated_blocks * (PAGES_IN_BLOCK as u64))
+            static_mem_in_pages(block_base) + (total_allocated_blocks * (PAGES_IN_BLOCK as u64))
         }
     }
 

--- a/test/bench/ok/heap-32.drun-run-opt.ok
+++ b/test/bench/ok/heap-32.drun-run-opt.ok
@@ -1,5 +1,5 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-debug.print: (50_227, +30_261_252, 620_394_326)
-debug.print: (50_070, +32_992_212, 671_304_540)
+debug.print: (50_227, +30_261_252, 620_394_287)
+debug.print: (50_070, +32_992_212, 671_304_488)
 ingress Completed: Reply: 0x4449444c0000

--- a/test/bench/ok/heap-32.drun-run.ok
+++ b/test/bench/ok/heap-32.drun-run.ok
@@ -1,5 +1,5 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-debug.print: (50_227, +30_261_252, 667_797_538)
-debug.print: (50_070, +32_992_212, 720_521_460)
+debug.print: (50_227, +30_261_252, 667_797_463)
+debug.print: (50_070, +32_992_212, 720_521_360)
 ingress Completed: Reply: 0x4449444c0000

--- a/test/bench/ok/region-mem.drun-run-opt.ok
+++ b/test/bench/ok/region-mem.drun-run-opt.ok
@@ -1,4 +1,4 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-debug.print: {heap_diff = 0; instr_diff = 5_070_913_820}
+debug.print: {heap_diff = 0; instr_diff = 5_096_079_644}
 ingress Completed: Reply: 0x4449444c0000

--- a/test/bench/ok/region-mem.drun-run.ok
+++ b/test/bench/ok/region-mem.drun-run.ok
@@ -1,4 +1,4 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-debug.print: {heap_diff = 0; instr_diff = 5_322_572_082}
+debug.print: {heap_diff = 0; instr_diff = 5_398_069_554}
 ingress Completed: Reply: 0x4449444c0000

--- a/test/bench/ok/region0-mem.drun-run-opt.ok
+++ b/test/bench/ok/region0-mem.drun-run-opt.ok
@@ -1,4 +1,4 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-debug.print: {heap_diff = 0; instr_diff = 5_196_742_940}
+debug.print: {heap_diff = 0; instr_diff = 5_221_908_764}
 ingress Completed: Reply: 0x4449444c0000

--- a/test/bench/ok/region0-mem.drun-run.ok
+++ b/test/bench/ok/region0-mem.drun-run.ok
@@ -1,4 +1,4 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-debug.print: {heap_diff = 0; instr_diff = 5_561_647_410}
+debug.print: {heap_diff = 0; instr_diff = 5_637_144_882}
 ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/ok/region0-rts-stats.drun-run.ok
+++ b/test/run-drun/ok/region0-rts-stats.drun-run.ok
@@ -1,10 +1,10 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 debug.print: {l1 = 6; s1 = 6}
-debug.print: {l2 = 256; s2 = 256}
+debug.print: {l2 = 144; s2 = 144}
 ingress Completed: Reply: 0x4449444c0000
-debug.print: {l1 = 256; s1 = 258}
+debug.print: {l1 = 144; s1 = 146}
 ingress Err: IC0503: Canister rwlgt-iiaaa-aaaaa-aaaaa-cai trapped explicitly: pattern failed
-debug.print: {l1 = 256; s1 = 258}
+debug.print: {l1 = 144; s1 = 146}
 ingress Err: IC0503: Canister rwlgt-iiaaa-aaaaa-aaaaa-cai trapped explicitly: pattern failed
-debug.print: {l1 = 256; s1 = 258}
+debug.print: {l1 = 144; s1 = 146}
 ingress Err: IC0503: Canister rwlgt-iiaaa-aaaaa-aaaaa-cai trapped explicitly: pattern failed

--- a/test/run-drun/ok/regions-base-high.drun-run.ok
+++ b/test/run-drun/ok/regions-base-high.drun-run.ok
@@ -1,0 +1,21 @@
+ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
+debug.print: =============
+debug.print: do nothing
+debug.print: {l1 = 0; s1 = 0}
+debug.print: SM.grow(1)
+debug.print: {l2 = 1; s2 = 1}
+debug.print: let r1=Region.new()
+debug.print: {l3 = 256; r1 = 16; s3 = 256}
+debug.print: let _ = Region.grow(r1,1)
+debug.print: {l4 = 384; r1 = 16; s4 = 384}
+ingress Completed: Reply: 0x4449444c0000
+debug.print: =============
+debug.print: do nothing
+debug.print: {l1 = 384; s1 = 385}
+debug.print: SM.grow(1)
+debug.print: {l2 = 384; s2 = 385}
+debug.print: let r1=Region.new()
+debug.print: {l3 = 384; r1 = 16; s3 = 385}
+debug.print: let _ = Region.grow(r1,1)
+debug.print: {l4 = 384; r1 = 16; s4 = 385}
+ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/ok/regions-base-low.drun-run.ok
+++ b/test/run-drun/ok/regions-base-low.drun-run.ok
@@ -1,0 +1,21 @@
+ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
+debug.print: =============
+debug.print: do nothing
+debug.print: {l1 = 0; s1 = 0}
+debug.print: SM.grow(0)
+debug.print: {l2 = 0; s2 = 0}
+debug.print: let r1=Region.new()
+debug.print: {l3 = 6; r1 = 16; s3 = 6}
+debug.print: let _ = Region.grow(r1,1)
+debug.print: {l4 = 144; r1 = 16; s4 = 144}
+ingress Completed: Reply: 0x4449444c0000
+debug.print: =============
+debug.print: do nothing
+debug.print: {l1 = 144; s1 = 145}
+debug.print: SM.grow(0)
+debug.print: {l2 = 144; s2 = 145}
+debug.print: let r1=Region.new()
+debug.print: {l3 = 144; r1 = 16; s3 = 145}
+debug.print: let _ = Region.grow(r1,1)
+debug.print: {l4 = 144; r1 = 16; s4 = 145}
+ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/ok/regions-pay-as-you-go.drun-run.ok
+++ b/test/run-drun/ok/regions-pay-as-you-go.drun-run.ok
@@ -3,39 +3,39 @@ debug.print: =============
 debug.print: do nothing
 debug.print: {l1 = 6; s1 = 6}
 debug.print: SM.grow(16)
-debug.print: {l2 = 256; s2 = 256}
+debug.print: {l2 = 144; s2 = 144}
 debug.print: Region.new()
-debug.print: {l3 = 256; r1 = 16; s3 = 256}
+debug.print: {l3 = 144; r1 = 16; s3 = 144}
 debug.print: Region.new()
-debug.print: {l4 = 256; r1 = 16; r2 = 17; s4 = 256}
+debug.print: {l4 = 144; r1 = 16; r2 = 17; s4 = 144}
 ingress Completed: Reply: 0x4449444c0000
 debug.print: =============
 debug.print: do nothing
-debug.print: {l1 = 256; s1 = 257}
+debug.print: {l1 = 144; s1 = 145}
 debug.print: SM.grow(16)
-debug.print: {l2 = 256; s2 = 257}
+debug.print: {l2 = 144; s2 = 145}
 debug.print: Region.new()
-debug.print: {l3 = 256; r1 = 18; s3 = 257}
+debug.print: {l3 = 144; r1 = 18; s3 = 145}
 debug.print: Region.new()
-debug.print: {l4 = 256; r1 = 18; r2 = 17; s4 = 257}
+debug.print: {l4 = 144; r1 = 18; r2 = 17; s4 = 145}
 ingress Completed: Reply: 0x4449444c0000
 debug.print: =============
 debug.print: do nothing
-debug.print: {l1 = 256; s1 = 257}
+debug.print: {l1 = 144; s1 = 145}
 debug.print: SM.grow(16)
-debug.print: {l2 = 256; s2 = 257}
+debug.print: {l2 = 144; s2 = 145}
 debug.print: Region.new()
-debug.print: {l3 = 256; r1 = 19; s3 = 257}
+debug.print: {l3 = 144; r1 = 19; s3 = 145}
 debug.print: Region.new()
-debug.print: {l4 = 256; r1 = 19; r2 = 17; s4 = 257}
+debug.print: {l4 = 144; r1 = 19; r2 = 17; s4 = 145}
 ingress Completed: Reply: 0x4449444c0000
 debug.print: =============
 debug.print: do nothing
-debug.print: {l1 = 256; s1 = 257}
+debug.print: {l1 = 144; s1 = 145}
 debug.print: SM.grow(16)
-debug.print: {l2 = 256; s2 = 257}
+debug.print: {l2 = 144; s2 = 145}
 debug.print: Region.new()
-debug.print: {l3 = 256; r1 = 20; s3 = 257}
+debug.print: {l3 = 144; r1 = 20; s3 = 145}
 debug.print: Region.new()
-debug.print: {l4 = 256; r1 = 20; r2 = 17; s4 = 257}
+debug.print: {l4 = 144; r1 = 20; r2 = 17; s4 = 145}
 ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/regions-base-high.mo
+++ b/test/run-drun/regions-base-high.mo
@@ -1,0 +1,32 @@
+import P "mo:⛔";
+import StableMemory "stable-mem/StableMemory";
+import Region "stable-region/Region";
+actor {
+  P.debugPrint("=============");
+  P.debugPrint ("do nothing");
+  let s1 = P.rts_stable_memory_size();
+  let l1 = P.rts_logical_stable_memory_size();
+  P.debugPrint (debug_show({s1;l1}));
+  P.debugPrint ("SM.grow(1)");
+  let _ = StableMemory.grow(1);
+  let s2 = P.rts_stable_memory_size();
+  let l2 = P.rts_logical_stable_memory_size();
+  P.debugPrint (debug_show({s2;l2}));
+  P.debugPrint ("let r1=Region.new()");
+  stable let r1 = Region.new();
+  let s3 = P.rts_stable_memory_size();
+  let l3 = P.rts_logical_stable_memory_size();
+  P.debugPrint (debug_show({s3;l3;r1 = Region.id(r1)}));
+  P.debugPrint ("let _ = Region.grow(r1,1)");
+  let _ = Region.grow(r1, 1);
+  let s4 = P.rts_stable_memory_size();
+  let l4 = P.rts_logical_stable_memory_size();
+  P.debugPrint (debug_show({s4;l4;r1 = Region.id(r1)}));
+}
+
+//SKIP run
+//SKIP run-low
+//SKIP run-ir
+// too slow on ic-ref-run:
+//SKIP comp-ref
+//CALL upgrade ""

--- a/test/run-drun/regions-base-low.mo
+++ b/test/run-drun/regions-base-low.mo
@@ -1,0 +1,33 @@
+import P "mo:⛔";
+import StableMemory "stable-mem/StableMemory";
+import Region "stable-region/Region";
+actor {
+  P.debugPrint("=============");
+  P.debugPrint ("do nothing");
+  let s1 = P.rts_stable_memory_size();
+  let l1 = P.rts_logical_stable_memory_size();
+  P.debugPrint (debug_show({s1;l1}));
+  P.debugPrint ("SM.grow(0)");
+  let _ = StableMemory.grow(0);
+  let s2 = P.rts_stable_memory_size();
+  let l2 = P.rts_logical_stable_memory_size();
+  P.debugPrint (debug_show({s2;l2}));
+  P.debugPrint ("let r1=Region.new()");
+  stable let r1 = Region.new();
+  let s3 = P.rts_stable_memory_size();
+  let l3 = P.rts_logical_stable_memory_size();
+  P.debugPrint (debug_show({s3;l3;r1 = Region.id(r1)}));
+  P.debugPrint ("let _ = Region.grow(r1,1)");
+  let _ = Region.grow(r1, 1);
+  let s4 = P.rts_stable_memory_size();
+  let l4 = P.rts_logical_stable_memory_size();
+  P.debugPrint (debug_show({s4;l4;r1 = Region.id(r1)}));
+}
+
+//SKIP run
+//SKIP run-low
+//SKIP run-ir
+// too slow on ic-ref-run:
+//SKIP comp-ref
+//CALL upgrade ""
+


### PR DESCRIPTION
In the current design, the first 8MB block of IC stable memory is largely unused to accommodate migration from users of legacy Experimental Stable Memory (migration from ESM moves just the first block of ESM to a higher block to make way for Regions metadata (6 pages), while keeping the other blocks of ESM in-place, requiring blocks to be aligned at 8MB offsets).

This means that code that only uses Regions (or uses them first before using ESM) unnecessarily  wastes the first 8MB block of IC  stable memory instead of just 6 pages.

This PR dynamically sets the base offset for the first allocated block to 1M (for a canister that doesn't yet use ESM) or 8MB (for code that does), reducing the overhead for code that only use regions, or uses regions before ESM.

The base offset (along with fixed block size in pages, in case we change that in future) is recorded in the meta-data, for resumption after upgrade.

We reserve a full 16, not just 6 pages, for future use (e.g. halving block size would double metadata space to 12 pages)