### PR TITLE
chore: improve the description of PRs generated by the update-flake-lock workflows

### DIFF
--- a/.github/workflows/update-flake-lock-trial.yml
+++ b/.github/workflows/update-flake-lock-trial.yml
@@ -34,4 +34,15 @@ jobs:
           pr-title: "chore: weekly flake.lock update"
           pr-labels: |
             autoclose
+          pr-body: |
+            Automated changes by the [update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock) GitHub Action
+            as defined in [.github/workflows/update-flake-lock-trial.yml](https://github.com/dfinity/motoko/blob/master/.github/workflows/update-flake-lock-trial.yml).
+
+            ```
+            {{ env.GIT_COMMIT_MESSAGE }}
+            ```
+
+            This PR is just to test if the above dependency bumps cause issues.
+            If checks fail this PR remains open so we can investigate.
+            If all checks succeed this PR is automatically closed.
           token: ${{ secrets.NIV_UPDATER_TOKEN }}

--- a/.github/workflows/update-flake-lock-trial.yml
+++ b/.github/workflows/update-flake-lock-trial.yml
@@ -36,7 +36,8 @@ jobs:
             autoclose
           pr-body: |
             Automated changes by the [update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock) GitHub Action
-            as defined in [.github/workflows/update-flake-lock-trial.yml](https://github.com/dfinity/motoko/blob/master/.github/workflows/update-flake-lock-trial.yml).
+            as defined in [.github/workflows/update-flake-lock-trial.yml]({{ env.GITHUB_SERVER_URL }}/{{ env.GITHUB_REPOSITORY }}/blob/master/.github/workflows/update-flake-lock-trial.yml)
+            and run in: {{ env.GITHUB_SERVER_URL }}/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }}/attempts/{{ env.GITHUB_RUN_ATTEMPT }}:
 
             ```
             {{ env.GIT_COMMIT_MESSAGE }}

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -43,4 +43,11 @@ jobs:
           pr-title: "chore: daily flake.lock update"
           pr-labels: |
             automerge-squash
+          pr-body: |
+            Automated changes by the [update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock) GitHub Action.
+            as defined in [.github/workflows/update-flake-lock.yml](https://github.com/dfinity/motoko/blob/master/.github/workflows/update-flake-lock.yml).
+
+            ```
+            {{ env.GIT_COMMIT_MESSAGE }}
+            ```
           token: ${{ secrets.NIV_UPDATER_TOKEN }}

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -45,7 +45,8 @@ jobs:
             automerge-squash
           pr-body: |
             Automated changes by the [update-flake-lock](https://github.com/DeterminateSystems/update-flake-lock) GitHub Action.
-            as defined in [.github/workflows/update-flake-lock.yml](https://github.com/dfinity/motoko/blob/master/.github/workflows/update-flake-lock.yml).
+            as defined in [.github/workflows/update-flake-lock.yml]({{ env.GITHUB_SERVER_URL }}/{{ env.GITHUB_REPOSITORY }}/blob/master/.github/workflows/update-flake-lock.yml)
+            and run in: {{ env.GITHUB_SERVER_URL }}/{{ env.GITHUB_REPOSITORY }}/actions/runs/{{ env.GITHUB_RUN_ID }}/attempts/{{ env.GITHUB_RUN_ATTEMPT }}:
 
             ```
             {{ env.GIT_COMMIT_MESSAGE }}


### PR DESCRIPTION
The default description of the PRs generated by the update-flake-lock workflows contains the incorrect sentence:

> GitHub Actions will not run workflows on pull requests which are opened by a GitHub Action.

In our case GitHub Actions will run on these PRs since we specify a PAT when creating the PR. 

So this PR improves the PR description by removing this line and also adding a reference to the workflow that generated the PR.

Example: https://github.com/dfinity/motoko/pull/5084.
