### PR TITLE
experiment: candid metering

### DIFF
--- a/rts/motoko-rts-tests/src/bigint.rs
+++ b/rts/motoko-rts-tests/src/bigint.rs
@@ -73,6 +73,8 @@ unsafe fn test_bigint_leb128(n: Value) {
     let mut buf_ = Buf {
         ptr: buf.as_mut_ptr(),
         end: buf.as_mut_ptr().add(100),
+        decoding_quota: 0,
+        skipping_quota: 0,
     };
     bigint_leb128_encode(n, buf.as_mut_ptr());
     let n2 = bigint_leb128_decode(&mut buf_ as *mut _);
@@ -88,6 +90,8 @@ unsafe fn test_bigint_sleb128(n: Value) {
     let mut buf_ = Buf {
         ptr: buf.as_mut_ptr(),
         end: buf.as_mut_ptr().add(100),
+        decoding_quota: 0,
+        skipping_quota: 0,
     };
     let n2 = bigint_sleb128_decode(&mut buf_ as *mut _);
     assert!(bigint_eq(n, n2));

--- a/rts/motoko-rts-tests/src/leb128.rs
+++ b/rts/motoko-rts-tests/src/leb128.rs
@@ -67,6 +67,8 @@ fn roundtrip_signed(val: i32) -> TestCaseResult {
         let mut buf_ = Buf {
             ptr: buf.as_mut_ptr(),
             end: buf.as_mut_ptr().add(100),
+            decoding_quota: 0,
+            skipping_quota: 0,
         };
 
         match sleb128_decode_checked(&mut buf_) {
@@ -94,6 +96,8 @@ fn roundtrip_unsigned(val: u32) -> TestCaseResult {
         let mut buf_ = Buf {
             ptr: buf.as_mut_ptr(),
             end: buf.as_mut_ptr().add(100),
+            decoding_quota: 0,
+            skipping_quota: 0,
         };
 
         match leb128_decode_checked(&mut buf_) {
@@ -117,6 +121,8 @@ unsafe fn check_signed_decode_overflow(buf: &[u8]) {
     let mut buf_ = Buf {
         ptr: buf.as_ptr() as *mut _,
         end: buf.as_ptr().add(buf.len()) as *mut _,
+        decoding_quota: 0,
+        skipping_quota: 0,
     };
 
     assert_eq!(sleb128_decode_checked(&mut buf_), None);
@@ -126,6 +132,8 @@ unsafe fn check_unsigned_decode_overflow(buf: &[u8]) {
     let mut buf_ = Buf {
         ptr: buf.as_ptr() as *mut _,
         end: buf.as_ptr().add(buf.len()) as *mut _,
+        decoding_quota: 0,
+        skipping_quota: 0,
     };
 
     assert_eq!(leb128_decode_checked(&mut buf_), None);

--- a/rts/motoko-rts/src/buf.rs
+++ b/rts/motoko-rts/src/buf.rs
@@ -89,8 +89,8 @@ unsafe fn advance(buf: *mut Buf, n: u32) {
 #[no_mangle]
 pub(crate) unsafe extern "C" fn skip_leb128(buf: *mut Buf) {
     loop {
-        let byte = read_byte(buf);
         buf.add_skip_cost(1); // TBR
+        let byte = read_byte(buf);
         if byte & 0b1000_0000 == 0 {
             break;
         }

--- a/rts/motoko-rts/src/buf.rs
+++ b/rts/motoko-rts/src/buf.rs
@@ -99,19 +99,19 @@ pub(crate) unsafe extern "C" fn skip_leb128(buf: *mut Buf) {
 
 #[cfg(feature = "ic")]
 #[no_mangle]
-pub(crate) unsafe extern "C" fn add_decode_cost(buf: *mut Buf, cost: usize) {
+pub(crate) unsafe extern "C" fn idl_decode_cost(buf: *mut Buf, cost: usize) {
     buf.add_decode_cost(cost);
 }
 
 #[cfg(feature = "ic")]
 #[no_mangle]
-pub(crate) unsafe extern "C" fn add_skip_cost(buf: *mut Buf, cost: usize) {
+pub(crate) unsafe extern "C" fn idl_skip_cost(buf: *mut Buf, cost: usize) {
     buf.add_skip_cost(cost);
 }
 
 #[cfg(feature = "ic")]
 #[no_mangle]
-pub(crate) unsafe extern "C" fn set_quotas(
+pub(crate) unsafe extern "C" fn idl_set_quotas(
     buf: *mut Buf,
     decoding_quota: usize,
     skipping_quota: usize,

--- a/rts/motoko-rts/src/idl.rs
+++ b/rts/motoko-rts/src/idl.rs
@@ -532,6 +532,7 @@ unsafe extern "C" fn find_field(
     tag: u32,
     n: *mut u8,
 ) -> u32 {
+    //TODO costs?
     while *n > 0 {
         let last_p = (*tb).ptr;
         let this_tag = leb128_decode(tb);
@@ -554,6 +555,7 @@ unsafe extern "C" fn find_field(
 
 #[no_mangle]
 unsafe extern "C" fn skip_fields(tb: *mut Buf, buf: *mut Buf, typtbl: *mut *mut u8, n: *mut u8) {
+    //TODO costs?
     while *n > 0 {
         skip_leb128(tb);
         let it = sleb128_decode(tb);

--- a/src/codegen/compile.ml
+++ b/src/codegen/compile.ml
@@ -3038,7 +3038,7 @@ module ReadBuf = struct
     set_end get_buf
       (get_ptr get_buf ^^ get_size ^^ G.i (Binary (Wasm.Values.I32 I32Op.Add)))
 
-  let alloc env f = Stack.with_words env "buf" 2l f
+  let alloc env f = Stack.with_words env "buf" 4l f
 
   let advance get_buf get_delta =
     set_ptr get_buf (get_ptr get_buf ^^ get_delta ^^ G.i (Binary (Wasm.Values.I32 I32Op.Add)))


### PR DESCRIPTION
- add optional quotas to Buf.rs

Inspired by https://github.com/dfinity/candid/pull/524

TODO:
[ ] skipping compound types
[ ] specialize add_decode/skip_cost
[ ] compile.ml ReadBuf & other changes.
