### PR TITLE
doc: new `persistent` and `transient` keywords

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -20,17 +20,17 @@
         transient var invocations = 0;
 
         // counts increments since first installation
-        var counter = 0;
+        var value = 0; 	// implicitly `stable`
 
         public func inc() : async () {
-          counter += 1;
+          value += 1;
           invocations += 1;
         }
 
       }
       ```
 
-      On upgrade, the transient variable `invocations` will be reset to `0` and `counter`, now implicitly `stable`, will retain its current value.
+      On upgrade, the transient variable `invocations` will be reset to `0` and `value`, now implicitly `stable`, will retain its current value.
 
       Legacy actors and classes declared without the `persistent` keyword have the same semantics as before.
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -29,7 +29,7 @@ html:
 preview:
 	make -C ../src moc_interpreter.js
 	cp -f ../src/moc_interpreter.js docusaurus/static
-	cd docusaurus; npm install; npm start
+	cd docusaurus; npm install; npm run clear; npm start
 
 
 .PHONY: base

--- a/doc/docusaurus/src/theme/CodeBlock/hljs_run.js
+++ b/doc/docusaurus/src/theme/CodeBlock/hljs_run.js
@@ -78,7 +78,7 @@ export function registerMotoko() {
         $pattern: "[a-zA-Z_]\\w*",
         keyword:
           "actor and await break case catch class" +
-          " continue composite debug do else for func if in import" +
+          " continue composite debug do else finally for func if in import" +
           " module not object or label let loop persistent private" +
           " public return shared transient try throw query switch" +
           " type var while with stable flexible system debug_show assert ignore from_candid to_candid",

--- a/doc/docusaurus/src/theme/CodeBlock/hljs_run.js
+++ b/doc/docusaurus/src/theme/CodeBlock/hljs_run.js
@@ -79,8 +79,8 @@ export function registerMotoko() {
         keyword:
           "actor and await break case catch class" +
           " continue composite debug do else for func if in import" +
-          " module not object or label let loop private" +
-          " public return shared try throw query switch" +
+          " module not object or label let loop persistent private" +
+          " public return shared transient try throw query switch" +
           " type var while with stable flexible system debug_show assert ignore from_candid to_candid",
         literal: "true false null",
         built_in:

--- a/doc/md/canister-maintenance/compatibility.md
+++ b/doc/md/canister-maintenance/compatibility.md
@@ -198,23 +198,23 @@ A common, real-world example of an incompatible upgrade can be found [on the for
 In that example, a user was attempting to add a field to the record payload of an array, by upgrading from stable type interface:
 
 ``` motoko no-repl
-actor {
+persistent actor {
   type Card = {
     title : Text;
   };
-  stable var map : [(Nat32, Card)] = [(0, { title = "TEST"})];
+  var map : [(Nat32, Card)] = [(0, { title = "TEST"})];
 };
 ```
 
 to *incompatible* stable type interface:
 
 ``` motoko no-repl
-actor {
+persistent actor {
   type Card = {
     title : Text;
     description : Text;
   };
-  stable var map : [(Nat32, Card)] = [];
+  var map : [(Nat32, Card)] = [];
 };
 ```
 
@@ -249,7 +249,7 @@ To resolve this issue, an [explicit](#explicit-migration) is needed:
 ``` motoko no-repl
 import Array "mo:base/Array";
 
-actor {
+persistent actor {
   type OldCard = {
     title : Text;
   };
@@ -257,9 +257,9 @@ actor {
     title : Text;
     description : Text;
   };
-  
-  stable var map : [(Nat32, OldCard)] = [];
-  stable var newMap : [(Nat32, NewCard)] = Array.map<(Nat32, OldCard), (Nat32, NewCard)>(
+
+  var map : [(Nat32, OldCard)] = [];
+  var newMap : [(Nat32, NewCard)] = Array.map<(Nat32, OldCard), (Nat32, NewCard)>(
     map,
     func(key, { title }) { (key, { title; description = "<empty>" }) },
   );
@@ -269,12 +269,12 @@ actor {
 4. **After** we have successfully upgraded to this new version, we can upgrade once more to a version, that drops the old `map`.
 
 ``` motoko no-repl
-actor {
+persistent actor {
   type Card = {
     title : Text;
     description : Text;
   };
-  stable var newMap : [(Nat32, Card)] = [];
+  var newMap : [(Nat32, Card)] = [];
 };
 ```
 

--- a/doc/md/canister-maintenance/compatibility.md
+++ b/doc/md/canister-maintenance/compatibility.md
@@ -22,15 +22,25 @@ The following is a simple example of how to declare a stateful counter:
 ```
 
 Importantly, in this example, when the counter is upgraded, its state is lost.
-This is because actor variables are by default `flexible`, meaning they get reinitialized on an upgrade.
+This is because actor variables are by default `transient`, meaning they get reinitialized on an upgrade.
+The above actor is equivalent to using the `transient` declaration:
 
-To fix this, you can declare a stable variable that is retained across upgrades:
+``` motoko no-repl file=../examples/count-v0transient.mo
+```
 
+
+To fix this, you can declare a `stable` variable that is retained across upgrades:
+
+
+``` motoko no-repl file=../examples/count-v1stable.mo
+```
+
+To make `stable` the default for all declarations, and `transient` optional, you can prefix the actor declaration with the keyword `persistent`.
 
 ``` motoko no-repl file=../examples/count-v1.mo
 ```
 
-If the variable `state` were not declared `stable`, `state` would restart from `0` on upgrade.
+If the variable `state` were not declared `stable`, either explicitly or by applying `persistent` to the `actor` keyword, `state` would restart from `0` on upgrade.
 
 ## Evolving the stable declarations
 

--- a/doc/md/canister-maintenance/compatibility.md
+++ b/doc/md/canister-maintenance/compatibility.md
@@ -35,7 +35,7 @@ To fix this, you can declare a `stable` variable that is retained across upgrade
 ``` motoko no-repl file=../examples/count-v1stable.mo
 ```
 
-To make `stable` the default for all declarations, and `transient` optional, you can prefix the actor declaration with the keyword `persistent`.
+To make `stable` the default for all declarations and `transient` optional, you can prefix the actor declaration with the keyword `persistent`.
 
 ``` motoko no-repl file=../examples/count-v1.mo
 ```

--- a/doc/md/canister-maintenance/upgrades.md
+++ b/doc/md/canister-maintenance/upgrades.md
@@ -23,7 +23,7 @@ The semantics of the modifiers is as follows:
 
 :::note
 
-Previous versions of Motoko (up to version 0.13.4) used the keyword `flexible` instead of `transient`. Both keywords are accepted interchangeably but the legacy `flexible` keyword may be deprecated in future.
+Previous versions of Motoko (up to version 0.13.4) used the keyword `flexible` instead of `transient`. Both keywords are accepted interchangeably but the legacy `flexible` keyword may be deprecated in the future.
 
 :::note
 
@@ -35,7 +35,7 @@ The following is a simple example of how to declare a stable counter that can be
 Starting with Motoko v0.13.5, if you prefix the `actor` keyword with the keyword `persistent`, then all `let` and `var` declarations of the actor or actor class are implicitly declared `stable`. Only `transient` variables will need an explicit `transient` declaration.
 Using a `persistent` actor can help avoid unintended data loss. It is the recommended declaration syntax for actors and actor classes. The non-`persistent` declaration is provided for backwards compatibility.
 
-Since Motoko 0.13.5, the recommended way to declare `StableCounter` above is:
+Since Motoko v0.13.5, the recommended way to declare `StableCounter` above is:
 
 ``` motoko file=../examples/PersistentCounter.mo
 ```

--- a/doc/md/canister-maintenance/upgrades.md
+++ b/doc/md/canister-maintenance/upgrades.md
@@ -23,7 +23,7 @@ The semantics of the modifiers is as follows:
 
 :::note
 
-Previous versions of Motoko (up to version 0.13.4) used the keyword `flexible` instead of `transient`. Both keywords are accepted interchangebly but the legacy `flexible` keyword may be deprecated in future.
+Previous versions of Motoko (up to version 0.13.4) used the keyword `flexible` instead of `transient`. Both keywords are accepted interchangeably but the legacy `flexible` keyword may be deprecated in future.
 
 :::note
 

--- a/doc/md/canister-maintenance/upgrades.md
+++ b/doc/md/canister-maintenance/upgrades.md
@@ -14,27 +14,43 @@ This is substantially different to other languages supported on the IC, which us
 
 In an actor, you can configure which part of the program is considered to be persistent, i.e. survives upgrades, and which part are ephemeral, i.e. are reset on upgrades.
 
-More precisely, each `let` and `var` variable declaration in an actor can specify whether the variable is `stable` or `flexible`. If you don’t provide a modifier, the variable is assumed to be `flexible` by default.
+More precisely, each `let` and `var` variable declaration in an actor can specify whether the variable is `stable` or `transient`. If you don’t provide a modifier, the variable is assumed to be `transient` by default.
+
 
 The semantics of the modifiers is as follows:
 * `stable` means that all values directly or indirectly reachable from that stable actor variable are considered persistent and automatically retained across upgrades. This is the primary choice for most of the program's state.
-* `flexible` means that the variable is re-initialized on upgrade, such that the values referenced by this flexible variable can be discarded, unless the values are transitively reachable by other variables that are stable. `flexible` is only used for temporal state or references to high-order types, such as local function references, see [stable types](#stable-types).
+* `transient` means that the variable is re-initialized on upgrade, such that the values referenced by this transient variable can be discarded, unless the values are transitively reachable by other variables that are stable. `transient` is only used for temporary state or references to high-order types, such as local function references, see [stable types](#stable-types).
+
+::: note
+
+Previous versions of Motoko (up to version 0.13.4) used the keyword `flexible` instead of `transient`. Both keywords are accepted interchangebly but the legacy `flexible` keyword may be deprecated in future.
+
+::: note
 
 The following is a simple example of how to declare a stable counter that can be upgraded while preserving the counter’s value:
 
 ``` motoko file=../examples/StableCounter.mo
 ```
 
+Starting with Motoko 0.13.5, if you prefix the `actor` keyword with the keyword `persistent`, then all `let` and `var` declarations of the actor or actor class are implicitly declared `stable`, and only `transient` variables need an explicit `transient` declaration.
+Using a `persistent` actor can help avoid unintended data loss, and is the recommended declaration syntax for actors and actor classes. The non-`peristent` declaration is provided for backwards compatibility.
+
+Since Motoko 0.13.5, the recommended way to declare `StableCounter` above is:
+
+``` motoko file=../examples/PersistentCounter.mo
+```
+
 :::note
 
-You can only use the `stable` or `flexible` modifier on `let` and `var` declarations that are **actor fields**. You cannot use these modifiers anywhere else in your program.
+You can only use the `stable`, `transient` (or legacy `flexible`) modifier on `let` and `var` declarations that are **actor fields**. You cannot use these modifiers anywhere else in your program.
 
 :::
 
-When you first compile and deploy a canister, all flexible and stable variables in the actor are initialized in sequence. When you deploy a canister using the `upgrade` mode, all stable variables that existed in the previous version of the actor are pre-initialized with their old values. After the stable variables are initialized with their previous values, the remaining flexible and newly-added stable variables are initialized in sequence.
+
+When you first compile and deploy a canister, all transient and stable variables in the actor are initialized in sequence. When you deploy a canister using the `upgrade` mode, all stable variables that existed in the previous version of the actor are pre-initialized with their old values. After the stable variables are initialized with their previous values, the remaining transient and newly-added stable variables are initialized in sequence.
 
 :::danger
-Do not forget to declare variables `stable` if they should survive canister upgrades as the default is `flexible` if no modifier is declared.
+Do not forget to declare variables `stable` if they should survive canister upgrades as the default is `transient` if no modifier is declared.
 :::
 
 ## Persistence modes
@@ -67,30 +83,14 @@ For variables that do not have a stable type, there are two options for making t
 Unlike stable data structures in the Rust CDK, these modules do not use stable memory but rely on orthogonal persistence. The adjective "stable" only denotes a stable type in Motoko.
 :::
 
-2. Extract the state in a stable type, and wrap it in the non-stable type. 
+2. Extract the state in a stable type, and wrap it in the non-stable type.
 
 For example, the stable type `TemperatureSeries` covers the persistent data, while the non-stable type `Weather` wraps this with additional methods (local function types).
 
-```motoko no-repl
-actor {
-  type TemperatureSeries = [Float];
 
-  class Weather(temperatures : TemperatureSeries) {
-    public func averageTemperature() : Float {
-      var sum = 0.0;
-      var count = 0.0;
-      for (value in temperatures.vals()) {
-        sum += value;
-        count += 1;
-      };
-      return sum / count;
-    };
-  };
-
-  stable var temperatures : TemperatureSeries = [30.0, 31.5, 29.2];
-  flexible var weather = Weather(temperatures);
-};
+``` motoko no-repl file=../examples/WeatherActor.mo
 ```
+
 
 3. __Discouraged and not recommended__: [Pre- and post-upgrade hooks](#preupgrade-and-postupgrade-system-methods) allow copying non-stable types to stable types during upgrades. This approach is error-prone and does not scale for large data. **Per best practices, using these methods should be avoided if possible.** Conceptually, it also does not align well with the idea of orthogonal persistence.
 
@@ -121,7 +121,7 @@ A stable signature `<stab-sig1>` is stable-compatible with signature `<stab-sig2
 - `<stab-sig2>` does not contain a stable field `<id>`.
 - `<stab-sig>` has a matching stable field `<id> : U` with `T <: U`.
 
-Note that `<stab-sig2>` may contain additional fields or abandon fields of `<stab-sig1>`. Mutability can be different for matching fields. 
+Note that `<stab-sig2>` may contain additional fields or abandon fields of `<stab-sig1>`. Mutability can be different for matching fields.
 
 `<stab-sig1>` is the signature of an older version while `<stab-sig2>` is the signature of a newer version.
 
@@ -142,7 +142,7 @@ When upgrading a canister, it is important to verify that the upgrade can procee
 -   Breaking clients due to a Candid interface change.
 
 With [enhanced orthogonal persistence](orthogonal-persistence/enhanced.md), Motoko rejects incompatible changes of stable declarations during upgrade attempt.
-Moreover, `dfx` checks the two conditions before attempting then upgrade and warns users correspondingly.
+Moreover, `dfx` checks the two conditions before attempting the upgrade and warns users correspondingly.
 
 A Motoko canister upgrade is safe provided:
 

--- a/doc/md/canister-maintenance/upgrades.md
+++ b/doc/md/canister-maintenance/upgrades.md
@@ -33,7 +33,7 @@ The following is a simple example of how to declare a stable counter that can be
 ```
 
 Starting with Motoko v0.13.5, if you prefix the `actor` keyword with the keyword `persistent`, then all `let` and `var` declarations of the actor or actor class are implicitly declared `stable`. Only `transient` variables will need an explicit `transient` declaration.
-Using a `persistent` actor can help avoid unintended data loss, and is the recommended declaration syntax for actors and actor classes. The non-`peristent` declaration is provided for backwards compatibility.
+Using a `persistent` actor can help avoid unintended data loss. It is the recommended declaration syntax for actors and actor classes. The non-`persistent` declaration is provided for backwards compatibility.
 
 Since Motoko 0.13.5, the recommended way to declare `StableCounter` above is:
 

--- a/doc/md/canister-maintenance/upgrades.md
+++ b/doc/md/canister-maintenance/upgrades.md
@@ -21,11 +21,11 @@ The semantics of the modifiers is as follows:
 * `stable` means that all values directly or indirectly reachable from that stable actor variable are considered persistent and automatically retained across upgrades. This is the primary choice for most of the program's state.
 * `transient` means that the variable is re-initialized on upgrade, such that the values referenced by this transient variable can be discarded, unless the values are transitively reachable by other variables that are stable. `transient` is only used for temporary state or references to high-order types, such as local function references, see [stable types](#stable-types).
 
-::: note
+:::note
 
 Previous versions of Motoko (up to version 0.13.4) used the keyword `flexible` instead of `transient`. Both keywords are accepted interchangebly but the legacy `flexible` keyword may be deprecated in future.
 
-::: note
+:::note
 
 The following is a simple example of how to declare a stable counter that can be upgraded while preserving the counter’s value:
 
@@ -51,6 +51,7 @@ When you first compile and deploy a canister, all transient and stable variables
 
 :::danger
 Do not forget to declare variables `stable` if they should survive canister upgrades as the default is `transient` if no modifier is declared.
+A simple precaution is declare the entire actor or actor class `persistent`.
 :::
 
 ## Persistence modes

--- a/doc/md/canister-maintenance/upgrades.md
+++ b/doc/md/canister-maintenance/upgrades.md
@@ -32,7 +32,7 @@ The following is a simple example of how to declare a stable counter that can be
 ``` motoko file=../examples/StableCounter.mo
 ```
 
-Starting with Motoko 0.13.5, if you prefix the `actor` keyword with the keyword `persistent`, then all `let` and `var` declarations of the actor or actor class are implicitly declared `stable`, and only `transient` variables need an explicit `transient` declaration.
+Starting with Motoko v0.13.5, if you prefix the `actor` keyword with the keyword `persistent`, then all `let` and `var` declarations of the actor or actor class are implicitly declared `stable`. Only `transient` variables will need an explicit `transient` declaration.
 Using a `persistent` actor can help avoid unintended data loss, and is the recommended declaration syntax for actors and actor classes. The non-`peristent` declaration is provided for backwards compatibility.
 
 Since Motoko 0.13.5, the recommended way to declare `StableCounter` above is:

--- a/doc/md/examples/Alarm.mo
+++ b/doc/md/examples/Alarm.mo
@@ -1,6 +1,6 @@
 import Debug "mo:base/Debug";
 
-actor Alarm {
+persistent actor Alarm {
 
   let n = 5;
   var count = 0;

--- a/doc/md/examples/Buckets.mo
+++ b/doc/md/examples/Buckets.mo
@@ -1,21 +1,23 @@
 import Nat "mo:base/Nat";
-import Map "mo:base/RBTree";
+import Map "mo:base/OrderedMap";
 
-actor class Bucket(n : Nat, i : Nat) {
+persistent actor class Bucket(n : Nat, i : Nat) {
 
   type Key = Nat;
   type Value = Text;
 
-  let map = Map.RBTree<Key, Value>(Nat.compare);
+  transient let keyMap = Map.Make<Key>(Nat.compare);
+
+  var map : Map.Map<Key, Value> = keyMap.empty();
 
   public func get(k : Key) : async ?Value {
     assert((k % n) == i);
-    map.get(k);
+    keyMap.get(map, k);
   };
 
   public func put(k : Key, v : Value) : async () {
     assert((k % n) == i);
-    map.put(k,v);
+    map := keyMap.put(map, k, v);
   };
 
 };

--- a/doc/md/examples/Calc.mo
+++ b/doc/md/examples/Calc.mo
@@ -1,0 +1,39 @@
+// This single-cell calculator defines one calculator instruction per
+// public entry point (add, sub, mul, div).
+
+// Create a simple Calc actor.
+persistent actor Calc {
+
+  var cell : Int = 0;
+
+  // Define functions to add, subtract, multiply, and divide
+  public func add(n:Int) : async Int {
+    cell += n;
+    cell
+  };
+
+  public func sub(n:Int) : async Int {
+    cell -= n;
+    cell
+  };
+
+  public func mul(n:Int) : async Int {
+    cell *= n;
+    cell
+  };
+
+  public func div(n:Int) : async ?Int {
+    if ( n == 0 ) {
+      null // null indicates div-by-zero error
+    } else {
+      cell /= n;
+      ?cell
+    }
+  };
+
+  // Clear the cell, resetting to zero
+  public func clearall() : async Int {
+    cell := 0;
+    cell
+  };
+};

--- a/doc/md/examples/CardShuffle.mo
+++ b/doc/md/examples/CardShuffle.mo
@@ -1,0 +1,72 @@
+// Import the necessary modules, including the Random module:
+import Random = "mo:base/Random";
+import Char = "mo:base/Char";
+import Error = "mo:base/Error";
+
+// Define an actor
+
+persistent actor {
+
+  // Define a stable variable that contains each card as a unicode character:
+  var deck : ?[var Char] = ?[var
+    '🂡','🂢','🂣','🂤','🂥','🂦','🂧','🂨','🂩','🂪','🂫','🂬','🂭','🂮',
+    '🂱','🂲','🂳','🂴','🂵','🂶','🂷','🂸','🂹','🂺','🂻','🂼','🂽','🂾',
+    '🃁','🃂','🃃','🃄','🃅','🃆','🃇','🃈','🃉','🃊','🃋','🃌','🃍','🃎',
+    '🃑','🃒','🃓','🃔','🃕','🃖','🃗','🃘','🃙','🃚','🃛','🃜','🃝','🃞',
+    '🃏'
+  ];
+
+  func bit(b : Bool) : Nat {
+    if (b) 1 else 0;
+  };
+
+  // Use a finite source of randomness defined as `f`.
+  // Return an optional random number between [0..`max`) using rejection sampling.
+  // A return value of `null` indicates that `f` is exhausted and should be replaced.
+  func chooseMax(f : Random.Finite, max : Nat) : ? Nat {
+    assert max > 0;
+    do ? {
+      var n = max - 1 : Nat;
+      var k = 0;
+      while (n != 0) {
+        k *= 2;
+        k += bit(f.coin()!);
+        n /= 2;
+      };
+      if (k < max) k else chooseMax(f, max)!;
+    };
+  };
+
+  // Define a function to shuffle the cards using `Random.Finite`.
+  public func shuffle() : async () {
+    let ?cards = deck else throw Error.reject("shuffle in progress");
+    deck := null;
+    var f = Random.Finite(await Random.blob());
+    var i : Nat = cards.size() - 1;
+    while (i > 0) {
+      switch (chooseMax(f, i + 1)) {
+        case (?j) {
+          let temp = cards[i];
+          cards[i] := cards[j];
+          cards[j] := temp;
+          i -= 1;
+        };
+        case null { // need more entropy
+          f := Random.Finite(await Random.blob());
+        }
+      }
+    };
+    deck := ?cards;
+  };
+
+  // Define a function to display the randomly shuffled cards.
+  public query func show() : async Text {
+    let ?cards = deck else throw Error.reject("shuffle in progress");
+    var t = "";
+    for (card in cards.vals()) {
+       t #= Char.toText(card);
+    };
+    return t;
+  }
+
+};

--- a/doc/md/examples/CardShuffle.mo
+++ b/doc/md/examples/CardShuffle.mo
@@ -66,7 +66,7 @@ persistent actor {
     for (card in cards.vals()) {
        t #= Char.toText(card);
     };
-    return t;
+    t;
   }
 
 };

--- a/doc/md/examples/CompositeSemantics.mo
+++ b/doc/md/examples/CompositeSemantics.mo
@@ -1,4 +1,4 @@
-actor Composites {
+persistent actor Composites {
 
   var state = 0;
 

--- a/doc/md/examples/CountToTen.mo
+++ b/doc/md/examples/CountToTen.mo
@@ -2,7 +2,7 @@ import Counters "Counters";
 import Debug "mo:base/Debug";
 import Nat "mo:base/Nat";
 
-actor CountToTen {
+persistent actor CountToTen {
   public func countToTen() : async () {
     let C : Counters.Counter = await Counters.Counter(1);
     while ((await C.read()) < 10) {

--- a/doc/md/examples/Counter.mo
+++ b/doc/md/examples/Counter.mo
@@ -1,4 +1,4 @@
-persistent actor Counter {
+actor Counter {
 
   var value = 0;
 

--- a/doc/md/examples/Counter.mo
+++ b/doc/md/examples/Counter.mo
@@ -1,4 +1,4 @@
-actor Counter {
+persistent actor Counter {
 
   var value = 0;
 

--- a/doc/md/examples/CounterWithCompositeQuery.mo
+++ b/doc/md/examples/CounterWithCompositeQuery.mo
@@ -1,4 +1,4 @@
-actor class Counter () {
+persistent actor class Counter () {
 
   var count = 0;
 

--- a/doc/md/examples/CounterWithQuery.mo
+++ b/doc/md/examples/CounterWithQuery.mo
@@ -1,4 +1,4 @@
-actor Counter {
+persistent actor Counter {
 
   var count = 0;
 

--- a/doc/md/examples/Counters-caller-pat.mo
+++ b/doc/md/examples/Counters-caller-pat.mo
@@ -1,4 +1,4 @@
-shared({caller = owner}) actor class Counter(init : Nat) {
+shared({caller = owner}) persistent actor class Counter(init : Nat) {
 
   var count : Nat = init;
 

--- a/doc/md/examples/Counters-caller.mo
+++ b/doc/md/examples/Counters-caller.mo
@@ -1,6 +1,6 @@
-shared(msg) actor class Counter(init : Nat) {
+shared(msg) persistent actor class Counter(init : Nat) {
 
-  let owner = msg.caller;
+  transient let owner = msg.caller;
 
   var count = init;
 

--- a/doc/md/examples/Counters.mo
+++ b/doc/md/examples/Counters.mo
@@ -1,4 +1,4 @@
-actor class Counter(init : Nat) {
+persistent actor class Counter(init : Nat) {
   var count = init;
 
   public func inc() : async () { count += 1 };

--- a/doc/md/examples/InspectArg.mo
+++ b/doc/md/examples/InspectArg.mo
@@ -1,4 +1,4 @@
-actor {
+persistent actor {
 
    var c = 0;
 

--- a/doc/md/examples/InspectArg.mo
+++ b/doc/md/examples/InspectArg.mo
@@ -1,14 +1,14 @@
 persistent actor {
 
-   var c = 0;
+  var c = 0;
 
-   public func inc() : async () { c += 1 };
-   public func set(n : Nat) : async () { c := n };
-   public query func read() : async Nat { c };
-   public func reset() : () { c := 0 }; // oneway
+  public func inc() : async () { c += 1 };
+  public func set(n : Nat) : async () { c := n };
+  public query func read() : async Nat { c };
+  public func reset() : () { c := 0 }; // oneway
 
-   system func inspect({ arg : Blob }) : Bool {
-     arg.size() <= 512;
-   }
+  system func inspect({ arg : Blob }) : Bool {
+    arg.size() <= 512;
+  }
 
 };

--- a/doc/md/examples/InspectCaller.mo
+++ b/doc/md/examples/InspectCaller.mo
@@ -1,6 +1,6 @@
 import Principal = "mo:base/Principal";
 
-actor {
+persistent actor {
 
    var c = 0;
 

--- a/doc/md/examples/InspectFull.mo
+++ b/doc/md/examples/InspectFull.mo
@@ -1,6 +1,6 @@
 import Principal = "mo:base/Principal";
 
-actor {
+persistent actor {
 
    var c = 0;
 

--- a/doc/md/examples/InspectMixed.mo
+++ b/doc/md/examples/InspectMixed.mo
@@ -2,24 +2,24 @@ import Principal = "mo:base/Principal";
 
 persistent actor {
 
-   var c = 0;
+  var c = 0;
 
-   public func inc() : async () { c += 1 };
-   public func set(n : Nat) : async () { c := n };
-   public query func read() : async Nat { c };
-   public func reset() : () { c := 0 }; // oneway
+  public func inc() : async () { c += 1 };
+  public func set(n : Nat) : async () { c := n };
+  public query func read() : async Nat { c };
+  public func reset() : () { c := 0 }; // oneway
 
-   system func inspect(
-     {
-       caller : Principal;
-       arg : Blob;
-       msg : {
-         #inc : Any;
-         #set : () -> Nat;
-         #read : Any;
-         #reset : Any;
-       }
-     }) : Bool {
+  system func inspect(
+    {
+      caller : Principal;
+      arg : Blob;
+      msg : {
+        #inc : Any;
+        #set : () -> Nat;
+        #read : Any;
+        #reset : Any;
+      }
+    }) : Bool {
     if (Principal.isAnonymous(caller)) return false;
     if (arg.size() > 512) return false;
     switch (msg) {

--- a/doc/md/examples/InspectMixed.mo
+++ b/doc/md/examples/InspectMixed.mo
@@ -1,6 +1,6 @@
 import Principal = "mo:base/Principal";
 
-actor {
+persistent actor {
 
    var c = 0;
 

--- a/doc/md/examples/InspectName.mo
+++ b/doc/md/examples/InspectName.mo
@@ -1,21 +1,21 @@
 persistent actor {
 
-   var c = 0;
+  var c = 0;
 
-   public func inc() : async () { c += 1 };
-   public func set(n : Nat) : async () { c := n };
-   public query func read() : async Nat { c };
-   public func reset() : () { c := 0 }; // oneway
+  public func inc() : async () { c += 1 };
+  public func set(n : Nat) : async () { c := n };
+  public query func read() : async Nat { c };
+  public func reset() : () { c := 0 }; // oneway
 
-   system func inspect(
-     {
-       msg : {
-         #inc : Any;
-         #set : Any;
-         #read : Any;
-         #reset : Any;
-       }
-     }) : Bool {
+  system func inspect(
+    {
+      msg : {
+        #inc : Any;
+        #set : Any;
+        #read : Any;
+        #reset : Any;
+      }
+    }) : Bool {
     switch (msg) {
       case ((#set _) or (#reset _)) { false };
       case _ { true }; // allow inc and read

--- a/doc/md/examples/InspectName.mo
+++ b/doc/md/examples/InspectName.mo
@@ -1,4 +1,4 @@
-actor {
+persistent actor {
 
    var c = 0;
 

--- a/doc/md/examples/InspectNone.mo
+++ b/doc/md/examples/InspectNone.mo
@@ -1,4 +1,4 @@
-actor {
+persistent actor {
 
    var c = 0;
 

--- a/doc/md/examples/InspectTrick.mo
+++ b/doc/md/examples/InspectTrick.mo
@@ -1,4 +1,4 @@
-actor {
+persistent actor {
 
    var c = 0;
 

--- a/doc/md/examples/InspectTrick.mo
+++ b/doc/md/examples/InspectTrick.mo
@@ -1,14 +1,16 @@
 persistent actor {
 
-   var c = 0;
+  var c = 0;
 
-   public func inc() : async () { c += 1 };
-   public func set(n : Nat) : async () { c := n };
-   public query func read() : async Nat { c };
-   public func reset() : () { c := 0 }; // oneway
+  public func inc() : async () { c += 1 };
+  public func set(n : Nat) : async () { c := n };
+  public query func read() : async Nat { c };
+  public func reset() : () { c := 0 }; // oneway
+
 /*
-   system func inspect() : Bool {
+  system func inspect() : Bool {
      false
-   }
+  }
 */
+
 };

--- a/doc/md/examples/Map.mo
+++ b/doc/md/examples/Map.mo
@@ -1,7 +1,7 @@
 import Array "mo:base/Array";
 import Buckets "Buckets";
 
-actor Map {
+persistent actor Map {
 
   let n = 8; // number of buckets
 

--- a/doc/md/examples/PersistentCounter.mo
+++ b/doc/md/examples/PersistentCounter.mo
@@ -1,6 +1,6 @@
 persistent actor Counter {
 
-  var value = 0; // implicity `stable`
+  var value = 0; // implicitly stable!
 
   public func inc() : async Nat {
     value += 1;

--- a/doc/md/examples/PersistentCounter.mo
+++ b/doc/md/examples/PersistentCounter.mo
@@ -4,6 +4,6 @@ persistent actor Counter {
 
   public func inc() : async Nat {
     value += 1;
-    return value;
+    value;
   };
 }

--- a/doc/md/examples/PersistentStableCounter.mo
+++ b/doc/md/examples/PersistentStableCounter.mo
@@ -7,7 +7,7 @@ persistent actor Counter {
   public func inc() : async Nat {
     value += 1;
     invocations += 1;
-    return value;
+    value;
   };
 
   public func reset() : async () {

--- a/doc/md/examples/PersistentStableCounter.mo
+++ b/doc/md/examples/PersistentStableCounter.mo
@@ -14,7 +14,7 @@ persistent actor Counter {
     value := 0;
   };
 
-  public func invocations() : async Nat {
+  public func getInvocations() : async Nat {
     invocations
   }
 

--- a/doc/md/examples/PersistentStableCounter.mo
+++ b/doc/md/examples/PersistentStableCounter.mo
@@ -1,0 +1,21 @@
+persistent actor Counter {
+
+  var value = 0; // implicitly stable
+
+  transient var invocations = 0; // reset on upgrade
+
+  public func inc() : async Nat {
+    value += 1;
+    invocations += 1;
+    return value;
+  };
+
+  public func reset() : async () {
+    value := 0;
+  };
+
+  public func invocations() : async Nat {
+    invocations
+  }
+
+}

--- a/doc/md/examples/PiggyBank.mo
+++ b/doc/md/examples/PiggyBank.mo
@@ -1,11 +1,11 @@
 import Cycles "mo:base/ExperimentalCycles";
 
-shared(msg) actor class PiggyBank(
+shared(msg) persistent actor class PiggyBank(
   benefit : shared () -> async (),
   capacity: Nat
   ) {
 
-  let owner = msg.caller;
+  transient let owner = msg.caller;
 
   var savings = 0;
 

--- a/doc/md/examples/RawRand.mo
+++ b/doc/md/examples/RawRand.mo
@@ -1,0 +1,10 @@
+persistent actor {
+  let SubnetManager : actor {
+    raw_rand() : async Blob;
+  } = actor "aaaaa-aa";
+
+  public func random_bytes() : async Blob {
+    let bytes = await SubnetManager.raw_rand();
+    return bytes;
+  };
+};

--- a/doc/md/examples/RawRand.mo
+++ b/doc/md/examples/RawRand.mo
@@ -1,5 +1,5 @@
 persistent actor {
-  let SubnetManager : actor {
+  transient let SubnetManager : actor {
     raw_rand() : async Blob;
   } = actor "aaaaa-aa";
 

--- a/doc/md/examples/RawRand.mo
+++ b/doc/md/examples/RawRand.mo
@@ -5,6 +5,6 @@ persistent actor {
 
   public func random_bytes() : async Blob {
     let bytes = await SubnetManager.raw_rand();
-    return bytes;
+    bytes;
   };
 };

--- a/doc/md/examples/RecordPrincipals.mo
+++ b/doc/md/examples/RecordPrincipals.mo
@@ -1,0 +1,27 @@
+import Principal "mo:base/Principal";
+import OrderedSet "mo:base/OrderedSet";
+import Error "mo:base/Error";
+
+persistent actor {
+
+    transient let principalSet = OrderedSet.Make<Principal>(Principal.compare);
+
+    // Create set to record principals
+    var principals : OrderedSet.Set<Principal> = principalSet.empty();
+
+    // Check if principal is recorded
+    public shared query(msg) func isRecorded() : async Bool {
+        let caller = msg.caller;
+        principalSet.contains(principals, caller);
+    };
+
+    // Record a new principal
+    public shared(msg) func recordPrincipal() : async () {
+        let caller = msg.caller;
+        if (Principal.isAnonymous(caller)) {
+            throw Error.reject("Anonymous principal not allowed");
+        };
+
+        principals := principalSet.put(principals, caller)
+    };
+};

--- a/doc/md/examples/Registry.mo
+++ b/doc/md/examples/Registry.mo
@@ -10,7 +10,7 @@ actor Registry {
       case null {
         map.put(name, map.size());
       };
-      case (?id) { };
+      case (?_) { };
     }
   };
 

--- a/doc/md/examples/Reminder.mo
+++ b/doc/md/examples/Reminder.mo
@@ -3,9 +3,9 @@ import { abs } = "mo:base/Int";
 import { now } = "mo:base/Time";
 import { setTimer; recurringTimer } = "mo:base/Timer";
 
-actor Reminder {
+persistent actor Reminder {
 
-  let solarYearSeconds = 356_925_216;
+  transient let solarYearSeconds = 356_925_216;
 
   private func remind() : async () {
     print("Happy New Year!");

--- a/doc/md/examples/StableCounter.mo
+++ b/doc/md/examples/StableCounter.mo
@@ -1,6 +1,6 @@
-persistent actor Counter {
+actor Counter {
 
-  var value = 0; // implicity `stable`
+  stable var value = 0;
 
   public func inc() : async Nat {
     value += 1;

--- a/doc/md/examples/StableCounterUpgrade.mo
+++ b/doc/md/examples/StableCounterUpgrade.mo
@@ -1,6 +1,6 @@
-actor Counter {
+persistent actor Counter {
 
-  stable var value = 0;
+  var value = 0;
 
   public func inc() : async Nat {
     value += 1;

--- a/doc/md/examples/StableCounterUpgrade.mo
+++ b/doc/md/examples/StableCounterUpgrade.mo
@@ -1,6 +1,6 @@
-persistent actor Counter {
+actor Counter {
 
-  var value = 0;
+  stable var value = 0;
 
   public func inc() : async Nat {
     value += 1;

--- a/doc/md/examples/StableLog.mo
+++ b/doc/md/examples/StableLog.mo
@@ -4,7 +4,7 @@ import Text "mo:base/Text";
 import Array "mo:base/Array";
 import StableMemory "mo:base/ExperimentalStableMemory";
 
-actor StableLog {
+persistent actor StableLog {
 
   func ensure(offset : Nat64) {
     let pages = (offset + 65536) >> 16;
@@ -14,7 +14,7 @@ actor StableLog {
     };
   };
 
-  stable var base : Nat64 = 0;
+  var base : Nat64 = 0; // implicitly `stable`
 
   public func log(t : Text) {
     let blob = Text.encodeUtf8(t);

--- a/doc/md/examples/StableMultiLog.mo
+++ b/doc/md/examples/StableMultiLog.mo
@@ -1,13 +1,13 @@
 import Nat64 "mo:base/Nat64";
 import Region "mo:base/Region";
 
-actor StableLog {
+persistent actor StableLog {
 
   // Index of saved log entry.
   public type Index = Nat64;
 
   // Internal representation uses two regions, working together.
-  stable var state = {
+  var state = { // implicitly `stable`
     bytes = Region.new();
     var bytes_count : Nat64 = 0;
     elems = Region.new ();
@@ -29,7 +29,7 @@ actor StableLog {
     size : Nat64;
   };
 
-  let elem_size = 16 : Nat64; /* two Nat64s, for pos and size. */
+  transient let elem_size = 16 : Nat64; /* two Nat64s, for pos and size. */
 
   // Count of elements (Blobs) that have been logged.
   public func size() : async Nat64 {

--- a/doc/md/examples/StableRegistry.mo
+++ b/doc/md/examples/StableRegistry.mo
@@ -2,11 +2,11 @@ import Text "mo:base/Text";
 import Map "mo:base/HashMap";
 import Iter "mo:base/Iter";
 
-actor Registry {
+persistent actor Registry {
 
-  stable var entries : [(Text, Nat)] = [];
+  var entries : [(Text, Nat)] = []; // implicitly `stable`
 
-  let map = Map.fromIter<Text,Nat>(
+  transient let map = Map.fromIter<Text,Nat>(
     entries.vals(), 10, Text.equal, Text.hash);
 
   public func register(name : Text) : async () {
@@ -14,7 +14,7 @@ actor Registry {
       case null  {
         map.put(name, map.size());
       };
-      case (?id) { };
+      case (?_) { };
     }
   };
 

--- a/doc/md/examples/WeatherActor.mo
+++ b/doc/md/examples/WeatherActor.mo
@@ -1,0 +1,18 @@
+persistent actor {
+  type TemperatureSeries = [Float];
+
+  class Weather(temperatures : TemperatureSeries) {
+    public func averageTemperature() : Float {
+      var sum = 0.0;
+      var count = 0.0;
+      for (value in temperatures.vals()) {
+        sum += value;
+        count += 1;
+      };
+      return sum / count;
+    };
+  };
+
+  var temperatures : TemperatureSeries = [30.0, 31.5, 29.2];
+  transient var weather = Weather(temperatures);
+};

--- a/doc/md/examples/count-v0.mo
+++ b/doc/md/examples/count-v0.mo
@@ -1,7 +1,7 @@
 import Debug "mo:base/Debug";
 
 actor Counter_v0 {
-  var state : Nat = 0;
+  var state : Nat = 0; // implicitly `transient`
 
   public func increment() : async () {
     state += 1;

--- a/doc/md/examples/count-v0transient.mo
+++ b/doc/md/examples/count-v0transient.mo
@@ -1,7 +1,7 @@
 import Debug "mo:base/Debug";
 
-persistent actor Counter_v1 {
-  var state : Nat = 0; // implicitly `stable`
+actor Counter_v0 {
+  transient var state : Nat = 0;
 
   public func increment() : async () {
     state += 1;

--- a/doc/md/examples/count-v1stable.mo
+++ b/doc/md/examples/count-v1stable.mo
@@ -1,7 +1,7 @@
 import Debug "mo:base/Debug";
 
-persistent actor Counter_v1 {
-  var state : Nat = 0; // implicitly `stable`
+actor Counter_v1 {
+  stable var state : Nat = 0;
 
   public func increment() : async () {
     state += 1;

--- a/doc/md/examples/count-v2.mo
+++ b/doc/md/examples/count-v2.mo
@@ -1,7 +1,7 @@
 import Debug "mo:base/Debug";
 
-actor Counter_v2 {
-  stable var state : Int = 0;
+persistent actor Counter_v2 {
+  var state : Int = 0; // implicitly `stable`
 
   public func increment() : async () {
     state += 1;

--- a/doc/md/examples/count-v3.mo
+++ b/doc/md/examples/count-v3.mo
@@ -1,5 +1,5 @@
-actor Counter_v3 {
-  stable var state : Int = 0;
+persistent actor Counter_v3 {
+  var state : Int = 0; // implicitly `stable`
 
   public func increment() : async () {
     state += 1;

--- a/doc/md/examples/count-v4.mo
+++ b/doc/md/examples/count-v4.mo
@@ -1,7 +1,7 @@
 import Float "mo:base/Float";
 
-actor Counter_v4 {
-  stable var state : Float = 0.0;
+persistent actor Counter_v4 {
+  var state : Float = 0.0; // implicitly `stable`
 
   public func increment() : async () {
     state += 0.5;

--- a/doc/md/examples/count-v5.mo
+++ b/doc/md/examples/count-v5.mo
@@ -1,9 +1,9 @@
 import Debug "mo:base/Debug";
 import Float "mo:base/Float";
 
-actor Counter_v5 {
-  stable var state : Int = 0;
-  stable var newState : Float = Float.fromInt(state);
+persistent actor Counter_v5 {
+  var state : Int = 0; // implicitly `stable`
+  var newState : Float = Float.fromInt(state); // implicitly `stable`
 
   public func increment() : async () {
     newState += 0.5;

--- a/doc/md/examples/count-v6.mo
+++ b/doc/md/examples/count-v6.mo
@@ -1,8 +1,8 @@
 import Debug "mo:base/Debug";
 import Float "mo:base/Float";
 
-actor Counter_v6 {
-  stable var newState : Float = 0.0;
+persistent actor Counter_v6 {
+  var newState : Float = 0.0; // implicitly `stable`
 
   public func increment() : async () {
     newState += 0.5;

--- a/doc/md/examples/counter-actor-sugar.mo
+++ b/doc/md/examples/counter-actor-sugar.mo
@@ -1,6 +1,6 @@
-actor Counter {
+persistent actor Counter {
 
-  var count = 0;
+  stable var count = 0;
 
   public func inc() : async () { count += 1 };
 

--- a/doc/md/examples/counter-actor.mo
+++ b/doc/md/examples/counter-actor.mo
@@ -1,4 +1,4 @@
-actor Counter {
+persistent actor Counter {
 
   var count = 0;
 

--- a/doc/md/examples/todo-error.mo
+++ b/doc/md/examples/todo-error.mo
@@ -82,7 +82,7 @@ public shared func markDoneException(id : TodoId) : async Seconds {
       todos.put(id, #done(now));
       secondsBetween(todo.opened, now)
     };
-    case (?(#done(time))) {
+    case (?(#done _)) {
       throw Error.reject("Already done")
     };
     case null {
@@ -144,7 +144,7 @@ public shared func doneTodo4(id : Todo.TodoId) : async Text {
   try {
     let seconds = await Todo.markDoneException(id);
     "Congrats! That took " # Int.toText(seconds) # " seconds.";
-  } catch (e) {
+  } catch _ {
     "Something went wrong.";
   }
 };

--- a/doc/md/examples/todo-error.mo
+++ b/doc/md/examples/todo-error.mo
@@ -5,148 +5,148 @@ import Time "mo:base/Time";
 import Result "mo:base/Result";
 import Error "mo:base/Error";
 
-actor Todo {
+persistent actor Todo {
 
-type Time = Int;
-type Seconds = Int;
+  type Time = Int;
+  type Seconds = Int;
 
-func secondsBetween(start : Time, end : Time) : Seconds =
-  (end - start) / 1_000_000_000;
+  func secondsBetween(start : Time, end : Time) : Seconds =
+    (end - start) / 1_000_000_000;
 
-public type TodoId = Nat;
+  public type TodoId = Nat;
 
-type Todo = { #todo : { text : Text; opened : Time }; #done : Time };
-type TodoMap = Map.HashMap<TodoId, Todo>;
+  type Todo = { #todo : { text : Text; opened : Time }; #done : Time };
+  type TodoMap = Map.HashMap<TodoId, Todo>;
 
-var idGen : TodoId = 0;
-let todos : TodoMap = Map.HashMap(32, Int.equal, Hash.hash);
+  var idGen : TodoId = 0;
+  transient let todos : TodoMap = Map.HashMap(32, Int.equal, Hash.hash);
 
-private func nextId() : TodoId {
-  let id = idGen;
-  idGen += 1;
-  id
-};
-
-/// Creates a new todo and returns its id
-public shared func newTodo(txt : Text) : async TodoId {
-  let id = nextId();
-  let now = Time.now();
-  todos.put(id, #todo({ text = txt; opened = now }));
-  id
-};
-
-public shared func markDoneBad(id : TodoId) : async Seconds {
-  switch (todos.get(id)) {
-    case (?(#todo(todo))) {
-      let now = Time.now();
-      todos.put(id, #done(now));
-      secondsBetween(todo.opened, now)
-    };
-    case _ { -1 };
-  }
-};
-
-public shared func markDoneOption(id : TodoId) : async ?Seconds {
-  switch (todos.get(id)) {
-    case (?(#todo(todo))) {
-      let now = Time.now();
-      todos.put(id, #done(now));
-      ?(secondsBetween(todo.opened, now))
-    };
-    case _ { null };
-  }
-};
-
-public type TodoError = { #notFound; #alreadyDone : Time };
-
-public shared func markDoneResult(id : TodoId) : async Result.Result<Seconds, TodoError> {
-  switch (todos.get(id)) {
-    case (?(#todo(todo))) {
-      let now = Time.now();
-      todos.put(id, #done(now));
-      #ok(secondsBetween(todo.opened, now))
-    };
-    case (?(#done(time))) {
-      #err(#alreadyDone(time))
-    };
-    case null {
-      #err(#notFound)
-    };
-  }
-};
-
-public shared func markDoneException(id : TodoId) : async Seconds {
-  switch (todos.get(id)) {
-    case (?(#todo(todo))) {
-      let now = Time.now();
-      todos.put(id, #done(now));
-      secondsBetween(todo.opened, now)
-    };
-    case (?(#done _)) {
-      throw Error.reject("Already done")
-    };
-    case null {
-      throw Error.reject("Not Found")
-    };
-  }
-};
-
-};
-
-actor TodoCaller {
-
-type Time = Int;
-type Seconds = Int;
-
-func secondsBetween(start : Time, end : Time) : Seconds =
-  (end - start) / 1_000_000_000;
-
-public shared func mkTodo() : async Todo.TodoId {
-  await Todo.newTodo("Write error handling tutorial")
-};
-
-public shared func doneTodo1(id : Todo.TodoId) : async Text {
-  let seconds = await Todo.markDoneBad(id);
-  if (seconds != -1) {
-    "Congrats! That took " # Int.toText(seconds) # " seconds.";
-  } else {
-    "Something went wrong.";
+  private func nextId() : TodoId {
+    let id = idGen;
+    idGen += 1;
+    id
   };
+
+  /// Creates a new todo and returns its id
+  public shared func newTodo(txt : Text) : async TodoId {
+    let id = nextId();
+    let now = Time.now();
+    todos.put(id, #todo({ text = txt; opened = now }));
+    id
+  };
+
+  public shared func markDoneBad(id : TodoId) : async Seconds {
+    switch (todos.get(id)) {
+      case (?(#todo(todo))) {
+        let now = Time.now();
+        todos.put(id, #done(now));
+        secondsBetween(todo.opened, now)
+      };
+      case _ { -1 };
+    }
+  };
+
+  public shared func markDoneOption(id : TodoId) : async ?Seconds {
+    switch (todos.get(id)) {
+      case (?(#todo(todo))) {
+        let now = Time.now();
+        todos.put(id, #done(now));
+        ?(secondsBetween(todo.opened, now))
+      };
+      case _ { null };
+    }
+  };
+
+  public type TodoError = { #notFound; #alreadyDone : Time };
+
+  public shared func markDoneResult(id : TodoId) : async Result.Result<Seconds, TodoError> {
+    switch (todos.get(id)) {
+      case (?(#todo(todo))) {
+        let now = Time.now();
+        todos.put(id, #done(now));
+        #ok(secondsBetween(todo.opened, now))
+      };
+      case (?(#done(time))) {
+        #err(#alreadyDone(time))
+      };
+      case null {
+        #err(#notFound)
+      };
+    }
+  };
+
+  public shared func markDoneException(id : TodoId) : async Seconds {
+    switch (todos.get(id)) {
+      case (?(#todo(todo))) {
+        let now = Time.now();
+        todos.put(id, #done(now));
+        secondsBetween(todo.opened, now)
+      };
+      case (?(#done _)) {
+        throw Error.reject("Already done")
+      };
+      case null {
+        throw Error.reject("Not Found")
+      };
+    }
+  };
+
 };
 
-public shared func doneTodo2(id : Todo.TodoId) : async Text {
-  switch (await Todo.markDoneOption(id)) {
-    case null {
-      "Something went wrong."
-    };
-    case (?seconds) {
-      "Congrats! That took " # Int.toText(seconds) # " seconds."
+persistent actor TodoCaller {
+
+  type Time = Int;
+  type Seconds = Int;
+
+  func secondsBetween(start : Time, end : Time) : Seconds =
+    (end - start) / 1_000_000_000;
+
+  public shared func mkTodo() : async Todo.TodoId {
+    await Todo.newTodo("Write error handling tutorial")
+  };
+
+  public shared func doneTodo1(id : Todo.TodoId) : async Text {
+    let seconds = await Todo.markDoneBad(id);
+    if (seconds != -1) {
+      "Congrats! That took " # Int.toText(seconds) # " seconds.";
+    } else {
+      "Something went wrong.";
     };
   };
-};
 
-public shared func doneTodo3(id : Todo.TodoId) : async Text {
-  switch (await Todo.markDoneResult(id)) {
-    case (#err(#notFound)) {
-      "There is no Todo with that ID."
-    };
-    case (#err(#alreadyDone(at))) {
-      let doneAgo = secondsBetween(at, Time.now());
-      "You've already completed this todo " # Int.toText(doneAgo) # " seconds ago."
-    };
-    case (#ok(seconds)) {
-      "Congrats! That took " # Int.toText(seconds) # " seconds."
+  public shared func doneTodo2(id : Todo.TodoId) : async Text {
+    switch (await Todo.markDoneOption(id)) {
+      case null {
+        "Something went wrong."
+      };
+      case (?seconds) {
+        "Congrats! That took " # Int.toText(seconds) # " seconds."
+      };
     };
   };
-};
 
-public shared func doneTodo4(id : Todo.TodoId) : async Text {
-  try {
-    let seconds = await Todo.markDoneException(id);
-    "Congrats! That took " # Int.toText(seconds) # " seconds.";
-  } catch _ {
-    "Something went wrong.";
-  }
-};
+  public shared func doneTodo3(id : Todo.TodoId) : async Text {
+    switch (await Todo.markDoneResult(id)) {
+      case (#err(#notFound)) {
+        "There is no Todo with that ID."
+      };
+      case (#err(#alreadyDone(at))) {
+        let doneAgo = secondsBetween(at, Time.now());
+        "You've already completed this todo " # Int.toText(doneAgo) # " seconds ago."
+      };
+      case (#ok(seconds)) {
+        "Congrats! That took " # Int.toText(seconds) # " seconds."
+      };
+    };
+  };
+
+  public shared func doneTodo4(id : Todo.TodoId) : async Text {
+    try {
+      let seconds = await Todo.markDoneException(id);
+      "Congrats! That took " # Int.toText(seconds) # " seconds.";
+    } catch _ {
+      "Something went wrong.";
+    }
+  };
 
 };

--- a/doc/md/examples/try-finally.mo
+++ b/doc/md/examples/try-finally.mo
@@ -1,18 +1,19 @@
 import Text "mo:base/Text";
-import Debug "mo:base/Debug"
+import Debug "mo:base/Debug";
 
-actor {
-    public func tryFunction() {
+persistent actor {
 
-        try {
-            func greetOptional(optionalName : ?Text) : Text =
-                switch optionalName {
-                    case null { "No name to be found." };
-                    case (?name) { "Hello, " # name # "!" };
-                };
-            assert greetOptional(?"Motoko") == "Motoko";
-        } finally {
-            Debug.print("Finally block executed");
-        }
+  public func tryFunction() {
+   try {
+      func greetOptional(optionalName : ?Text) : Text =
+        switch optionalName {
+          case null { "No name to be found." };
+          case (?name) { "Hello, " # name # "!" };
+        };
+       assert greetOptional(?"Motoko") == "Motoko";
+    } finally {
+       Debug.print("Finally block executed");
     }
+  }
+
 }

--- a/doc/md/reference/language-manual.md
+++ b/doc/md/reference/language-manual.md
@@ -1314,7 +1314,7 @@ Any identifier bound by a `public` declaration appears in the type of enclosing 
 An identifier bound by a `private` or `system` declaration is excluded from the type of the enclosing object, module or actor and thus inaccessible.
 
 In a `persistent` actor or actor class, all declarations are implicitly `stable` unless explicitly declared otherwise.
-In a non-`persistent` actor or actor class, all declarations are implicitly `flexible` (equivalently `transient`) unless explicitly declared otherwise.
+In a non-`persistent` actor or actor class, all declarations are implicitly `transient` (equivalently `flexible`) unless explicitly declared otherwise.
 
 The declaration field has type `T` provided:
 
@@ -1324,7 +1324,7 @@ The declaration field has type `T` provided:
 
 -   If `<stab>?` is absent and the actor or actor class is `persistent`, then `T` must be a stable type (see [stability](#stability)).
 
-Actor fields declared `flexible` or `transient` can have any type, but will not be preserved across upgrades.
+Actor fields declared `transient` (or legacy `flexible`) can have any type, but will not be preserved across upgrades.
 
 Sequences of declaration fields are evaluated in order by evaluating their constituent declarations, with the following exception:
 

--- a/doc/md/reference/language-manual.md
+++ b/doc/md/reference/language-manual.md
@@ -1805,7 +1805,7 @@ Note `<shared-pat>?` must not be of the form `shared <query> <pat>?`: a construc
 
 An absent `<shared-pat>?` defaults to `shared` when `<sort>` = `persistent? actor`.
 
-If `sort` is `persisent? actor`, then:
+If `sort` is `persistent? actor`, then:
 
 -   `<typ-args>?` must be absent or empty, such that `actor` classes cannot have type parameters.
 

--- a/doc/md/reference/language-manual.md
+++ b/doc/md/reference/language-manual.md
@@ -92,9 +92,9 @@ The following keywords are reserved and may not be used as identifiers:
 
 actor and assert async async* await await* break case catch class
 composite continue debug debug_show do else false flexible finally for
-from_candid func if ignore import in module not null object or label
+from_candid func if ignore import in module not null persistent object or label
 let loop private public query return shared stable switch system throw
-to_candid true try type var while with
+to_candid true transient try type var while with
 ```
 
 ### Identifiers
@@ -415,6 +415,11 @@ The syntax of a declaration is as follows:
 <class-body> ::=         Class body
   = <id>? <obj-body>      Object body, optionally binding <id> to 'this' instance
   <obj-body>              Object body
+
+<sort> ::=
+   persistent? actor
+   module
+   object
 ```
 
 The syntax of a shared function qualifier with call-context pattern is as follows:
@@ -441,6 +446,7 @@ For `<shared-pat>`, an absent `<pat>?` is shorthand for the wildcard pattern `_`
 <stab> ::=                                     field stability (actor only)
   stable
   flexible
+  transient                                      (equivalent to flexible)
 ```
 
 The **visibility** qualifier `<vis>?` determines the accessibility of every field `<id>` declared by `<dec>`:
@@ -457,7 +463,10 @@ The **visibility** qualifier `<vis>?` determines the accessibility of every fiel
 
 The **stability** qualifier `<stab>` determines the **upgrade** behavior of actor fields:
 
--   A stability qualifier should appear on `let` and `var` declarations that are actor fields. An absent stability qualifier defaults to `flexible`.
+-   A stability qualifier should appear on `let` and `var` declarations that are actor fields.
+    Within a `persistent` actor or actor class, an absent stability qualifier defaults to `stable`.
+    Within a non-`persistent` actor or actor class, an absent stability qualifier defaults to `flexible` (or `transient`).
+    The keywords `transient` and `flexible` are interchangeable.
 
 -   `<stab>` qualifiers must not appear on fields of objects or modules.
 
@@ -567,7 +576,7 @@ Type expressions are used to specify the types of arguments, constraints on type
 ``` bnf
 <typ> ::=                                     Type expressions
   <path> <type-typ-args>?                       Constructor
-  <sort>? { <typ-field>;* }                     Object
+  <typ-sort>? { <typ-field>;* }                 Object
   { <typ-tag>;* }                               Variant
   { # }                                         Empty variant
   [ var? <typ> ]                                Array
@@ -584,7 +593,8 @@ Type expressions are used to specify the types of arguments, constraints on type
   Error                                         Errors/exceptions
   ( <typ> )                                     Parenthesized type
 
-<sort> ::= (actor | module | object)
+
+<typ-sort> ::= (actor | module | object)
 
 <shared> ::=                                 Shared function type qualifier
   shared <query>?
@@ -785,13 +795,13 @@ Though typically a type identifier, more generally, `<path>` may be a `.`-separa
 
 ### Object types
 
-`<sort>? { <typ-field>;* }` specifies an object type by listing its zero or more named **type fields**.
+`<typ-sort>? { <typ-field>;* }` specifies an object type by listing its zero or more named **type fields**.
 
 Within an object type, the names of fields must be distinct both by name and hash value.
 
 Object types that differ only in the ordering of the fields are equivalent.
 
-When `<sort>?` is `actor`, all fields have `shared` function type for specifying messages.
+When `<typ-sort>?` is `actor`, all fields have `shared` function type for specifying messages.
 
 ### Variant types
 
@@ -1041,9 +1051,9 @@ Two types `T`, `U` are related by subtyping, written `T <: U`, whenever, one of 
 
 -   `T` is a future `async V`, `U` is a future `async W`, and `V <: W`.
 
--   `T` is an object type `<sort0> { fts0 }`, `U` is an object type `<sort1> { fts1 }` and
+-   `T` is an object type `<typ-sort0> { fts0 }`, `U` is an object type `<typ-sort1> { fts1 }` and
 
-    -   `<sort0>` == `<sort1>`, and, for all fields,
+    -   `<typ-sort0>` == `<typ-sort1>`, and, for all fields,
 
     -   If field `id : W` is in `fts1` then `id : V` is in `fts0` and `V <: W`, and
 
@@ -1303,13 +1313,18 @@ Any identifier bound by a `public` declaration appears in the type of enclosing 
 
 An identifier bound by a `private` or `system` declaration is excluded from the type of the enclosing object, module or actor and thus inaccessible.
 
+In a `persistent` actor or actor class, all declarations are implicitly `stable` unless explicitly declared otherwise.
+In a non-`persistent` actor or actor class, all declarations are implicitly `flexible` (equivalently `transient`) unless explicitly declared otherwise.
+
 The declaration field has type `T` provided:
 
 -   `<dec>` has type `T`.
 
--   If `<stab>?` is `stable` then `T` must be a stable type (see [stability](#stability)).
+-   If `<stab>?` is `stable`  then `T` must be a stable type (see [stability](#stability)).
 
-Actor fields declared `flexible`, implicitly or explicitly, can have any type, but will not be preserved across upgrades.
+-   If `<stab>?` is absent and the actor or actor class is `persistent`, then `T` must be a stable type (see [stability](#stability)).
+
+Actor fields declared `flexible` or `transient` can have any type, but will not be preserved across upgrades.
 
 Sequences of declaration fields are evaluated in order by evaluating their constituent declarations, with the following exception:
 
@@ -1323,7 +1338,8 @@ Sequences of declaration fields are evaluated in order by evaluating their const
 
     - Every stable identifier declared with type `T` in the retired actor and declared stable and of type `U` in the replacement actor, must satisfy `T <: U`.
 
-This condition ensures that every stable variable is either fresh, requiring initialization, or its value can be safely inherited from the retired actor. Note that stable variables may be removed across upgrades, or may simply be deprecated by an upgrade to type `Any`.
+This condition ensures that every stable variable is either fresh, requiring initialization, or its value can be safely inherited from the retired actor.
+Note that stable variables may be removed across upgrades, or may simply be deprecated by an upgrade to type `Any`.
 
 #### System fields
 
@@ -1349,8 +1365,11 @@ The declaration `<dec>` of a `system` field must be a manifest `func` declaratio
 -   `postupgrade`: When declared, is called during an upgrade, immediately after the replacement actor body has initialized its fields, inheriting values of the retired actors' stable variables, and before its first message is processed. Its `<system>` type parameter is implicitly assumed and need not be declared.
 
 :::danger
-Using the pre- and post-upgrade system methods is discouraged. It is error-prone and can render a canister unusable. In particular, if a `preupgrade` method traps and cannot be prevented from trapping by other means, then your canister may be left in a state in which it can no longer be upgraded. 
+
+Using the pre- and post-upgrade system methods is discouraged. It is error-prone and can render a canister unusable.
+In particular, if a `preupgrade` method traps and cannot be prevented from trapping by other means, then your canister may be left in a state in which it can no longer be upgraded.
 Per best practices, using these methods should be avoided if possible.
+
 :::
 
 These `preupgrade` and `postupgrade` system methods provide the opportunity to save and restore in-flight data structures, e.g. caches, that are better represented using non-stable types.
@@ -1454,7 +1473,7 @@ Object patterns support punning for concision. A punned field `<id>` is shorthan
 
 Pattern matching fails if one of the pattern fields fails to match the corresponding field value of the object value. Pattern matching succeeds if every pattern field matches the corresponding named field of the object value. The binding returned by a successful match is the union of the bindings returned by the field matches.
 
-The `<sort>` of the matched object type must be determined by an enclosing type annotation or other contextual type information.
+The `<typ-sort>` of the matched object type must be determined by an enclosing type annotation or other contextual type information.
 
 ### Variant pattern
 
@@ -1640,11 +1659,12 @@ A similar looking definition that recursively instantiates `Seq` with a larger t
 
 Declaration `<sort> <id>? (: <typ>)? =? <obj-body>`, where `<obj-body>` is of the form `{ <dec-field>;* }`, declares an object with optional identifier `<id>` and zero or more fields `<dec-field>;*`. Fields can be declared with `public` or `private` visibility; if the visibility is omitted, it defaults to `private`.
 
-The qualifier `<sort>` (one of `actor`, `module` or `object`) specifies the *sort* of the object’s type. The sort imposes restrictions on the types of the public object fields.
+The qualifier `<sort>` (one of `persistent? actor`, `module` or `object`) specifies the `<typ-sort>` of the object’s type (`actor`, `module` or `object`, respectively).
+The sort imposes restrictions on the types of the public object fields.
 
-Let `T = <sort> { [var0] id0 : T0, …​ , [varn] idn : T0 }` denote the type of the object. Let `<dec>;*` be the sequence of declarations embedded in `<dec-field>;*`. The object declaration has type `T` provided that:
+Let `T = <typ-sort> { [var0] id0 : T0, …​ , [varn] idn : T0 }` denote the type of the object. Let `<dec>;*` be the sequence of declarations embedded in `<dec-field>;*`. The object declaration has type `T` provided that:
 
-1.  Type `T` is well-formed for sort `sort`, and
+1.  Type `T` is well-formed for sort `<typ-sort>`, and
 
 2.  Under the assumption that `<id> : T`,
 
@@ -1662,7 +1682,7 @@ Note that the first requirement imposes further constraints on the field types o
 
 Because actor construction is asynchronous, an actor declaration can only occur in an asynchronous context, i.e. in the body of a non-`<query>` `shared` function, `async` expression or `async*` expression.
 
-Evaluation of `<sort>? <id>? =? { <dec-field>;* }` proceeds by binding `<id>`, if present, to the eventual value `v`, and evaluating the declarations in `<dec>;*`. If the evaluation of `<dec>;*` traps, so does the object declaration. Otherwise, `<dec>;*` produces a set of bindings for identifiers in `Id`. let `v0`, …​, `vn` be the values or locations bound to identifiers `<id0>`, …​, `<idn>`. The result of the object declaration is the object `v == sort { <id0> = v1, …​, <idn> = vn}`.
+Evaluation of `<sort>? <id>? =? { <dec-field>;* }` proceeds by binding `<id>`, if present, to the eventual value `v`, and evaluating the declarations in `<dec>;*`. If the evaluation of `<dec>;*` traps, so does the object declaration. Otherwise, `<dec>;*` produces a set of bindings for identifiers in `Id`. let `v0`, …​, `vn` be the values or locations bound to identifiers `<id0>`, …​, `<idn>`. The result of the object declaration is the object `v == <typ-sort> { <id0> = v1, …​, <idn> = vn}`.
 
 If `<id>?` is present, the declaration binds `<id>` to `v`. Otherwise, it produces the empty set of bindings.
 
@@ -1769,7 +1789,7 @@ The class declaration `<shared-pat>? <sort>? class <id>? <typ-params>? <pat> (: 
 
 where:
 
--   `<shared-pat>?`, when present, requires `<sort>` == `actor`, and provides access to the `caller` of an `actor` constructor, and
+-   `<shared-pat>?`, when present, requires `<sort>` == `persistent? actor`, and provides access to the `caller` of an `actor` constructor, and
 
 -   `<typ-args>?` and `<type-typ-params>?` is the sequence of type identifiers bound by `<typ-params>?`, if any, and
 
@@ -1779,13 +1799,13 @@ where:
 
 -   `<id_this>?` is the optional **this** or **self** parameter of `<class-body>`.
 
--   `async?` is present, if only if, `<sort>` == `actor`.
+-   `async?` is present, if only if, `<sort>` == `persistent? actor`.
 
 Note `<shared-pat>?` must not be of the form `shared <query> <pat>?`: a constructor, unlike a function, cannot be a `query` or `composite query`.
 
-An absent `<shared-pat>?` defaults to `shared` when `sort` = `actor`.
+An absent `<shared-pat>?` defaults to `shared` when `<sort>` = `persistent? actor`.
 
-If `sort` is `actor`, then:
+If `sort` is `persisent? actor`, then:
 
 -   `<typ-args>?` must be absent or empty, such that `actor` classes cannot have type parameters.
 
@@ -1793,7 +1813,7 @@ If `sort` is `actor`, then:
 
 -   `(: <typ>)?`, if present, must be of the form `: async T` for some actor type `T`. Actor instantiation is asynchronous.
 
-If `(: <typ>)` is present, then the type `<async?> <sort> {  <typ_field>;* }` must be a subtype of the annotation `<typ>`. In particular, the annotation is used only to check, but not affect, the inferred type of function `<id>`.
+If `(: <typ>)` is present, then the type `<async?> <typ-sort> {  <typ_field>;* }` must be a subtype of the annotation `<typ>`. In particular, the annotation is used only to check, but not affect, the inferred type of function `<id>`. `<typ-sort>` is just `<sort>` erasing any `persistent?` modifier.
 
 The class declaration has the same type as function `<id>` and evaluates to the function value `<id>`.
 

--- a/doc/md/writing-motoko/arguments.md
+++ b/doc/md/writing-motoko/arguments.md
@@ -13,10 +13,10 @@ Arguments can be passed to an actor's function for the function to use as input.
 First, define an argument that has a `location` function and the `name` argument with a `city` argument:
 
 ```motoko
-actor {
-public func location(city : Text) : async Text {
+persistent actor {
+  public func location(city : Text) : async Text {
     return "Hello, " # city # "!";
-};
+  };
 };
 ```
 
@@ -33,19 +33,19 @@ You might want to try modifying the source code to return different results. For
 Revise the `location` function with two new functions:
 
 ```motoko
-actor {
+persistent actor {
 
-public func location(cities : [Text]) : async Text {
+  public func location(cities : [Text]) : async Text {
     return "Hello, from " # (debug_show cities) # "!";
-};
+  };
 
-public func location_pretty(cities : [Text]) : async Text {
+  public func location_pretty(cities : [Text]) : async Text {
     var str = "Hello from ";
     for (city in cities.vals()) {
         str := str # city # ", ";
     };
     return str # "bon voyage!";
-}
+  }
 };
 
 ```

--- a/doc/md/writing-motoko/async-star.md
+++ b/doc/md/writing-motoko/async-star.md
@@ -24,7 +24,7 @@ Though this can work, it has some overhead and pitfalls:
 Consider the following code that does some logging to a remote canister.
 
 ``` motoko
-actor class (Logger : actor { log : Text -> async () }) {
+persistent actor class (Logger : actor { log : Text -> async () }) {
 
   var logging = true;
 
@@ -42,7 +42,7 @@ The `maybeLog` function needs to be asynchronous because communicating with the 
 
 
 ``` motoko
-actor class (Logger : actor { log : Text -> async () }) {
+persistent actor class (Logger : actor { log : Text -> async () }) {
 
   var logging = true;
 
@@ -66,7 +66,7 @@ A safer refactoring passes the current state of the `logging` variable with each
 
 
 ``` motoko
-actor class (Logger : actor { log : Text -> async () }) {
+persistent actor class (Logger : actor { log : Text -> async () }) {
 
   var logging = true;
 
@@ -102,7 +102,7 @@ To compute the result of an `async*` computation, you just use an `await*`.
 Here's how we can refactor our original class to be clearer, efficient and have the same meaning, using computations instead of futures:
 
 ``` motoko
-actor class (Logger : actor { log : Text -> async () }) {
+persistent actor class (Logger : actor { log : Text -> async () }) {
 
   var logging = true;
 

--- a/doc/md/writing-motoko/candid.md
+++ b/doc/md/writing-motoko/candid.md
@@ -87,7 +87,7 @@ In this example, we use the imported `call` function to make a dynamic call on t
 import Principal "mo:base/Principal";
 import {call} "mo:base/ExperimentalInternetComputer";
 
-actor This {
+persistent actor This {
 
    public func concat(ts : [Text]) : async Text {
       var r = "";

--- a/doc/md/writing-motoko/integers.md
+++ b/doc/md/writing-motoko/integers.md
@@ -36,33 +36,7 @@ To illustrate working with numbers, here is an example calculator program that c
 
 ## Using integers
 
-```motoko
-// This single-cell calculator defines one calculator instruction per
-// public entry point (add, sub, mul, div).
-
-// Create a simple Calc actor.
-actor Calc {
-  var cell : Int = 0;
-
-  // Define functions to add, subtract, multiply, and divide
-  public func add(n:Int) : async Int { cell += n; cell };
-  public func sub(n:Int) : async Int { cell -= n; cell };
-  public func mul(n:Int) : async Int { cell *= n; cell };
-  public func div(n:Int) : async ?Int {
-    if ( n == 0 ) {
-      return null // null indicates div-by-zero error
-    } else {
-      cell /= n; ?cell
-    }
-  };
-
-  // Clear the calculator and reset to zero
-  public func clearall() : async Int {
-    if (cell : Int != 0)
-      cell -= cell;
-    return cell
-  };
- };
+```motoko file=../examples/Calc.mo
 ```
 
 You might notice that this sample code uses integer ([`Int`](../base/Int.md)) data types, enabling you to use positive or negative numbers. If you wanted to restrict the functions in this calculator code to only use positive numbers, you could change the data type to only allow natural ([`Nat`](../base/Nat.md)) data.

--- a/doc/md/writing-motoko/intercanister-calls.md
+++ b/doc/md/writing-motoko/intercanister-calls.md
@@ -21,10 +21,12 @@ Consider the following code for `Canister1`:
 ```motoko no-repl
 import Canister2 "canister:canister2";
 
-actor Canister1 {
-    public func main() : async Nat {
-        return await Canister2.getValue();
-    };
+persistent actor Canister1 {
+
+  public func main() : async Nat {
+    return await Canister2.getValue();
+  };
+
 };
 ```
 
@@ -33,11 +35,11 @@ Then, consider the following code for `Canister2`:
 ```motoko
 import Debug "mo:base/Debug";
 
-actor Canister2 {
-    public func getValue() : async Nat {
-        Debug.print("Hello from canister 2!");
-        return 10;
-    };
+persistent actor Canister2 {
+  public func getValue() : async Nat {
+    Debug.print("Hello from canister 2!");
+    return 10;
+  };
 };
 ```
 
@@ -58,11 +60,13 @@ The output should resemble the following:
 Alternatively, you can also use a canister id to access a previously deployed canister by using the following piece of code in `canister1`:
 
 ```motoko
-actor {
-    public func main(canisterId: Text) : async Nat {
-        let canister2 = actor(canisterId): actor { getValue: () -> async Nat };
-        return await canister2.getValue();
-    };
+persistent actor {
+
+  public func main(canisterId: Text) : async Nat {
+    let canister2 = actor(canisterId): actor { getValue: () -> async Nat };
+    return await canister2.getValue();
+  };
+
 };
 ```
 
@@ -82,7 +86,7 @@ Here is an example which you can modify for your specific use case:
 import IC "mo:base/ExperimentalInternetComputer";
 import Debug "mo:base/Debug";
 
-actor AdvancedCanister1 {
+persistent actor AdvancedCanister1 {
   public func main(canisterId : Principal) : async Nat {
     // Define the method name and input args
     let name = "getValue";
@@ -103,11 +107,13 @@ actor AdvancedCanister1 {
 ```motoko
 import Debug "mo:base/Debug";
 
-actor AdvancedCanister2 {
-    public func getValue(number: Nat) : async Nat {
-        Debug.print("Hello from advanced canister 2!");
-        return number * 2;
-    };
+persistent actor AdvancedCanister2 {
+
+  public func getValue(number: Nat) : async Nat {
+     Debug.print("Hello from advanced canister 2!");
+     return number * 2;
+  };
+
 };
 ```
 

--- a/doc/md/writing-motoko/local-objects-classes.md
+++ b/doc/md/writing-motoko/local-objects-classes.md
@@ -175,7 +175,8 @@ For example, you can write a `Counter` class that takes an argument of type `Nat
 ``` motoko no-repl
 import Nat "mo:base/Nat";
 
-actor {
+persistent actor {
+
   class Counter(init : Nat, flag : Bool) {
     var c = init;
     var f = flag;
@@ -186,6 +187,7 @@ actor {
       return c;
     };
   };
+
 }
 ```
 

--- a/doc/md/writing-motoko/message-inspection.md
+++ b/doc/md/writing-motoko/message-inspection.md
@@ -81,12 +81,12 @@ Declining anonymous calls:
 
 Declining large messages, based on the raw size in bytes of `arg` prior to any decoding from Candid binary blob to Motoko value:
 
-``` motoko no-repl file=../examples/InspectArg.mo#L12-L14
+``` motoko no-repl file=../examples/InspectArg.mo#L10-L13
 ```
 
 Declining messages by name only, ignoring message arguments. Note the use of type `Any` as message argument variants:
 
-``` motoko no-repl file=../examples/InspectName.mo#L12-L25
+``` motoko no-repl file=../examples/InspectName.mo#L10-L23
 ```
 
 A combination of the previous three, specifying the argument types of some variants while ignoring others at type `Any` and using pattern matching to conflate identical cases:
@@ -100,7 +100,7 @@ Implementing `inspect` after the fact once all shared functions of an actor have
 
 For example, in the actor from the previous section, incorrectly declaring forces the compiler to report the expected type below, which you can then cut-and-paste into your code:
 
-``` motoko no-repl file=../examples/InspectTrick.mo#L12-L14
+``` motoko no-repl file=../examples/InspectTrick.mo#L11-L13
 ```
 
 ``` motoko no-repl

--- a/doc/md/writing-motoko/randomness.md
+++ b/doc/md/writing-motoko/randomness.md
@@ -23,79 +23,7 @@ The Random module features a class called `Finite` and a `*From` method. These c
 
 To demonstrate randomness, consider the following example that shuffles a deck of cards then returns the cards in their shuffled order. The code is annotated with additional information:
 
-```motoko
-// Import the necessary modules, including the Random module:
-import Random = "mo:base/Random";
-import Char = "mo:base/Char";
-import Error = "mo:base/Error";
-
-// Define an actor
-
-persistent actor {
-
-  // Define a stable variable that contains each card as a unicode character:
-  var deck : ?[var Char] = ?[var
-    '🂡','🂢','🂣','🂤','🂥','🂦','🂧','🂨','🂩','🂪','🂫','🂬','🂭','🂮',
-    '🂱','🂲','🂳','🂴','🂵','🂶','🂷','🂸','🂹','🂺','🂻','🂼','🂽','🂾',
-    '🃁','🃂','🃃','🃄','🃅','🃆','🃇','🃈','🃉','🃊','🃋','🃌','🃍','🃎',
-    '🃑','🃒','🃓','🃔','🃕','🃖','🃗','🃘','🃙','🃚','🃛','🃜','🃝','🃞',
-    '🃏'
-  ];
-
-  func bit(b : Bool) : Nat {
-    if (b) 1 else 0;
-  };
-
-  // Use a finite source of randomness defined as `f`.
-  // Return an optional random number between [0..`max`) using rejection sampling.
-  // A return value of `null` indicates that `f` is exhausted and should be replaced.
-  func chooseMax(f : Random.Finite, max : Nat) : ? Nat {
-    assert max > 0;
-    do ? {
-      var n = max - 1 : Nat;
-      var k = 0;
-      while (n != 0) {
-        k *= 2;
-        k += bit(f.coin()!);
-        n /= 2;
-      };
-      if (k < max) k else chooseMax(f, max)!;
-    };
-  };
-
-  // Define a function to shuffle the cards using `Random.Finite`.
-  public func shuffle() : async () {
-    let ?cards = deck else throw Error.reject("shuffle in progress");
-    deck := null;
-    var f = Random.Finite(await Random.blob());
-    var i : Nat = cards.size() - 1;
-    while (i > 0) {
-      switch (chooseMax(f, i + 1)) {
-        case (?j) {
-          let temp = cards[i];
-          cards[i] := cards[j];
-          cards[j] := temp;
-          i -= 1;
-        };
-        case null { // need more entropy
-          f := Random.Finite(await Random.blob());
-        }
-      }
-    };
-    deck := ?cards;
-  };
-
-  // Define a function to display the randomly shuffled cards.
-  public query func show() : async Text {
-    let ?cards = deck else throw Error.reject("shuffle in progress");
-    var t = "";
-    for (card in cards.vals()) {
-       t #= Char.toText(card);
-    };
-    return t;
-  }
-
-};
+```motoko file=../examples/CardShuffle.mo
 ```
 
 View this example on the [Motoko Playground](https://play.motoko.org/?tag=2675232834) or on [GitHub](https://github.com/crusso/card-shuffle/blob/main/src/cards_backend/main.mo).
@@ -112,17 +40,7 @@ When its current supply of bits is exhausted, the code asynchronously requests a
 
 Alternatively, you can use randomness by calling the management canister's `raw_rand` endpoint:
 
-```motoko
-actor {
-  let SubnetManager : actor {
-    raw_rand() : async Blob;
-  } = actor "aaaaa-aa";
-
-  public func random_bytes() : async Blob {
-    let bytes = await SubnetManager.raw_rand();
-    return bytes;
-  };
-};
+```motoko file=../examples/RawRand.mo
 ```
 
 ## Resources

--- a/doc/md/writing-motoko/randomness.md
+++ b/doc/md/writing-motoko/randomness.md
@@ -31,10 +31,10 @@ import Error = "mo:base/Error";
 
 // Define an actor
 
-actor {
+persistent actor {
 
   // Define a stable variable that contains each card as a unicode character:
-  stable var deck : ?[var Char] = ?[var
+  var deck : ?[var Char] = ?[var
     '🂡','🂢','🂣','🂤','🂥','🂦','🂧','🂨','🂩','🂪','🂫','🂬','🂭','🂮',
     '🂱','🂲','🂳','🂴','🂵','🂶','🂷','🂸','🂹','🂺','🂻','🂼','🂽','🂾',
     '🃁','🃂','🃃','🃄','🃅','🃆','🃇','🃈','🃉','🃊','🃋','🃌','🃍','🃎',

--- a/doc/md/writing-motoko/writing-intro.md
+++ b/doc/md/writing-motoko/writing-intro.md
@@ -77,6 +77,17 @@ The `value` was declared `stable`, meaning the current state, *n*, of the servic
 
 The new interface is compatible with the previous one, allowing existing clients referencing the canister to continue to work. New clients will be able to exploit its upgraded functionality, in this example the additional `reset` function.
 
+To make it more convenient to declare stable variables, and to prevent missing
+`stable` declarations,
+Motoko let's you prefix the entire actor with the keyword `persistent`. In a `persistent` actor,
+all declarations are `stable` by default. Only declarations that are explicitly marked `transient` will be discarded on upgrade.
+
+``` motoko file=../examples/PersistentStableCounter.mo
+```
+
+In this example, `value` is now implicitly stable, while `invocations` is just a transient
+temporary that won't survive upgrades: it counts the number of calls to `inc` since installation.
+
 For scenarios that can’t be solved using stable variables alone, Motoko provides user-definable upgrade hooks that run immediately before and after an upgrade, allowing you to migrate arbitrary state to stable variables.
 
 ## Source code organization

--- a/doc/md/writing-motoko/writing-intro.md
+++ b/doc/md/writing-motoko/writing-intro.md
@@ -79,14 +79,14 @@ The new interface is compatible with the previous one, allowing existing clients
 
 To make it more convenient to declare stable variables, and to prevent missing
 `stable` declarations,
-Motoko let's you prefix the entire actor with the keyword `persistent`. In a `persistent` actor,
+Motoko allows you to prefix the entire actor with the keyword `persistent`. In a `persistent` actor,
 all declarations are `stable` by default. Only declarations that are explicitly marked `transient` will be discarded on upgrade.
 
 ``` motoko file=../examples/PersistentStableCounter.mo
 ```
 
 In this example, `value` is now implicitly stable, while `invocations` is just a transient
-temporary that won't survive upgrades: it counts the number of calls to `inc` since the first installation or last upgrade.
+temporary declaration that won't survive upgrades: it counts the number of calls to `inc` since the first installation or last upgrade.
 
 For scenarios that can’t be solved using stable variables alone, Motoko provides user-definable upgrade hooks that run immediately before and after an upgrade, allowing you to migrate arbitrary state to stable variables.
 

--- a/doc/md/writing-motoko/writing-intro.md
+++ b/doc/md/writing-motoko/writing-intro.md
@@ -86,7 +86,7 @@ all declarations are `stable` by default. Only declarations that are explicitly 
 ```
 
 In this example, `value` is now implicitly stable, while `invocations` is just a transient
-temporary that won't survive upgrades: it counts the number of calls to `inc` since installation.
+temporary that won't survive upgrades: it counts the number of calls to `inc` since the first installation or last upgrade.
 
 For scenarios that can’t be solved using stable variables alone, Motoko provides user-definable upgrade hooks that run immediately before and after an upgrade, allowing you to migrate arbitrary state to stable variables.
 


### PR DESCRIPTION
Builds on #4784 

* Documents the new `persistent` and `transient` keywords and updates all the examples. 

* Extracts some inline examples to files for checking with examples/check.sh

* Manually checked with doc/make preview

I think we've just introduced a new hazard: someone declares an implicitly stable variable and expects it to be re-initialized, but instead its previous value is re-used. 

For example:
```
shared(msg) persistent actor class C() {
 let installer = msg.caller
}
```
This only stores the first installer on initial install, not any of the subsequent installers...

Nothing is perfect I guess.



