### PR TITLE
chore: Update `CODEOWNERS` to omit review necessity on `Changelog.md`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
+Changelog.md
 * @dfinity/languages


### PR DESCRIPTION
Along the lines of https://github.com/orgs/community/discussions/23064#discussioncomment-8383923 mark `Changelog.md` as not owned. This means no review is necessary on it and it can be merged automatically