### PR TITLE
WIP: use promises for `actor` environments

### DIFF
--- a/src/mo_interpreter/interpret.ml
+++ b/src/mo_interpreter/interpret.ml
@@ -1041,15 +1041,14 @@ let ensure_management_canister env =
       V.Env.add
         (* ManagementCanister with raw_rand (only) *)
         ""
-        (V.Obj
-           (V.Env.singleton "raw_rand"
-              (V.async_func (T.Write) 0 1
-                 (fun c v k ->
-                   async env
-                     Source.no_region
-                     (fun k' r ->
-                       k' (V.Blob (V.Blob.rand32 ())))
-                     k))) |> Lib.Promise.make_fulfilled)
+        V.(Obj
+          (Env.singleton "raw_rand"
+             (async_func T.Write 0 1
+                (fun c v k ->
+                  async env
+                    Source.no_region
+                    (fun k' r -> k' (Blob (Blob.rand32 ())))
+                    k))) |> Lib.Promise.make_fulfilled)
         !(env.actor_env)
 
 let interpret_prog flags scope p : (V.value * scope) option =


### PR DESCRIPTION
This PR implements the "crazy idea" from #4719 (see comments) in order to roll back the pair representation change for `shared` actor methods.