### PR TITLE
chore: Upgrade `drun` 

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -26,10 +26,10 @@
         "homepage": "",
         "owner": "luc-blaeser",
         "repo": "ic",
-        "rev": "7b130fb48003a74ab76fbdee44132aa7b3a967e6",
-        "sha256": "1h97j39wcx28nw7zhbhlim13dksgcrrlxvm6if5rc8vnp2y1wkgy",
+        "rev": "6c718b80e04ad1930a08e6c53440c15021ca9c3d",
+        "sha256": "0iglm7m69d836wipzi25xza25l84dmjq9b4s1y6rwa8xnmiipnbh",
         "type": "tarball",
-        "url": "https://github.com/luc-blaeser/ic/archive/7b130fb48003a74ab76fbdee44132aa7b3a967e6.tar.gz",
+        "url": "https://github.com/luc-blaeser/ic/archive/6c718b80e04ad1930a08e6c53440c15021ca9c3d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "ic-hs": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -21,15 +21,15 @@
         "version": "3.2.25"
     },
     "ic": {
-        "branch": "luc/latest-ic-wasm64-test",
+        "branch": "luc/adjust-drun",
         "description": "Internet Computer blockchain source: the client/replica software run by nodes",
         "homepage": "",
         "owner": "luc-blaeser",
         "repo": "ic",
-        "rev": "7921f5f3dc0d9fb774e3222f8ff6b1c00a086f1a",
-        "sha256": "1ykawbpaqnf1y508vh81m30p813ykmnbffxc3p0hw0p0k1ynq6zz",
+        "rev": "7b130fb48003a74ab76fbdee44132aa7b3a967e6",
+        "sha256": "1h97j39wcx28nw7zhbhlim13dksgcrrlxvm6if5rc8vnp2y1wkgy",
         "type": "tarball",
-        "url": "https://github.com/luc-blaeser/ic/archive/7921f5f3dc0d9fb774e3222f8ff6b1c00a086f1a.tar.gz",
+        "url": "https://github.com/luc-blaeser/ic/archive/7b130fb48003a74ab76fbdee44132aa7b3a967e6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "ic-hs": {


### PR DESCRIPTION
Using IC 2024-08-16 with some adjustments:
* `drun` adjustments for better testing
   - https://github.com/dfinity/ic/pull/662 (Lift 8GB memory boundary from drun)
   - https://github.com/dfinity/ic/pull/988 (Enable Wasm64 with 16GB main memory capacity)
   - https://github.com/dfinity/ic/pull/991 (Disable DTS for deterministic debug outputs)
   - https://github.com/dfinity/ic/pull/992 (Increase batch limit for longer running tests)
   - https://github.com/dfinity/ic/pull/1240 (Enable canister snapshots)
* IC build fixes for `nix`:
   - Remove duplicate entries of same crate with same versions in `Cargo.toml`.
   - https://github.com/dfinity/ic/pull/993 (Fix MacOS `rocksdb` dependency).
* Other IC fixes:
   - https://github.com/dfinity/ic/pull/1250 (Fix canister snapshots)