### PR TITLE
experiment: binary search for regression in `jsoo`

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -46,10 +46,10 @@ let
 
               # upgrade `js_of_ocaml(-compiler)` until we have figured out the bug related to 4.1.0 (which is in nixpkgs)
               js_of_ocaml-compiler = super.ocamlPackages.js_of_ocaml-compiler.overrideAttrs rec {
-                version = "5.0.1";
+                version = "5.4.0";
                 src = self.fetchurl {
                   url = "https://github.com/ocsigen/js_of_ocaml/releases/download/${version}/js_of_ocaml-${version}.tbz";
-                  sha256 = "sha256-eiEPHKFqdCOBlH3GfD2Nn0yU+/IHOHRLE1OJeYW2EGk=";
+                  sha256 = "sha256-8SFd4TOGf+/bFuJ5iiJe4ERkaaV0Yq8N7r3SLSqNO5Q=";
                 };
               };
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -46,10 +46,10 @@ let
 
               # upgrade `js_of_ocaml(-compiler)` until we have figured out the bug related to 4.1.0 (which is in nixpkgs)
               js_of_ocaml-compiler = super.ocamlPackages.js_of_ocaml-compiler.overrideAttrs rec {
-                version = "5.2.0";
+                version = "5.1.0";
                 src = self.fetchurl {
                   url = "https://github.com/ocsigen/js_of_ocaml/releases/download/${version}/js_of_ocaml-${version}.tbz";
-                  sha256 = "sha256-ZQqwpP+mpQVxa3OtspNCj6e/1qApM0m/GGEjM4p/zrU=";
+                  sha256 = "sha256-wXrRUHct9D/E5jzhuUGfI8ZBaWlaTMQWDu3LyPTUwEc=";
                 };
               };
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -46,10 +46,10 @@ let
 
               # upgrade `js_of_ocaml(-compiler)` until we have figured out the bug related to 4.1.0 (which is in nixpkgs)
               js_of_ocaml-compiler = super.ocamlPackages.js_of_ocaml-compiler.overrideAttrs rec {
-                version = "5.4.0";
+                version = "5.2.0";
                 src = self.fetchurl {
                   url = "https://github.com/ocsigen/js_of_ocaml/releases/download/${version}/js_of_ocaml-${version}.tbz";
-                  sha256 = "sha256-8SFd4TOGf+/bFuJ5iiJe4ERkaaV0Yq8N7r3SLSqNO5Q=";
+                  sha256 = "sha256-ZQqwpP+mpQVxa3OtspNCj6e/1qApM0m/GGEjM4p/zrU=";
                 };
               };
 


### PR DESCRIPTION
- [x] 5.0.1 ✅
- [x] 5.1.0 🚩
- [x] 5.2.0 🚩
- [x] 5.4.0 🚩
- [x] 5.8.2 🚩

Looks like the problem started with 5.1.0. Below patch fixes the stack overflow (just like #4965)
``` diff
$ git diff
diff --git a/test/test-moc_interpreter.js b/test/test-moc_interpreter.js
index 55ba4697b..7ffe421a7 100644
--- a/test/test-moc_interpreter.js
+++ b/test/test-moc_interpreter.js
@@ -10,7 +10,7 @@ moc.Motoko.saveFile('empty.mo', '');
 moc.Motoko.saveFile('ok.mo', '1');
 moc.Motoko.saveFile('warn.mo', '2 - 1');
 moc.Motoko.saveFile('bad.mo', '1+');
-moc.Motoko.saveFile('limit.mo', 'var i = 0; while (i < 10000) { i += 1 }; i');
+moc.Motoko.saveFile('limit.mo', 'var i = 0; while (i < 7600) { i += 1 }; i');
 moc.Motoko.saveFile('text.mo', `let s = "${'⛔|'.repeat(10000)}"; s.size()`); // #3822
 
 try {

```