### PR TITLE
experiment: strip rts name section for reproducible builds

### DIFF
--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -699,6 +699,7 @@ let load_as_rts () =
     | _ -> assert false
   in
   let rts = Wasm_exts.CustomModuleDecode.decode "rts.wasm" (Lazy.force rts) in
+  (* strip name section for reproducible build *)
   Wasm_exts.CustomModule.{ rts with name = empty_name_section }
 
 type compile_result = (Idllib.Syntax.prog * Wasm_exts.CustomModule.extended_module) Diag.result

--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -698,7 +698,8 @@ let load_as_rts () =
     | (false, true, Flags.Incremental) -> Rts.wasm_incremental_debug
     | _ -> assert false
   in
-  Wasm_exts.CustomModuleDecode.decode "rts.wasm" (Lazy.force rts)
+  let rts = Wasm_exts.CustomModuleDecode.decode "rts.wasm" (Lazy.force rts) in
+  Wasm_exts.CustomModule.{ rts with name = empty_name_section }
 
 type compile_result = (Idllib.Syntax.prog * Wasm_exts.CustomModule.extended_module) Diag.result
 


### PR DESCRIPTION
Seems like most of the differences on mac and linux are just in the name section of the rts, apart from 2 functions that have swaped indices (to do with format! of floats, AFAICT)