### PR TITLE
experiment: mo-doc add option to strip comments

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -16,6 +16,9 @@ overview-slides.html : overview-slides.md
 	  # # -V minScale=2 \
 	  # # -V maxScale=2
 
+outline:
+	mo-doc --strip-comments --source $(MOTOKO_BASE) --output $(OUT)/outline --format plain
+
 base:
 	mo-doc --source $(MOTOKO_BASE) --output $(OUT)/base --format plain
 

--- a/src/docs/docs.mli
+++ b/src/docs/docs.mli
@@ -2,4 +2,4 @@ type output_format = Plain | Adoc | Html
 
 (** Generates documentation for all Motoko source files in the _input_ directory
  ** inside the _output_ directory using the specified _output format_. *)
-val start : output_format -> string -> string -> unit
+val start : output_format -> string -> string -> bool -> unit

--- a/src/docs/extract.ml
+++ b/src/docs/extract.ml
@@ -218,9 +218,10 @@ struct
     else None
 end
 
-let extract_docs : Syntax.prog -> (extracted, string) result =
- fun prog ->
-  let lookup_trivia (line, column) =
+let extract_docs : bool -> Syntax.prog -> (extracted, string) result =
+ fun skip_comments prog ->
+ let lookup_trivia (line, column) =
+    if skip_comments then None else
     PosTable.find_opt prog.note.Syntax.trivia Trivia.{ line; column }
   in
   let find_trivia (parser_pos : Source.region) : Trivia.trivia_info =

--- a/src/exes/mo_doc.ml
+++ b/src/exes/mo_doc.ml
@@ -1,6 +1,7 @@
 let source : string ref = ref "src"
 let output : string ref = ref "docs"
 let format : Docs.output_format ref = ref Docs.Html
+let strip_comments = ref false
 
 let set_source s = source := s
 let set_output o = output := o
@@ -21,6 +22,9 @@ let argspec = [
     ; "--format",
       Arg.String set_format,
       "<format>  specifies the generated format. One of `html`, `adoc`, or `plain` Defaults to `html`"
+    ; "--strip-comments",
+      Arg.Set strip_comments,
+      " ignore doc comments"
     ]
 
 let invalid s =
@@ -30,4 +34,4 @@ let invalid s =
 
 let () =
   Arg.parse argspec invalid usage;
-  Docs.start !format !source !output
+  Docs.start !format !source !output !strip_comments


### PR DESCRIPTION
To ease overview of API changes 


TODO:

- [ ] Use a global flag instead? Passing down the flag is a pain.