### PR TITLE
chore: some fixes for the update-flake-lock workflows

### DIFF
--- a/.github/workflows/update-flake-lock-trial.yml
+++ b/.github/workflows/update-flake-lock-trial.yml
@@ -16,7 +16,7 @@ on:
     - cron: '0 0 * * 0'
 jobs:
   flake-updater:
-    name: 'Update flake.lock (trial)'
+    name: 'Update flake.lock'
     timeout-minutes: 2 # if this takes more than 2 minutes then something's wrong
     runs-on: ubuntu-latest
     steps:
@@ -31,7 +31,7 @@ jobs:
             nixpkgs
             ic-src
             rust-overlay
-          pr-title: "flake.lock: Update (weekly)"
+          pr-title: "chore: weekly flake.lock update"
           pr-labels: |
             autoclose
           token: ${{ secrets.NIV_UPDATER_TOKEN }}

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -16,7 +16,7 @@ on:
     - cron: '0 0 * * *'
 jobs:
   flake-updater:
-    name: 'Update flake.lock (daily)'
+    name: 'Update flake.lock'
     timeout-minutes: 2 # if this takes more than 2 minutes then something's wrong
     runs-on: ubuntu-latest
     steps:
@@ -40,7 +40,7 @@ jobs:
             ocaml-vlq-src
             wasm-spec-src
             ocaml-recovery-parser-src
-          pr-title: "flake.lock: Update (daily)"
+          pr-title: "chore: daily flake.lock update"
           pr-labels: |
             automerge-squash
           token: ${{ secrets.NIV_UPDATER_TOKEN }}


### PR DESCRIPTION
Use correct PR titles for the `.github/workflows/update-flake-lock.yml` workflows.