### PR TITLE
chore: update `motoko-mode.el` to v29 apostrophe conventions

### DIFF
--- a/emacs/motoko-mode.el
+++ b/emacs/motoko-mode.el
@@ -5,7 +5,7 @@
 (setq motoko-font-lock-keywords
       (let* (
              ;; define several category of keywords
-             ;; these are each taken from either Motoko's `lexer.mll' or `prelude.ml' files.
+             ;; these are each taken from either Motoko\\='s `lexer.mll' or `prelude.ml' files.
              (x-types
               '("Any"
                 "None"


### PR DESCRIPTION
this removes `emacs` warnings when loading the mode

see: https://emacs.stackexchange.com/questions/73047/emacs-29-docstring-single-quote-escaping-rules-compiler-level-event

not sure whether elisp really qualify as docstrings, but this helps