### PR TITLE
chore: use PocketIC in drun

### DIFF
--- a/test/drun-wrapper.sh
+++ b/test/drun-wrapper.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-CONFIG=$(realpath $(dirname $0)/drun.json5)
-
 #
 # This script wraps drun to
 #
@@ -23,26 +21,20 @@ fi
 
 export LANG=C.UTF-8
 
-# this could be used to delay drun to make it more deterministic, but
-# it doesn't work reliably and slows down the test significantly.
-# so until DFN-1269 fixes this properly, let's just not run
-# affected tests on drun (only ic-ref-run).
-EXTRA_BATCHES=1
-
 # on darwin, I have seen
 #   thread 'MR Batch Processor' has overflowed its stack
 # and this helps (default is 2MB)
 export RUST_MIN_STACK=$((10*1024*1024))
 
 # drun creates canisters with this ID:
-ID=rwlgt-iiaaa-aaaaa-aaaaa-cai
+ID=lxzze-o7777-77777-aaaaa-cai
 
 if [ "${1: -5}" = ".drun" ]
 then
   # work around different IDs in ic-ref-run and drun
   ( echo "create"
     LANG=C perl -npe 's,\$ID,'$ID',g' $1
-  ) | drun -c "$CONFIG" --extra-batches $EXTRA_BATCHES /dev/stdin
+  ) | drun --cycles-used-file /dev/fd/222 /dev/stdin
 else
   ( echo "create"
     echo "install $ID $1 0x"
@@ -50,5 +42,5 @@ else
     then
       LANG=C perl -ne 'print "$1 '$ID' $2\n" if m,^//CALL (ingress|query) (.*),;print "upgrade '$ID' '"$1"' 0x\n" if m,^//CALL upgrade,; ' $2
     fi
-  ) | drun -c "$CONFIG" --extra-batches $EXTRA_BATCHES /dev/stdin
+  ) | drun --cycles-used-file /dev/fd/222 /dev/stdin
 fi

--- a/test/drun.json5
+++ b/test/drun.json5
@@ -1,6 +1,0 @@
-{
-  metrics: {
-    exporter: { file: "/dev/fd/222" }
-  },
-}
-

--- a/test/profile-report.sh
+++ b/test/profile-report.sh
@@ -55,7 +55,7 @@ for file in perf/*.mo; do
   wasm-profiler-instrument --ic-system-api -i "_profile_build/$base.wasm" -o "_profile_build/$base.instrumented.wasm"
 
   # qr.mo takes far too long with profiling instrumentation, so limit runtime
-  timeout 20s ./drun-wrapper.sh "_profile_build/$base.instrumented.wasm" "$file" |&
+  timeout 20s ./drun-wrapper.sh "_profile_build/$base.instrumented.wasm" "$file" 222>/dev/null |&
     wasm-profiler-postproc flamegraph "_profile_build/$base.instrumented.wasm" \
     > "_profile_build/$base.flamegraph"
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -395,7 +395,7 @@ do
           if [ $DTESTS = yes ]
           then
             if [ $HAVE_drun = yes ]; then
-              run_if wasm drun-run $WRAP_drun $out/$base.wasm $mangled
+              run_if wasm drun-run $WRAP_drun $out/$base.wasm $mangled 222>/dev/null
             fi
             if [ $HAVE_ic_ref_run = yes ]; then
               run_if ref.wasm ic-ref-run $WRAP_ic_ref_run $out/$base.ref.wasm $mangled
@@ -403,12 +403,13 @@ do
           elif [ $PERF = yes ]
           then
             if [ $HAVE_drun = yes ]; then
-              run_if wasm drun-run $WRAP_drun $out/$base.wasm $mangled 222> $out/$base.metrics
+              run_if wasm drun-run $WRAP_drun $out/$base.wasm $mangled 222>$out/$base.metrics
               if [ -e $out/$base.metrics -a -n "$PERF_OUT" ]
               then
-                LANG=C perl -ne "print \"gas/$base;\$1\n\" if /^scheduler_(?:cycles|instructions)_consumed_per_round_sum (\\d+)\$/" $out/$base.metrics >> $PERF_OUT;
+                CYCLES_USED="$(awk -F':' '{sum+=$2;} END {print sum;}' $out/$base.metrics)";
+                echo "gas/$base;$CYCLES_USED" >> $PERF_OUT;
               fi
-              run_if opt.wasm drun-run-opt $WRAP_drun $out/$base.opt.wasm $mangled
+              run_if opt.wasm drun-run-opt $WRAP_drun $out/$base.opt.wasm $mangled 222>/dev/null
             fi
           else
             run_if wasm wasm-run wasmtime run $WASMTIME_OPTIONS $out/$base.wasm


### PR DESCRIPTION
This MR needs to pull the latest drun and PocketIC server binaries:
```
https://download.dfinity.systems/ic/a6707c42691fccbe3d90dcd596637172a926ce02/binaries/x86_64-linux/drun.gz
https://download.dfinity.systems/ic/a6707c42691fccbe3d90dcd596637172a926ce02/binaries/x86_64-linux/pocket-ic.gz
```
and
```
export POCKET_IC_BIN=<path-to-pocket-ic>
```
Also note that the output format changed slightly and thus the expected test output should be regenerated.