### PR TITLE
optimization: remove (most) quadratic list operations in compile_enhanced.ml

### DIFF
--- a/src/codegen/compile_enhanced.ml
+++ b/src/codegen/compile_enhanced.ml
@@ -441,7 +441,7 @@ end = struct
   let add (l, es) e = (l, (l + 1, e :: es))
   let length (l, es) = l
   let to_list (l, es) = List.rev es
-  let from_list es = (List.length es, es)
+  let from_list es = (List.length es, List.rev es)
 end
 
 module E = struct


### PR DESCRIPTION
Builds on #5233:

- removes quadratic behaviour in backend due to list based table representation used allocate indices to Wasm functions, datasegments, locals, shared objects  etc...

- shaves 12% off wall-clock compilation time for CycleOps (eop)  

(a similar optimization could apply to the classical backend)
