### PR TITLE
fix: passing `<system>` to class methods from bodies

### DIFF
--- a/test/fail/issue-4447.mo
+++ b/test/fail/issue-4447.mo
@@ -1,10 +1,21 @@
 import { debugPrint; setTimer } = "mo:⛔";
 
-func() {
+func _f() {
 
     func indirect<system>() {
         ignore setTimer<system>(0, false, func () : async () { debugPrint "YEP!" });
     };
 
-    indirect<system>()
+    indirect<system>();
+    ignore indirect<system>()
+};
+
+class _C() {
+
+    func indirect<system>() {
+        ignore setTimer<system>(0, false, func () : async () { debugPrint "YEP!" });
+    };
+
+    indirect<system>();
+    ignore indirect<system>()
 }

--- a/test/fail/issue-4447.mo
+++ b/test/fail/issue-4447.mo
@@ -1,0 +1,10 @@
+import { debugPrint; setTimer } = "mo:⛔";
+
+func() {
+
+    func indirect<system>() {
+        ignore setTimer<system>(0, false, func () : async () { debugPrint "YEP!" });
+    };
+
+    indirect<system>()
+}

--- a/test/fail/ok/issue-4447.tc.ok
+++ b/test/fail/ok/issue-4447.tc.ok
@@ -1,0 +1,2 @@
+issue-4447.mo:9.5-9.23: type error [M0197], `system` capability required, but not available
+ (need an enclosing async expression or function body or explicit `system` type parameter)

--- a/test/fail/ok/issue-4447.tc.ok
+++ b/test/fail/ok/issue-4447.tc.ok
@@ -1,2 +1,10 @@
 issue-4447.mo:9.5-9.23: type error [M0197], `system` capability required, but not available
  (need an enclosing async expression or function body or explicit `system` type parameter)
+issue-4447.mo:10.12-10.30: type error [M0197], `system` capability required, but not available
+ (need an enclosing async expression or function body or explicit `system` type parameter)
+issue-4447.mo:10.5-10.30: warning [M0089], redundant ignore, operand already has type ()
+issue-4447.mo:19.5-19.23: type error [M0197], `system` capability required, but not available
+ (need an enclosing async expression or function body or explicit `system` type parameter)
+issue-4447.mo:20.12-20.30: type error [M0197], `system` capability required, but not available
+ (need an enclosing async expression or function body or explicit `system` type parameter)
+issue-4447.mo:20.5-20.30: warning [M0089], redundant ignore, operand already has type ()

--- a/test/fail/ok/issue-4447.tc.ret.ok
+++ b/test/fail/ok/issue-4447.tc.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/run-drun/issue-4447.mo
+++ b/test/run-drun/issue-4447.mo
@@ -1,0 +1,15 @@
+import { debugPrint; setTimer } = "mo:⛔";
+
+class <system>() {
+
+    func indirect<system>() {
+        ignore setTimer<system>(0, false, func () : async () { debugPrint "YEPYEP!" });
+    };
+    
+    ignore setTimer<system>(0, false, func () : async () { debugPrint "YEP!" });
+    indirect<system>()
+}
+
+//SKIP run
+//SKIP run-low
+//SKIP run-ir

--- a/test/run-drun/ok/issue-4447.comp-ref.ok
+++ b/test/run-drun/ok/issue-4447.comp-ref.ok
@@ -1,0 +1,4 @@
+issue-4447.mo:10.5-10.23: type error [M0197], `system` capability required, but not available
+ (need an enclosing async expression or function body or explicit `system` type parameter)
+issue-4447.mo:10.5-10.23: type error [M0197], `system` capability required, but not available
+ (need an enclosing async expression or function body or explicit `system` type parameter)

--- a/test/run-drun/ok/issue-4447.comp-ref.ret.ok
+++ b/test/run-drun/ok/issue-4447.comp-ref.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/run-drun/ok/issue-4447.comp.ok
+++ b/test/run-drun/ok/issue-4447.comp.ok
@@ -1,0 +1,4 @@
+issue-4447.mo:10.5-10.23: type error [M0197], `system` capability required, but not available
+ (need an enclosing async expression or function body or explicit `system` type parameter)
+issue-4447.mo:10.5-10.23: type error [M0197], `system` capability required, but not available
+ (need an enclosing async expression or function body or explicit `system` type parameter)

--- a/test/run-drun/ok/issue-4447.comp.ret.ok
+++ b/test/run-drun/ok/issue-4447.comp.ret.ok
@@ -1,0 +1,1 @@
+Return code 1


### PR DESCRIPTION
This (hopefully) resolves #4447.

The problem was that the two modes of bidirectional type checking behaved differently, because of a bug in setting up the checking environment. That has been fixed by @crusso in #4453, where he also corrected the issue with the error message showing up twice in the test case.

When calling `setTimer` from the class body type _checking_ happens, while when calling a self-method it is _infer_.