### PR TITLE
better grammar for parentheticals

### DIFF
--- a/doc/md/examples/grammar.txt
+++ b/doc/md/examples/grammar.txt
@@ -158,6 +158,9 @@
     '<>>='
     '@='
 
+<parenthetical> ::= 
+    '(' <exp_post>? 'with' <list(<exp_field>, ';')> ')'
+
 <exp_obj> ::= 
     '{' <list(<exp_field>, ';')> '}'
     '{' <exp_post> 'and' <exp_post> ('and' <exp_post>)* '}'
@@ -185,6 +188,7 @@
 
 <exp_un> ::= 
     <exp_post>
+    <parenthetical> <exp_post> <inst> <exp_nullary>
     '#' <id>
     '#' <id> <exp_nullary>
     '?' <exp_un>
@@ -210,7 +214,7 @@
     <exp_bin> ':=' <exp>
     <exp_bin> <binassign> <exp>
     'return' <exp>?
-    'async' <exp_nest>
+    <parenthetical>? 'async' <exp_nest>
     'async*' <exp_nest>
     'await' <exp_nest>
     'await*' <exp_nest>
@@ -219,7 +223,6 @@
     'break' <id> <exp_nullary>?
     'continue' <id>
     'debug' <exp_nest>
-    '(' <exp_post>? 'with' <list(<exp_field>, ';')> ')' <exp_nest>
     'if' <exp_nullary> <exp_nest>
     'if' <exp_nullary> <exp_nest> 'else' <exp_nest>
     'try' <exp_nest> <catch>

--- a/src/mo_frontend/printers.ml
+++ b/src/mo_frontend/printers.ml
@@ -152,6 +152,8 @@ let string_of_symbol = function
   | X (N N_dec_field) -> "<dec_field>"
   | X (N N_dec_nonvar) -> "<dec_nonvar>"
   | X (N N_dec_var) -> "<dec_var>"
+  | X (N N_parenthetical) -> "<parenthetical>"
+  | X (N N_option_parenthetical_) -> "<parenthetical>?"
   | X (N N_exp_bl_) -> "<exp(bl)>"
   | X (N N_exp_ob_) -> "<exp(ob)>"
   | X (N N_exp_bin_bl_) -> "<exp_bin(bl)>"

--- a/test/fail/ok/cycle-type.tc.ok
+++ b/test/fail/ok/cycle-type.tc.ok
@@ -6,9 +6,9 @@ cycle-type.mo:5.39-5.46: type error [M0050], literal of type
   Text
 does not have expected type
   Nat
-cycle-type.mo:7.23-7.32: warning [M0202], unexpected parenthetical note on a non-send call
-cycle-type.mo:7.23-7.32: warning [M0203], redundant empty parenthetical note
-cycle-type.mo:9.19-9.29: warning [M0203], redundant empty parenthetical note
+cycle-type.mo:7.16-7.22: warning [M0202], unexpected parenthetical note on a non-send call
+cycle-type.mo:7.16-7.22: warning [M0203], redundant empty parenthetical note
+cycle-type.mo:9.9-9.18: warning [M0203], redundant empty parenthetical note
 cycle-type.mo:10.31-10.34: type error [M0050], literal of type
   Char
 does not have expected type

--- a/test/fail/ok/syntax4.tc.ok
+++ b/test/fail/ok/syntax4.tc.ok
@@ -1,4 +1,5 @@
 syntax4.mo:1.1-1.2: syntax error [M0001], unexpected token '*', expected one of token or <phrase> sequence:
   <eof>
+  async <exp_nest>
   seplist(<dec>,<semicolon>) <eof>
   seplist(<imp>,<semicolon>) seplist(<dec>,<semicolon>) <eof>

--- a/test/fail/ok/syntax5.tc.ok
+++ b/test/fail/ok/syntax5.tc.ok
@@ -17,5 +17,5 @@ syntax5.mo:3.1: syntax error [M0001], unexpected end of input, expected one of t
   and <exp_bin(ob)>
   <unop> <exp_bin(ob)>
   <inst> <exp_nullary(ob)>
+  with seplist(<exp_field>,<semicolon>) )
   [ <exp(ob)> ]
-  with seplist(<exp_field>,<semicolon>) ) <exp_nest>

--- a/test/run-drun/ok/par.tc.ok
+++ b/test/run-drun/ok/par.tc.ok
@@ -1,1 +1,1 @@
-par.mo:56.9-56.67: warning [M0204], unrecognised attribute yeah in parenthetical note
+par.mo:55.15-55.59: warning [M0204], unrecognised attribute yeah in parenthetical note

--- a/test/run-drun/par.mo
+++ b/test/run-drun/par.mo
@@ -61,7 +61,7 @@ actor A {
     public func test2() : async () {
         debugPrint "test2()";
         await (with cycles = 1042) async { assert Cycles.available() == 1042 };
-        await (with cycles = 3042) (with cycles = 4042) async { assert Cycles.available() == 3042/*FIXME: WHY?*/ };
+        //await (with cycles = 3042) (with cycles = 4042) async { assert Cycles.available() == 3042/*FIXME: WHY?*/ };
     };
 
     public func test3() : async () {


### PR DESCRIPTION
This syntax won't allow repetition of parentheticals and only allow it on calls (sadly some duplication happens here) and `async` expressions. But I still think this is an improvement!