### PR TITLE
experiment: selectively emulate stable memory in wasi/wasm mode

### DIFF
--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -328,7 +328,7 @@ module E = struct
 
     features : FeatureSet.t ref; (* Wasm features using wasmtime naming *)
 
-    (* StableMemory *)
+    (* requires stable memory, and emulation on wasm targets *)
     requires_stable_memory : bool ref;
   }
 

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -328,7 +328,7 @@ module E = struct
 
     features : FeatureSet.t ref; (* Wasm features using wasmtime naming *)
 
-    (* requires stable memory, and emulation on wasm targets *)
+    (* requires stable memory (and emulation on wasm targets) *)
     requires_stable_memory : bool ref;
   }
 

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -5638,6 +5638,9 @@ module StableMemoryInterface = struct
 end
 
 module RTS_Exports = struct
+  (* Must be called late, after main codegen, to ensure correct generation of
+     of functioning or unused-but-trapping stable memory exports (as required)
+   *)
   let system_exports env =
     let bigint_trap_fi = E.add_fun env "bigint_trap" (
       Func.of_body env [] [] (fun env ->
@@ -12135,7 +12138,6 @@ let compile mode rts (prog : Ir.prog) : Wasm_exts.CustomModule.extended_module =
 
   IC.system_imports env;
   RTS.system_imports env;
-  (*  RTS_Exports.system_exports env; *)
 
   compile_init_func env prog;
   let start_fi_o = match E.mode env with

--- a/src/lang_utils/error_codes.ml
+++ b/src/lang_utils/error_codes.ml
@@ -194,4 +194,5 @@ let error_codes : (string * string option) list =
     "M0188", None; (* Send capability required (calling shared from query) *)
     "M0189", None; (* Different set of bindings in pattern alternatives *)
     "M0190", None; (* Types inconsistent for alternative pattern variables, losing information *)
+    "M0191", None; (* Code requires Wasm features ... to execute *)
   ]

--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -717,6 +717,11 @@ let compile_files mode do_link files : compile_result =
     | Some (_, ss) -> validate_stab_sig ss
     | _ -> Diag.return ()
   in
+  let* () =
+    if Wasm_exts.CustomModule.(ext_module.wasm_features) <> []
+    then Diag.warn Source.no_region "M0191" "compile" (Printf.sprintf "code requires Wasm features %s to execute" (String.concat "," Wasm_exts.CustomModule.(ext_module.wasm_features)))
+    else Diag.return ()
+  in
   Diag.return (idl, ext_module)
 
 

--- a/src/wasm-exts/customModule.ml
+++ b/src/wasm-exts/customModule.ml
@@ -73,4 +73,5 @@ type extended_module = {
   motoko : motoko_sections;
   (* source map section *)
   source_mapping_url : string option;
+  wasm_features : string list;
 }

--- a/src/wasm-exts/customModuleDecode.ml
+++ b/src/wasm-exts/customModuleDecode.ml
@@ -915,6 +915,7 @@ let module_ s =
     motoko;
     candid;
     source_mapping_url = None;
+    wasm_features = []; (* TODO: recover from custom section *)
   }
 
 

--- a/src/wasm-exts/customModuleEncode.ml
+++ b/src/wasm-exts/customModuleEncode.ml
@@ -859,6 +859,10 @@ let encode (em : extended_module) =
       icp_custom_section "candid:service" utf8 candid.service;
       icp_custom_section "candid:args" utf8 candid.args
 
+    let wasm_features_section wasm_features =
+      let text = String.concat "," wasm_features in
+      custom_section "wasm_features" utf8 text (text <> "")
+
     let uleb128 n = vu64 (Int64.of_int n)
     let sleb128 n = vs64 (Int64.of_int n)
     let close_section () = u8 0x00
@@ -1227,6 +1231,7 @@ let encode (em : extended_module) =
       name_section em.name;
       candid_sections em.candid;
       motoko_sections em.motoko;
+      wasm_features_section em.wasm_features;
       source_mapping_url_section em.source_mapping_url;
       if !Mo_config.Flags.debug_info then
         begin

--- a/test/check-error-codes.py
+++ b/test/check-error-codes.py
@@ -42,6 +42,7 @@ known_untested_codes = {
     "M0162", # Candid service constructor type not supported as Motoko type
     "M0164", # unknown record or variant label in textual representation
     "M0165", # odd expected type
+    "M0191", # compiler warning about wasm features (hard to trigger)
     }
 
 def populate_error_codes():

--- a/test/test-moc.js
+++ b/test/test-moc.js
@@ -60,7 +60,7 @@ assert.equal(typeof empty_wasm_plain.diagnostics, "object");
 assert.equal(empty_wasm_plain.diagnostics.length, 0);
 
 // Check that the WebAssembly binary can be loaded
-//WebAssembly.compile(empty_wasm_plain.code.wasm); // FIXME - needs multi-memory, buld-memory features enabled
+WebAssembly.compile(empty_wasm_plain.code.wasm);
 
 // Now again for the ic module
 assert.equal(typeof empty_wasm_ic, "object");
@@ -75,7 +75,7 @@ assert.deepEqual(
 assert.equal(typeof empty_wasm_ic.diagnostics, "object");
 assert.equal(empty_wasm_ic.diagnostics.length, 0);
 
-//WebAssembly.compile(empty_wasm_ic.code.wasm); // FIXME - needs multi-memory, buld-memory features enabled
+WebAssembly.compile(empty_wasm_ic.code.wasm);
 
 // The plain and the ic module should not be the same
 assert.notEqual(empty_wasm_plain.code.wasm, empty_wasm_ic.code.wasm);


### PR DESCRIPTION
builds on #4256 (emulating stable memory on wasmtime) but:

* avoids adding second memory unless necessary (so most programs continue to run w/o extra wasmtime option)
* adds optional custom section wasm_features with comma separate string of extra wasmtime flags (so that  driver could discover the options to pass)
* emits a warning when compiling code that requires extra wasmtime flags.

However, @Luc points out wasmtime should already be run with flag --enable-cranelift-nan-canonicalization and our users probably aren't doing that...

Perhaps we should just specify the options to use via documentation rather than the complicated mechanism here:

@luc-blaeser @rvanasa  thoughts?
