### PR TITLE
experiment: add optional stability modifiers before body to control default

### DIFF
--- a/doc/md/examples/grammar.txt
+++ b/doc/md/examples/grammar.txt
@@ -305,7 +305,7 @@
     'type' <id> ('<' <list(<typ_bind>, ',')> '>')? '=' <typ>
     <obj_sort> <id>? (':' <typ>)? '='? <stab> <obj_body>
     <shared_pat_opt> 'func' <id>? <typ_params_opt> <pat_plain> (':' <typ>)? <func_body>
-    <shared_pat_opt> <obj_sort>? 'class' <id>? <typ_params_opt> <pat_plain> (':' <typ>)? <stab> <class_body>
+    <shared_pat_opt> <obj_sort>? 'class' <id>? <typ_params_opt> <pat_plain> (':' <typ>)? <class_body>
 
 <dec> ::= 
     <dec_var>
@@ -321,8 +321,8 @@
     '{' <list(<dec_field>, ';')> '}'
 
 <class_body> ::= 
-    '=' <id>? <obj_body>
-    <obj_body>
+    '=' <id>? <stab> <obj_body>
+    <stab> <obj_body>
 
 <imp> ::= 
     'import' <pat_nullary> '='? <text>

--- a/doc/md/examples/grammar.txt
+++ b/doc/md/examples/grammar.txt
@@ -303,9 +303,9 @@
 <dec_nonvar> ::= 
     'let' <pat> '=' <exp>
     'type' <id> ('<' <list(<typ_bind>, ',')> '>')? '=' <typ>
-    <obj_sort> <id>? (':' <typ>)? '='? <obj_body>
+    <obj_sort> <id>? (':' <typ>)? '='? <stab> <obj_body>
     <shared_pat_opt> 'func' <id>? <typ_params_opt> <pat_plain> (':' <typ>)? <func_body>
-    <shared_pat_opt> <obj_sort>? 'class' <id>? <typ_params_opt> <pat_plain> (':' <typ>)? <class_body>
+    <shared_pat_opt> <obj_sort>? 'class' <id>? <typ_params_opt> <pat_plain> (':' <typ>)? <stab> <class_body>
 
 <dec> ::= 
     <dec_var>

--- a/src/mo_frontend/parser.mly
+++ b/src/mo_frontend/parser.mly
@@ -308,7 +308,7 @@ and objblock s id ty dec_fields =
 %type<Mo_def.Syntax.dec> dec imp dec_var dec_nonvar
 %type<Mo_def.Syntax.exp_field> exp_field
 %type<Mo_def.Syntax.dec_field> dec_field
-%type<Mo_def.Syntax.id * Mo_def.Syntax.dec_field list> class_body
+%type<Mo_def.Syntax.id * Mo_def.Syntax.stab option * Mo_def.Syntax.dec_field list> class_body
 %type<Mo_def.Syntax.case> catch case
 %type<Mo_def.Syntax.exp> bl ob
 %type<Mo_def.Syntax.dec list> import_list
@@ -907,8 +907,8 @@ dec_nonvar :
       let is_sugar, e = desugar_func_body sp x t fb in
       let_or_exp named x (func_exp x.it sp tps p t is_sugar e) (at $sloc) }
   | sp=shared_pat_opt s=obj_sort_opt CLASS xf=typ_id_opt
-      tps=typ_params_opt p=pat_plain t=annot_opt stab=stab cb=class_body
-    { let x, dfs = cb in
+      tps=typ_params_opt p=pat_plain t=annot_opt  cb=class_body
+    { let x, stab, dfs = cb in
       let dfs', tps', t' =
         if s.it = Type.Actor then
           let default_stab = match stab with
@@ -942,8 +942,8 @@ obj_body :
   | LCURLY dfs=seplist(dec_field, semicolon) RCURLY { dfs }
 
 class_body :
-  | EQ xf=id_opt dfs=obj_body { snd (xf "object" $sloc), dfs }
-  | dfs=obj_body { anon_id "object" (at $sloc) @@ at $sloc, dfs }
+  | EQ xf=id_opt stab=stab dfs=obj_body { snd (xf "object" $sloc), stab, dfs }
+  | stab=stab dfs=obj_body { anon_id "object" (at $sloc) @@ at $sloc, stab,  dfs }
 
 
 (* Programs *)

--- a/src/mo_frontend/parser.mly
+++ b/src/mo_frontend/parser.mly
@@ -197,7 +197,12 @@ let share_dec_field default_stab (df : dec_field) =
     {df with it =
        {df.it with stab =
           match df.it.stab with
-          | None -> Some (default_stab @@ df.it.dec.at)
+          | None ->
+             (match df.it.dec.it with
+             | ExpD _
+             | TypD _
+             | ClassD _ -> None
+             | _ -> Some (default_stab @@ df.it.dec.at))
           | some -> some}
     }
 

--- a/test/run-drun/ok/stable-counter-class.drun.ok
+++ b/test/run-drun/ok/stable-counter-class.drun.ok
@@ -1,0 +1,8 @@
+ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
+ingress Completed: Reply: 0x4449444c0000
+debug.print: 1
+ingress Completed: Reply: 0x4449444c00017d01
+debug.print: {pre = 1}
+ingress Completed: Reply: 0x4449444c0000
+debug.print: 2
+ingress Completed: Reply: 0x4449444c00017d02

--- a/test/run-drun/ok/stable-counter.drun.ok
+++ b/test/run-drun/ok/stable-counter.drun.ok
@@ -1,0 +1,8 @@
+ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
+ingress Completed: Reply: 0x4449444c0000
+debug.print: 1
+ingress Completed: Reply: 0x4449444c00017d01
+debug.print: {pre = 1}
+ingress Completed: Reply: 0x4449444c0000
+debug.print: 2
+ingress Completed: Reply: 0x4449444c00017d02

--- a/test/run-drun/stable-counter-class.drun
+++ b/test/run-drun/stable-counter-class.drun
@@ -1,0 +1,4 @@
+install $ID stable-counter-class/stable-counter-class.mo ""
+ingress $ID inc "DIDL\x00\x00"
+upgrade $ID stable-counter-class/stable-counter-class.mo ""
+ingress $ID inc "DIDL\x00\x00"

--- a/test/run-drun/stable-counter-class/stable-counter-class.mo
+++ b/test/run-drun/stable-counter-class/stable-counter-class.mo
@@ -1,0 +1,21 @@
+import Prim "mo:⛔";
+
+actor class Counter() stable {
+
+  var count : Nat = 0;
+
+  public func inc() : async Nat {
+    count += 1;
+    Prim.debugPrint (debug_show(count));
+    count
+  };
+
+  system func preupgrade() {
+    Prim.debugPrint (debug_show({pre=count}));
+  }
+
+  // let f = func(){}; // rejected as unstable
+
+}
+
+

--- a/test/run-drun/stable-counter.drun
+++ b/test/run-drun/stable-counter.drun
@@ -1,0 +1,4 @@
+install $ID stable-counter/stable-counter.mo ""
+ingress $ID inc "DIDL\x00\x00"
+upgrade $ID stable-counter/stable-counter.mo ""
+ingress $ID inc "DIDL\x00\x00"

--- a/test/run-drun/stable-counter/stable-counter.mo
+++ b/test/run-drun/stable-counter/stable-counter.mo
@@ -1,0 +1,21 @@
+import Prim "mo:⛔";
+
+actor Counter stable {
+
+  var count : Nat = 0;
+
+  public func inc() : async Nat {
+    count += 1;
+    Prim.debugPrint (debug_show(count));
+    count
+  };
+
+  system func preupgrade() {
+    Prim.debugPrint (debug_show({pre=count}));
+  }
+
+  // let f = func(){}; // rejected as unstable
+
+}
+
+


### PR DESCRIPTION
Investigate with prefixing body of actor or actor class with optional, default stability modifier, supporting the opt-in inversion from flexible to stable, without changing the semantics of existing code.

(Prefixing the `actor` keyword introduces hundreds of shift/reduce conflicts, so I tried this instead.
Perhaps the conflicts can be avoid by some grammar refactoring...)

Note: we only allow the stable modifier on simple let patterns bind a single identier and (all) mutable variables, so care must be taken not to default to stable in other cases...

```motoko
actor Counter stable {

  var count : Nat = 0; // defaults to stable

  public func inc() : async Nat {
    count += 1;
    count
  };

  // let f = func(){}; // rejected as unstable

}
```
and 

```motoko
actor class Counter() stable {

  var count : Nat = 0;  // defaults to stable

  public func inc() : async Nat {
    count += 1;
    Prim.debugPrint (debug_show(count));
    count
  };

  // let f = func(){}; // rejected as unstable

}
```

Not sure I'm loving it, tbh.