### PR TITLE
Small Refinements: Implement GC Trigger in Backend

### DIFF
--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -10556,9 +10556,9 @@ and compile_prim_invocation (env : E.t) ae p es at =
         go locals)
     end
 
-  | ICPerformGC force, [] ->
+  | ICPerformGC, [] ->
     SR.unit,
-    E.collect_garbage env force
+    GC.collect_garbage env
 
   | ICStableSize t, [e] ->
     SR.UnboxedWord64,

--- a/src/ir_def/arrange_ir.ml
+++ b/src/ir_def/arrange_ir.ml
@@ -107,7 +107,7 @@ and prim = function
   | CPSAsync (Type.Cmp, t) -> "CPSAsync*" $$ [typ t]
   | ICArgDataPrim     -> Atom "ICArgDataPrim"
   | ICStableSize t    -> "ICStableSize" $$ [typ t]
-  | ICPerformGC _     -> Atom "ICPerformGC"
+  | ICPerformGC       -> Atom "ICPerformGC"
   | ICReplyPrim ts    -> "ICReplyPrim" $$ List.map typ ts
   | ICRejectPrim      -> Atom "ICRejectPrim"
   | ICCallerPrim      -> Atom "ICCallerPrim"

--- a/src/ir_def/check_ir.ml
+++ b/src/ir_def/check_ir.ml
@@ -679,7 +679,7 @@ let rec check_exp env (exp:Ir.exp) : unit =
       T.unit <: t
     | GetCertificate, [] ->
       T.Opt T.blob <: t
-    | ICPerformGC _, [] ->
+    | ICPerformGC, [] ->
       T.unit <: t
     | ICStableSize t1, [e1] ->
       typ e1 <: t1;

--- a/src/ir_def/construct.ml
+++ b/src/ir_def/construct.ml
@@ -90,7 +90,7 @@ let primE prim es =
     | ICCallerPrim -> T.caller
     | ICStableRead t -> t
     | ICMethodNamePrim -> T.text
-    | ICPerformGC _
+    | ICPerformGC
     | ICStableWrite _ -> T.unit
     | ICStableSize _ -> T.nat64
     | IdxPrim

--- a/src/ir_def/ir.ml
+++ b/src/ir_def/ir.ml
@@ -164,7 +164,7 @@ and prim =
   | CPSAwait of Type.async_sort * Type.typ
                                       (* typ is the current continuation type of cps translation *)
   | CPSAsync of Type.async_sort * Type.typ
-  | ICPerformGC of bool               (* `true` in the boolean argument specifies force GC mode, overriding !Flags.force_gc *)
+  | ICPerformGC
   | ICReplyPrim of Type.typ list
   | ICRejectPrim
   | ICCallerPrim
@@ -306,7 +306,7 @@ let map_prim t_typ t_id p =
   | CPSAsync (s, t) -> CPSAsync (s, t_typ t)
   | ICReplyPrim ts -> ICReplyPrim (List.map t_typ ts)
   | ICArgDataPrim
-  | ICPerformGC _
+  | ICPerformGC
   | ICRejectPrim
   | ICCallerPrim
   | ICCallPrim

--- a/src/lowering/desugar.ml
+++ b/src/lowering/desugar.ml
@@ -501,7 +501,7 @@ and build_actor at ts self_id es obj_typ =
     let vs = fresh_vars "v" (List.map (fun f -> f.T.typ) fields) in
     blockE
       ((match call_system_func_opt "preupgrade" es obj_typ with
-        | Some call -> [ expD (primE (I.ICPerformGC false) []); expD call]
+        | Some call -> [ expD (primE (I.ICPerformGC) []); expD call]
         | None -> []) @
          [letP (seqP (List.map varP vs)) (* dereference any mutable vars, option 'em all *)
             (seqE (List.map (fun (i,t) -> optE (varE (var i t))) ids))])

--- a/test/bench/ok/heap-32.drun-run-opt.ok
+++ b/test/bench/ok/heap-32.drun-run-opt.ok
@@ -1,5 +1,5 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-debug.print: (50_227, +30_261_252, 620_249_054)
-debug.print: (50_070, +32_992_212, 671_159_894)
+debug.print: (50_227, +30_261_252, 620_249_106)
+debug.print: (50_070, +32_992_212, 671_159_946)
 ingress Completed: Reply: 0x4449444c0000

--- a/test/bench/ok/heap-32.drun-run.ok
+++ b/test/bench/ok/heap-32.drun-run.ok
@@ -1,5 +1,5 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-debug.print: (50_227, +30_261_252, 667_502_508)
-debug.print: (50_070, +32_992_212, 720_277_315)
+debug.print: (50_227, +30_261_252, 667_502_608)
+debug.print: (50_070, +32_992_212, 720_277_415)
 ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/gc-trigger.mo
+++ b/test/run-drun/gc-trigger.mo
@@ -30,4 +30,5 @@ actor {
 //CALL query checkBeforeGC "DIDL\x00\x00"
 //CALL ingress __motoko_gc_trigger "DIDL\x00\x00"
 //CALL ingress __motoko_gc_trigger "DIDL\x00\x00"
+//CALL ingress __motoko_gc_trigger "DIDL\x00\x00"
 //CALL query checkAfterGC "DIDL\x00\x00"

--- a/test/run-drun/ok/gc-trigger.drun-run.ok
+++ b/test/run-drun/ok/gc-trigger.drun-run.ok
@@ -4,4 +4,5 @@ ingress Completed: Reply: 0x4449444c0000
 Ok: Reply: 0x4449444c0000
 ingress Completed: Reply: 0x4449444c0000
 ingress Completed: Reply: 0x4449444c0000
+ingress Completed: Reply: 0x4449444c0000
 Ok: Reply: 0x4449444c0000


### PR DESCRIPTION
Small refinements for the GC trigger improvement by https://github.com/dfinity/motoko/pull/4303:
* Revert initial non-backend GC trigger changes
* Fix the `gc-trigger` test case
* Allow memory reserve for GC trigger (not sure, to be discussed)