### PR TITLE
experiment: two additional tests for graph-copy

### DIFF
--- a/test/run-drun-non-ci/stable-variable-large.mo
+++ b/test/run-drun-non-ci/stable-variable-large.mo
@@ -1,4 +1,6 @@
 //MOC-FLAG --incremental-gc
+// This would let us test that destablization of >2GB works,
+// if only drun could execute it properly.
 import P "mo:⛔";
 
 actor {
@@ -7,8 +9,7 @@ actor {
   stable var a : [Blob] = [];
 
   system func preupgrade() {
-    a := P.Array_tabulate(32768,func (i:Nat) : Blob {
-      P.debugPrint(debug_show {i; p=P.performanceCounter(0)});
+    a := P.Array_tabulate(32768+16384,func (i:Nat) : Blob {
       P.stableMemoryLoadBlob(0, 65535) });  // use ca. 3GB main memory
     P.debugPrint("upgrading...");
   };

--- a/test/run-drun-non-ci/stable-variable-large.mo
+++ b/test/run-drun-non-ci/stable-variable-large.mo
@@ -1,0 +1,30 @@
+//MOC-FLAG --incremental-gc
+import P "mo:⛔";
+
+actor {
+  stable let p = P.stableMemoryGrow(1);
+  assert (p == 0);
+  stable var a : [Blob] = [];
+
+  system func preupgrade() {
+    a := P.Array_tabulate(32768,func (i:Nat) : Blob {
+      P.debugPrint(debug_show {i; p=P.performanceCounter(0)});
+      P.stableMemoryLoadBlob(0, 65535) });  // use ca. 3GB main memory
+    P.debugPrint("upgrading...");
+  };
+
+  system func postupgrade() {
+   P.debugPrint("...upgraded");
+   assert false;
+  };
+
+}
+
+//SKIP run
+//SKIP run-low
+//SKIP run-ir
+// too slow on ic-ref-run:
+//SKIP comp-ref
+
+//CALL upgrade ""
+

--- a/test/run-drun/ok/stable-exp-immut.drun-run.ok
+++ b/test/run-drun/ok/stable-exp-immut.drun-run.ok
@@ -1,0 +1,14 @@
+ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
+ingress Completed: Reply: 0x4449444c0000
+debug.print: upgrading...
+debug.print: ...upgraded
+ingress Completed: Reply: 0x4449444c0000
+debug.print: upgrading...
+debug.print: ...upgraded
+ingress Completed: Reply: 0x4449444c0000
+debug.print: upgrading...
+debug.print: ...upgraded
+ingress Completed: Reply: 0x4449444c0000
+debug.print: upgrading...
+debug.print: ...upgraded
+ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/stable-exp-immut.mo
+++ b/test/run-drun/stable-exp-immut.mo
@@ -1,0 +1,91 @@
+import P "mo:⛔";
+// This test would fail with OOM if stable serialization did not preserve sharin of immutable arrays.
+
+actor {
+  stable let a = P.Array_tabulate(65536,func (_:Nat) : {var ref : Nat} { {var ref =  0 }});  // leads to explosion due to exponential serialized size
+  stable let a1 = [a, a];
+  stable let a2 = [a1, a1];
+  stable let a3 = [a2, a2];
+  stable let a4 = [a3, a3];
+  stable let a5 = [a4, a4];
+  stable let a6 = [a5, a5];
+  stable let a7 = [a6, a6];
+  stable let a8 = [a7, a7];
+
+  system func preupgrade() {
+    P.debugPrint("upgrading...");
+  };
+
+  system func postupgrade() {
+   // verify (some) aliasing
+   a[0].ref += 1;
+   let v = a[0].ref;
+
+   for (a in a1.vals())
+     { assert a[0].ref == v };
+
+   for (a1 in a2.vals())
+   for (a in a1.vals())
+     { assert a[0].ref == v };
+
+   for (a2 in a3.vals())
+   for (a1 in a2.vals())
+   for (a in a1.vals())
+     { assert a[0].ref == v };
+
+   for (a3 in a4.vals())
+   for (a2 in a3.vals())
+   for (a1 in a2.vals())
+   for (a in a1.vals())
+     { assert a[0].ref == v };
+
+   for (a4 in a5.vals())
+   for (a3 in a4.vals())
+   for (a2 in a3.vals())
+   for (a1 in a2.vals())
+   for (a in a1.vals())
+     { assert a[0].ref == v };
+
+   for (a5 in a6.vals())
+   for (a4 in a5.vals())
+   for (a3 in a4.vals())
+   for (a2 in a3.vals())
+   for (a1 in a2.vals())
+   for (a in a1.vals())
+     { assert a[0].ref == v };
+
+   for (a6 in a7.vals())
+   for (a5 in a6.vals())
+   for (a4 in a5.vals())
+   for (a3 in a4.vals())
+   for (a2 in a3.vals())
+   for (a1 in a2.vals())
+   for (a in a1.vals())
+     { assert a[0].ref == v };
+
+   for (a7 in a8.vals())
+   for (a6 in a7.vals())
+   for (a5 in a6.vals())
+   for (a4 in a5.vals())
+   for (a3 in a4.vals())
+   for (a2 in a3.vals())
+   for (a1 in a2.vals())
+   for (a in a1.vals())
+     { assert a[0].ref == v };
+
+   P.debugPrint("...upgraded");
+  };
+
+}
+
+//SKIP run
+//SKIP run-low
+//SKIP run-ir
+// too slow on ic-ref-run:
+//SKIP comp-ref
+
+//CALL upgrade ""
+//CALL upgrade ""
+//CALL upgrade ""
+//CALL upgrade ""
+


### PR DESCRIPTION
Two additional tests for @luc-blaeser's graph copying branch (luc/graph-copy), Builds on #4286.

- `run-drun/stable-exp-immut.mo` is a version of `stable-exp` that uses immutable arrays, to highlight the sharing of those arrays that would previously explode stabilization (using Candidish) (as suggested in a comment in `stable-exp.mp`)
- `run-drun-non-ci/stable-var-large.mo` attempts to allocated more than 2 GB of stable variables and then upgrade. This should succeed with graph-copy but fail with Candidish due to non-streaming destabilization (which requires copying all stable variable data to the heap before deserialization). Unfortunately, I can't execute it on my machine without causing drun to choke (possible due a lack of diskspace). Disabled for now by placing in attic run-drun-non-ci.