### PR TITLE
fix: add special case for displaying actor principal in `moc.js` output

### DIFF
--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -593,9 +593,13 @@ let run_stdin_from_file files file : Value.value option =
     Diag.flush_messages (load_decl (parse_file Source.no_region file) senv) in
   let denv' = interpret_libs denv libs in
   let* (v, dscope) = interpret_prog denv' prog in
-  Format.printf "@[<hv 2>%a :@ %a@]@."
+  (match t with
+  | Type.Obj (Type.Actor, _) ->
+      (* special case for actors *)
+      Format.printf "@[<hv 2>%a@]@." Type.pp_typ t
+  | _ -> Format.printf "@[<hv 2>%a :@ %a@]@."
     (Value.pp_val 10) v
-    Type.pp_typ t;
+    Type.pp_typ t);
   Some v
 
 let run_files_and_stdin files =

--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -595,8 +595,8 @@ let run_stdin_from_file files file : Value.value option =
   let* (v, dscope) = interpret_prog denv' prog in
   (match t with
   | Type.Obj (Type.Actor, _) ->
-      (* special case for actors *)
-      Format.printf "@[<hv 2>%a@]@." Type.pp_typ t
+    (* special case for actors *)
+    Format.printf "@[<hv 2>%a@]@." Type.pp_typ t
   | _ -> Format.printf "@[<hv 2>%a :@ %a@]@."
     (Value.pp_val 10) v
     Type.pp_typ t);

--- a/test/test-moc.js
+++ b/test/test-moc.js
@@ -143,12 +143,20 @@ assert.deepStrictEqual(Motoko.check("bad.mo"), {
   code: null,
 });
 
-const astString = JSON.stringify(
-  Motoko.parseMotoko(Motoko.readFile("ast.mo"))
-);
+// Run interpreter
+assert.deepStrictEqual(Motoko.run([], "actor.mo"), {
+  stdout: "actor {main : shared query () -> async A__9<Text>}\n",
+  stderr: "",
+  result: { error: null },
+});
+
+const astString = JSON.stringify(Motoko.parseMotoko(Motoko.readFile("ast.mo")));
 
 // Check doc comments
-assert.match(astString, /"name":"\*","args":\["Program comment\\n      multi-line"/);
+assert.match(
+  astString,
+  /"name":"\*","args":\["Program comment\\n      multi-line"/
+);
 assert.match(astString, /"name":"\*","args":\["Type comment"/);
 assert.match(astString, /"name":"\*","args":\["Variable comment"/);
 assert.match(astString, /"name":"\*","args":\["Function comment"/);
@@ -161,7 +169,8 @@ assert.deepStrictEqual(Motoko.check("text.mo"), {
   diagnostics: [],
 });
 
-const candid = `
+const candid =
+  `
 type T = nat;
 /// Program comment
 ///       multi-line
@@ -169,42 +178,44 @@ service : {
   /// Function comment
   main: () -> (T) query;
 }
-`.trim() + '\n';
-assert.deepStrictEqual(Motoko.candid('ast.mo'), {
+`.trim() + "\n";
+assert.deepStrictEqual(Motoko.candid("ast.mo"), {
   diagnostics: [
     {
-      category: 'type',
-      code: 'M0194',
-      message: 'unused identifier Prim (delete or rename to wildcard `_` or `_Prim`)',
+      category: "type",
+      code: "M0194",
+      message:
+        "unused identifier Prim (delete or rename to wildcard `_` or `_Prim`)",
       range: {
         end: {
           character: 13,
-          line: 3
+          line: 3,
         },
         start: {
           character: 9,
-          line: 3
-        }
+          line: 3,
+        },
       },
       severity: 2,
-      source: 'ast.mo'
+      source: "ast.mo",
     },
     {
-      category: 'type',
-      code: 'M0194',
-      message: 'unused identifier M (delete or rename to wildcard `_` or `_M`)',
+      category: "type",
+      code: "M0194",
+      message: "unused identifier M (delete or rename to wildcard `_` or `_M`)",
       range: {
         end: {
           character: 12,
-          line: 13
+          line: 13,
         },
         start: {
           character: 11,
-          line: 13
-        }
+          line: 13,
+        },
       },
       severity: 2,
-      source: 'ast.mo'
-    }
-  ], code: candid
+      source: "ast.mo",
+    },
+  ],
+  code: candid,
 });

--- a/test/test-moc.js
+++ b/test/test-moc.js
@@ -143,6 +143,10 @@ assert.deepStrictEqual(Motoko.check("bad.mo"), {
   code: null,
 });
 
+const astString = JSON.stringify(
+  Motoko.parseMotoko(Motoko.readFile("ast.mo"))
+);
+
 // Run interpreter
 assert.deepStrictEqual(Motoko.run([], "actor.mo"), {
   stdout: "actor {main : shared query () -> async A__9<Text>}\n",
@@ -150,13 +154,8 @@ assert.deepStrictEqual(Motoko.run([], "actor.mo"), {
   result: { error: null },
 });
 
-const astString = JSON.stringify(Motoko.parseMotoko(Motoko.readFile("ast.mo")));
-
 // Check doc comments
-assert.match(
-  astString,
-  /"name":"\*","args":\["Program comment\\n      multi-line"/
-);
+assert.match(astString, /"name":"\*","args":\["Program comment\\n      multi-line"/);
 assert.match(astString, /"name":"\*","args":\["Type comment"/);
 assert.match(astString, /"name":"\*","args":\["Variable comment"/);
 assert.match(astString, /"name":"\*","args":\["Function comment"/);
@@ -169,8 +168,7 @@ assert.deepStrictEqual(Motoko.check("text.mo"), {
   diagnostics: [],
 });
 
-const candid =
-  `
+const candid = `
 type T = nat;
 /// Program comment
 ///       multi-line
@@ -178,44 +176,42 @@ service : {
   /// Function comment
   main: () -> (T) query;
 }
-`.trim() + "\n";
-assert.deepStrictEqual(Motoko.candid("ast.mo"), {
+`.trim() + '\n';
+assert.deepStrictEqual(Motoko.candid('ast.mo'), {
   diagnostics: [
     {
-      category: "type",
-      code: "M0194",
-      message:
-        "unused identifier Prim (delete or rename to wildcard `_` or `_Prim`)",
+      category: 'type',
+      code: 'M0194',
+      message: 'unused identifier Prim (delete or rename to wildcard `_` or `_Prim`)',
       range: {
         end: {
           character: 13,
-          line: 3,
+          line: 3
         },
         start: {
           character: 9,
-          line: 3,
-        },
+          line: 3
+        }
       },
       severity: 2,
-      source: "ast.mo",
+      source: 'ast.mo'
     },
     {
-      category: "type",
-      code: "M0194",
-      message: "unused identifier M (delete or rename to wildcard `_` or `_M`)",
+      category: 'type',
+      code: 'M0194',
+      message: 'unused identifier M (delete or rename to wildcard `_` or `_M`)',
       range: {
         end: {
           character: 12,
-          line: 13,
+          line: 13
         },
         start: {
           character: 11,
-          line: 13,
-        },
+          line: 13
+        }
       },
       severity: 2,
-      source: "ast.mo",
-    },
-  ],
-  code: candid,
+      source: 'ast.mo'
+    }
+  ], code: candid
 });


### PR DESCRIPTION
This PR includes a special case in the `run_stdin_from_file` console output to address a quirk with `moc.js` in the developer documentation. 