### PR TITLE
experiment: stable functions

### DIFF
--- a/src/ir_def/rename.ml
+++ b/src/ir_def/rename.ml
@@ -12,6 +12,7 @@ let id rho i =
   with Not_found -> i
 
 let id_bind rho i =
+  if i.[0] = '@' then (i, rho) else
   let i' = fresh_id i in
   (i', Renaming.add i i' rho)
 

--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -754,6 +754,9 @@ let show_translation =
 let eq_translation =
   transform_if "Translate polymorphic equality" Eq.transform
 
+let rename_translation =
+  transform_if "Rename all bound variables" Rename.transform
+
 let analyze analysis_name analysis prog name =
   phase analysis_name name;
   analysis prog;
@@ -761,6 +764,8 @@ let analyze analysis_name analysis prog name =
   then Check_ir.check_prog !Flags.verbose analysis_name prog
 
 let ir_passes mode prog_ir name =
+  (* rename all bound variables (to test stable functions) *)
+  let prog_ir = rename_translation true prog_ir name in
   (* erase typ components from objects *)
   let prog_ir = typ_field_translation true prog_ir name in
   (* translations that extend the progam and must be done before await/cps conversion *)

--- a/test/run-drun/ok/stable-box-bug.drun-run.ok
+++ b/test/run-drun/ok/stable-box-bug.drun-run.ok
@@ -1,0 +1,3 @@
+ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
+ingress Completed: Reply: 0x4449444c0000
+ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/ok/stable-box-bug.tc.ok
+++ b/test/run-drun/ok/stable-box-bug.tc.ok
@@ -1,0 +1,1 @@
+stable-box-bug.mo:2.8-2.12: warning [M0194], unused identifier Prim (delete or rename to wildcard `_` or `_Prim`)

--- a/test/run-drun/ok/stable-class-bug.drun-run.ok
+++ b/test/run-drun/ok/stable-class-bug.drun-run.ok
@@ -1,0 +1,3 @@
+ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
+ingress Completed: Reply: 0x4449444c0000
+ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/stable-box-bug.mo
+++ b/test/run-drun/stable-box-bug.mo
@@ -1,0 +1,65 @@
+//ENHANCED-ORTHOGONAL-PERSISTENCE-ONLY
+import Prim "mo:prim";
+
+// counter-example, demonstrating unsoundness of promoting a generic stable function to a generic non-stable function.
+// Type arguments are restricted to stable types for stable functions, but
+// unrestricted for non-stable functions, so you can avoid the restriction
+// by promoting the function to a non-stable super type before application.
+
+//
+// Possible fixes:
+// * Only allow type parameters to range over stable types, both for local and stable functions.
+//   Probably too draconian. Not backwards compatible.
+// * Add a type parameter sort for stable type (similar to equality type parameters in SML/restricted type classes).
+// * Consider a stable-sorted function type stable only if, when applied to stable
+//   type parameters, its arguments and results are stable types too. That might
+//   rule out the map field below, because it's type is actually not stable,
+//   eventhough it contains just stable-sorted functions.
+
+/*
+[nix-shell:~/motoko/test/run-drun]$ EXTRA_MOC_ARGS=--enhanced-orthogonal-persistence ../run.sh -d  stable-box-bug.mo
+WARNING: Could not run ic-ref-run, will skip running some tests
+stable-class-bug: [tc] [comp] [comp-ref] [valid] [valid-ref] [drun-run]
+All tests passed.
+
+[nix-shell:~/motoko/test/run-drun]$ moc --enhanced-orthogonal-persistence --stable-types stable-box-bug.mo
+stable-box-bug.mo:2.8-2.12: warning [M0194], unused identifier Prim (delete or rename to wildcard `_` or `_Prim`)
+
+[nix-shell:~/motoko/test/run-drun]$ more stable-box-bug.most
+// Version: 1.0.0
+actor {
+  stable map : {get : stable () -> () -> (); put : stable (() -> ()) -> ()}
+};
+
+*/
+
+persistent actor {
+    class Box<T>(v : T) {
+        var value = v;
+        public func get() : T = v;
+        public func put(v : T) = value := v
+    };
+
+// correctly rejected, T is non-stable
+//    let box = Box<() -> ()>(func () {});
+//    box.put(func () {});
+
+    // a non-stable super-type of the class constructor type
+    type Super = <T>(v : T) ->
+    { put : stable T -> ();
+      get : stable ()-> T
+    };
+
+    transient let SuperBox = Box : Super;
+    // incorrectly allowed, though T is non-stable
+    let map = SuperBox<() -> ()>(func () {});
+    map.put(func () {});
+    map.get()();
+
+};
+
+//SKIP run
+//SKIP run-ir
+//SKIP run-low
+
+//CALL upgrade ""

--- a/test/run-drun/stable-class-bug.mo
+++ b/test/run-drun/stable-class-bug.mo
@@ -1,0 +1,72 @@
+//ENHANCED-ORTHOGONAL-PERSISTENCE-ONLY
+import Prim "mo:prim";
+
+persistent actor {
+    type Equality<T> = stable (first : T, second : T) -> Bool;
+    type Hash<T> = stable (value : T) -> Nat;
+
+    class SimpleHashMap<K, V>(capacity : Nat, equal : Equality<K>, hash : Hash<K>) {
+        private let table = Prim.Array_init<?(K, V)>(capacity, null);
+
+        public func put(key : K, value : V) {
+            let index = hash(key) % capacity;
+            switch (table[index]) {
+                case null table[index] := ?(key, value);
+                case (?(otherKey, _)) {
+                    if (equal(key, otherKey)) {
+                        table[index] := ?(key, value);
+                    } else {
+                        Prim.trap("Hash collision"); // simplification for testing
+                    };
+                };
+            };
+        };
+
+        public func get(key : K) : ?V {
+            let index = hash(key) % capacity;
+            switch (table[index]) {
+                case null null;
+                case (?(otherKey, value)) {
+                    if (equal(key, otherKey)) {
+                        ?value;
+                    } else {
+                        null;
+                    };
+                };
+            };
+        };
+    };
+
+    func natEqual(first : Nat, second : Nat) : Bool {
+        first == second;
+    };
+
+    func natHash(number : Nat) : Nat {
+        number;
+    };
+
+// correctly rejected:
+//    let map = SimpleHashMap<Nat, () -> Text>(10, natEqual, natHash);
+//    map.put(1, func () = "A");
+//    map.put(2, func () = "B");
+
+    // a non-stable super-type
+    type Super = <K, V>(capacity : Nat, equal : Equality<K>, hash : Hash<K>) ->
+    { put : stable (K, V) -> ();
+      get : stable K -> ?V
+    };
+
+    transient let SuperHashMap = SimpleHashMap : Super;
+    let map = SuperHashMap<Nat, () -> Text>(10, natEqual, natHash);
+    map.put(1, func () = "A");
+    map.put(2, func () = "B");
+//    assert (map.get(1)() == ?"A");
+//    assert (map.get(2) == ?"B");
+//    assert (map.get(3) == null);
+};
+
+//SKIP run
+//SKIP run-ir
+//SKIP run-low
+
+//CALL upgrade ""

--- a/test/run-drun/stable-class-bug.mo
+++ b/test/run-drun/stable-class-bug.mo
@@ -3,9 +3,18 @@ import Prim "mo:prim";
 
 // counter-example, demonstrating unsoundness of promoting a generic stable function to a generic non-stable function.
 // Type arguments are restricted to stable types for stable functions, but
-// unrestricted for non-stable functions, so you can obvoid the restriction
+// unrestricted for non-stable functions, so you can avoid the restriction
 // by promoting the function to a non-stable super type before application.
 
+//
+// Possible fixes:
+// * Only allow type parameters to range over stable types, both for local and stable functions.
+//   Probably too draconian. Not backwards compatible.
+// * Add a type parameter sort for stable type (similar to equality type parameters in SML/restricted type classes).
+// * Consider a stable-sorted function type stable only if, when applied to stable
+//   type parameters, its arguments and results are stable types too. That might
+//   rule out the map field below, because it's type is actually not stable,
+//   eventhough it contains just stable-sorted functions.
 
 /*
 [nix-shell:~/motoko/test/run-drun]$ EXTRA_MOC_ARGS=--enhanced-orthogonal-persistence ../run.sh -d  stable-class-bug.mo

--- a/test/run-drun/stable-class-bug.mo
+++ b/test/run-drun/stable-class-bug.mo
@@ -1,6 +1,28 @@
 //ENHANCED-ORTHOGONAL-PERSISTENCE-ONLY
 import Prim "mo:prim";
 
+// counter-example, demonstrating unsoundness of promoting a generic stable function to a generic non-stable function.
+// Type arguments are restricted to stable types for stable functions, but
+// unrestricted for non-stable functions, so you can obvoid the restriction
+// by promoting the function to a non-stable super type before application.
+
+
+/*
+[nix-shell:~/motoko/test/run-drun]$ EXTRA_MOC_ARGS=--enhanced-orthogonal-persistence ../run.sh -d  stable-class-bug.mo
+WARNING: Could not run ic-ref-run, will skip running some tests
+stable-class-bug: [tc] [comp] [comp-ref] [valid] [valid-ref] [drun-run]
+All tests passed.
+
+[nix-shell:~/motoko/test/run-drun]$ moc --enhanced-orthogonal-persistence --stable-types stable-class-bug.mo
+
+[nix-shell:~/motoko/test/run-drun]$ more stable-class-bug.most
+// Version: 1.0.0
+actor {
+  stable map :
+    {get : stable Nat -> ?(() -> Text); put : stable (Nat, () -> Text) -> ()}
+};
+*/
+
 persistent actor {
     type Equality<T> = stable (first : T, second : T) -> Bool;
     type Hash<T> = stable (value : T) -> Nat;
@@ -45,18 +67,19 @@ persistent actor {
         number;
     };
 
-// correctly rejected:
+// correctly rejected, V is non-stable
 //    let map = SimpleHashMap<Nat, () -> Text>(10, natEqual, natHash);
 //    map.put(1, func () = "A");
 //    map.put(2, func () = "B");
 
-    // a non-stable super-type
+    // a non-stable super-type of the class constructor type
     type Super = <K, V>(capacity : Nat, equal : Equality<K>, hash : Hash<K>) ->
     { put : stable (K, V) -> ();
       get : stable K -> ?V
     };
 
     transient let SuperHashMap = SimpleHashMap : Super;
+    // incorrectly allowed, though V is non-stable
     let map = SuperHashMap<Nat, () -> Text>(10, natEqual, natHash);
     map.put(1, func () = "A");
     map.put(2, func () = "B");


### PR DESCRIPTION
additional tests 

- stable-class-bug.mo: demonstrates unsoundness of promoting generic stable functions to generic local functions.
- stable-box-bug.mo: a simplified counter-example.

