### PR TITLE
test: add `only.mk` and `accept.mk`

### DIFF
--- a/test/accept.mk
+++ b/test/accept.mk
@@ -1,0 +1,9 @@
+.PHONY: %.accept
+%.accept: %.mo
+	../run.sh -a $(RUNFLAGS) $<
+	@ git status -s $< ok
+	@ echo STAGING: $< $(wildcard ok/$(basename $<).*)
+	@ if [ -n "$(wildcard ok/$(basename $<).*)" ] \
+	; then git add --ignore-errors --update $< $(wildcard ok/$(basename $<).*) \
+	; fi
+	@ git status -s $< $(wildcard ok/$(basename $<).*)

--- a/test/accept.mk
+++ b/test/accept.mk
@@ -1,9 +1,12 @@
 .PHONY: %.accept
+THIS_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+REPO_ROOT := $(shell git rev-parse --show-toplevel)
+
 %.accept: %.mo
 	../run.sh -a $(RUNFLAGS) $<
-	@ git status -s $< ok
+	@ git -C $(REPO_ROOT) status -s $(CURDIR)/$< $(THIS_DIR)/ok
 	@ echo STAGING: $< $(wildcard ok/$(basename $<).*)
-	@ if [ -n "$(wildcard ok/$(basename $<).*)" ] \
-	; then git add --ignore-errors --update $< $(wildcard ok/$(basename $<).*) \
+	@ if [ -n "$(wildcard $(THIS_DIR)/ok/$(basename $<).*)" ] \
+	; then git add --ignore-errors --update $< $(wildcard $(THIS_DIR)/ok/$(basename $<).*) \
 	; fi
-	@ git status -s $< $(wildcard ok/$(basename $<).*)
+	@ git -C $(REPO_ROOT) status -s $(CURDIR)/$< $(CURDIR)/ok/$(basename $<).*

--- a/test/accept.mk
+++ b/test/accept.mk
@@ -8,4 +8,6 @@ REPO_ROOT := $(shell git rev-parse --show-toplevel)
 	@ echo STAGING: $< $(wildcard ok/$(basename $<).*)
 	@ set -- $(CURDIR)/ok/$(basename $<).*; \
 	  [ -e "$$1" ] && git add --ignore-errors $(CURDIR)/$< "$$@" || true
+	@ git -C $(REPO_ROOT) status --porcelain -- "$(CURDIR)/ok/$(basename $<).*" | \
+	  awk '/^AD / {print $$2}' | xargs -r git -C $(REPO_ROOT) rm --cached --
 	@ git -C $(REPO_ROOT) status -s $(CURDIR)/$< $(CURDIR)/ok/$(basename $<).*

--- a/test/accept.mk
+++ b/test/accept.mk
@@ -9,5 +9,5 @@ REPO_ROOT := $(shell git rev-parse --show-toplevel)
 	@ set -- $(CURDIR)/ok/$(basename $<).*; \
 	  [ -e "$$1" ] && git add --ignore-errors $(CURDIR)/$< "$$@" || true
 	@ git -C $(REPO_ROOT) status --porcelain -- "$(CURDIR)/ok/$(basename $<).*" | \
-	  awk '/^AD / {print $$2}' | xargs -r git -C $(REPO_ROOT) rm --cached --
+	  awk '/^AD / {print $$2}' | xargs -r git -C $(REPO_ROOT) rm --cached --quiet --
 	@ git -C $(REPO_ROOT) status -s $(CURDIR)/$< $(CURDIR)/ok/$(basename $<).*

--- a/test/accept.mk
+++ b/test/accept.mk
@@ -2,8 +2,7 @@
 THIS_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
 
-%.accept: %.mo
-	../run.sh -a $(RUNFLAGS) $<
+define _stage_results
 	@ git -C $(REPO_ROOT) status -s $(CURDIR)/$< $(CURDIR)/ok
 	@ echo STAGING: $< $(wildcard ok/$(basename $<).*)
 	@ set -- $(CURDIR)/ok/$(basename $<).*; \
@@ -11,3 +10,12 @@ REPO_ROOT := $(shell git rev-parse --show-toplevel)
 	@ git -C $(REPO_ROOT) status --porcelain -- "$(CURDIR)/ok/$(basename $<).*" | \
 	  awk '/^AD / {print $$2}' | xargs -r git -C $(REPO_ROOT) rm --cached --quiet --
 	@ git -C $(REPO_ROOT) status -s $(CURDIR)/$< $(CURDIR)/ok/$(basename $<).*
+endef
+
+%.accept: %.mo
+	run-test -a $(RUNFLAGS) $<
+	$(_stage_results)
+
+%.accept: %.drun
+	run-test -a $(RUNFLAGS) -d $<
+	$(_stage_results)

--- a/test/accept.mk
+++ b/test/accept.mk
@@ -4,9 +4,8 @@ REPO_ROOT := $(shell git rev-parse --show-toplevel)
 
 %.accept: %.mo
 	../run.sh -a $(RUNFLAGS) $<
-	@ git -C $(REPO_ROOT) status -s $(CURDIR)/$< $(THIS_DIR)/ok
+	@ git -C $(REPO_ROOT) status -s $(CURDIR)/$< $(CURDIR)/ok
 	@ echo STAGING: $< $(wildcard ok/$(basename $<).*)
-	@ if [ -n "$(wildcard $(THIS_DIR)/ok/$(basename $<).*)" ] \
-	; then git add --ignore-errors --update $< $(wildcard $(THIS_DIR)/ok/$(basename $<).*) \
-	; fi
+	@ set -- $(CURDIR)/ok/$(basename $<).*; \
+	  [ -e "$$1" ] && git add --ignore-errors $(CURDIR)/$< "$$@" || true
 	@ git -C $(REPO_ROOT) status -s $(CURDIR)/$< $(CURDIR)/ok/$(basename $<).*

--- a/test/only.mk
+++ b/test/only.mk
@@ -1,0 +1,3 @@
+.PHONY: %.only
+%.only: %.mo
+	../run.sh $(RUNFLAGS) $<

--- a/test/only.mk
+++ b/test/only.mk
@@ -1,3 +1,4 @@
 .PHONY: %.only
+
 %.only: %.mo
-	../run.sh $(RUNFLAGS) $<
+	run-test $(RUNFLAGS) $<


### PR DESCRIPTION
This PR adds `*.mk` files written by @ggreif which simplify running and accepting changes for individual tests.

```sh
make -C test/run example.only # Run `example.mo`
make -C test/run example.accept # Run and accept output for `example.mo`
```

An additional property of the final `accept.mk`: the workflow

1. introduce a type error in `test.mo`
2. `make -s ... test.accept`  ← stages error output, unstages passing output
3. fix the error
4. `make -s ... test.accept`  ← restores passing output, unstages error output

leaves the repo index in exactly its original state — provided the `.ok` files are tracked and `test.mo` is restored to its original content. Step 4 re-stages `test.mo` and `test.drun-run.ok` (both now matching HEAD) and removes the ephemeral `test.tc.ok` / `test.tc.ret.ok` entries via the `git status --porcelain | awk | xargs git rm --cached` cleanup.