### PR TITLE
experiment: sanity check `async` vs `async*`

### DIFF
--- a/test/run-drun/byron.mo
+++ b/test/run-drun/byron.mo
@@ -1,0 +1,42 @@
+import Prim "mo:prim";
+actor a {
+
+  public func m() : async () {
+    Prim.debugPrint(debug_show {
+      cycles = Prim.cyclesAvailable();
+      deadline = Prim.replyDeadline()
+    });
+  };
+
+  func sync() : () {
+      Prim.debugPrint("f()");
+  };
+
+  func fstar() : async* () {
+    Prim.debugPrint("fstar()");
+    await (with cycles=200; timeout = 400) m();
+    ignore (with cycles=400; timeout = 800) m();
+  };
+
+  func f() : async () {
+    Prim.debugPrint("f()");
+    await (with cycles=600; timeout = 1200) m();
+    ignore (with cycles=800; timeout = 1600) m();
+  };
+
+  public func go() : async () {
+      await (with cycles=100; timeout = 200) m();
+      sync(); // some effect
+      ignore      sync(); // some effect
+      let _ = fstar(); // no effect
+      ignore fstar(); // no effect
+      await* fstar(); // some effect
+
+      let _ = f(); // some effect
+      ignore f(); // some effect
+      await f(); // some effect
+
+  };
+
+};
+await a.go();//OR-CALL ingress go "DIDL\x00\x00"

--- a/test/run-drun/byron.mo
+++ b/test/run-drun/byron.mo
@@ -4,7 +4,7 @@ actor a {
   public func m() : async () {
     Prim.debugPrint(debug_show {
       cycles = Prim.cyclesAvailable();
-      deadline = Prim.replyDeadline()/1000_000_000_000;
+      deadline = Prim.replyDeadline()/1_000_000_000_000_00;
     });
   };
 

--- a/test/run-drun/byron.mo
+++ b/test/run-drun/byron.mo
@@ -4,7 +4,7 @@ actor a {
   public func m() : async () {
     Prim.debugPrint(debug_show {
       cycles = Prim.cyclesAvailable();
-      deadline = Prim.replyDeadline()
+      deadline = Prim.replyDeadline()/1000_000_000_000;
     });
   };
 

--- a/test/run-drun/ok/byron.diff-ir.ok
+++ b/test/run-drun/ok/byron.diff-ir.ok
@@ -1,0 +1,7 @@
+--- byron.run
++++ byron.run-ir
+@@ -1 +1,3 @@
+-prim:___: execution error, Value.prim: cyclesAvailable
++prim:___: execution error, Unknown prim or wrong number of arguments (0 given):
++  SystemCyclesAvailablePrim
++

--- a/test/run-drun/ok/byron.diff-low.ok
+++ b/test/run-drun/ok/byron.diff-low.ok
@@ -1,0 +1,7 @@
+--- byron.run
++++ byron.run-low
+@@ -1 +1,3 @@
+-prim:___: execution error, Value.prim: cyclesAvailable
++prim:___: execution error, Unknown prim or wrong number of arguments (0 given):
++  SystemCyclesAvailablePrim
++

--- a/test/run-drun/ok/byron.drun-run.ok
+++ b/test/run-drun/ok/byron.drun-run.ok
@@ -1,0 +1,18 @@
+ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
+ingress Completed: Reply: 0x4449444c0000
+debug.print: {cycles = 100; deadline = 1_755_789_114_000_000_000}
+debug.print: f()
+debug.print: f()
+debug.print: fstar()
+debug.print: {cycles = 200; deadline = 1_755_789_214_000_000_000}
+debug.print: {cycles = 400; deadline = 1_755_789_214_000_000_000}
+debug.print: f()
+debug.print: f()
+debug.print: f()
+debug.print: {cycles = 600; deadline = 1_755_789_214_000_000_000}
+debug.print: {cycles = 600; deadline = 1_755_789_214_000_000_000}
+debug.print: {cycles = 600; deadline = 1_755_789_214_000_000_000}
+debug.print: {cycles = 800; deadline = 1_755_789_214_000_000_000}
+debug.print: {cycles = 800; deadline = 1_755_789_214_000_000_000}
+debug.print: {cycles = 800; deadline = 1_755_789_214_000_000_000}
+ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/ok/byron.drun-run.ok
+++ b/test/run-drun/ok/byron.drun-run.ok
@@ -1,18 +1,18 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-debug.print: {cycles = 100; deadline = 1_755_791}
+debug.print: {cycles = 100; deadline = 17_557}
 debug.print: f()
 debug.print: f()
 debug.print: fstar()
-debug.print: {cycles = 200; deadline = 1_755_792}
-debug.print: {cycles = 400; deadline = 1_755_792}
+debug.print: {cycles = 200; deadline = 17_557}
+debug.print: {cycles = 400; deadline = 17_557}
 debug.print: f()
 debug.print: f()
 debug.print: f()
-debug.print: {cycles = 600; deadline = 1_755_792}
-debug.print: {cycles = 600; deadline = 1_755_792}
-debug.print: {cycles = 600; deadline = 1_755_792}
-debug.print: {cycles = 800; deadline = 1_755_792}
-debug.print: {cycles = 800; deadline = 1_755_792}
-debug.print: {cycles = 800; deadline = 1_755_792}
+debug.print: {cycles = 600; deadline = 17_557}
+debug.print: {cycles = 600; deadline = 17_557}
+debug.print: {cycles = 600; deadline = 17_557}
+debug.print: {cycles = 800; deadline = 17_557}
+debug.print: {cycles = 800; deadline = 17_557}
+debug.print: {cycles = 800; deadline = 17_557}
 ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/ok/byron.drun-run.ok
+++ b/test/run-drun/ok/byron.drun-run.ok
@@ -1,18 +1,18 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-debug.print: {cycles = 100; deadline = 1_755_789_114_000_000_000}
+debug.print: {cycles = 100; deadline = 1_755_791}
 debug.print: f()
 debug.print: f()
 debug.print: fstar()
-debug.print: {cycles = 200; deadline = 1_755_789_214_000_000_000}
-debug.print: {cycles = 400; deadline = 1_755_789_214_000_000_000}
+debug.print: {cycles = 200; deadline = 1_755_792}
+debug.print: {cycles = 400; deadline = 1_755_792}
 debug.print: f()
 debug.print: f()
 debug.print: f()
-debug.print: {cycles = 600; deadline = 1_755_789_214_000_000_000}
-debug.print: {cycles = 600; deadline = 1_755_789_214_000_000_000}
-debug.print: {cycles = 600; deadline = 1_755_789_214_000_000_000}
-debug.print: {cycles = 800; deadline = 1_755_789_214_000_000_000}
-debug.print: {cycles = 800; deadline = 1_755_789_214_000_000_000}
-debug.print: {cycles = 800; deadline = 1_755_789_214_000_000_000}
+debug.print: {cycles = 600; deadline = 1_755_792}
+debug.print: {cycles = 600; deadline = 1_755_792}
+debug.print: {cycles = 600; deadline = 1_755_792}
+debug.print: {cycles = 800; deadline = 1_755_792}
+debug.print: {cycles = 800; deadline = 1_755_792}
+debug.print: {cycles = 800; deadline = 1_755_792}
 ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/ok/byron.run-ir.ok
+++ b/test/run-drun/ok/byron.run-ir.ok
@@ -1,0 +1,3 @@
+prim:___: execution error, Unknown prim or wrong number of arguments (0 given):
+  SystemCyclesAvailablePrim
+

--- a/test/run-drun/ok/byron.run-low.ok
+++ b/test/run-drun/ok/byron.run-low.ok
@@ -1,0 +1,3 @@
+prim:___: execution error, Unknown prim or wrong number of arguments (0 given):
+  SystemCyclesAvailablePrim
+

--- a/test/run-drun/ok/byron.run.ok
+++ b/test/run-drun/ok/byron.run.ok
@@ -1,0 +1,1 @@
+prim:___: execution error, Value.prim: cyclesAvailable

--- a/test/run-drun/ok/byron.run.ret.ok
+++ b/test/run-drun/ok/byron.run.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/run-drun/ok/byron.tc.ok
+++ b/test/run-drun/ok/byron.tc.ok
@@ -1,0 +1,1 @@
+byron.mo:30.7-30.25: warning [M0089], redundant ignore, operand already has type ()


### PR DESCRIPTION
@ggreif all seems ok to me.


```motoko
import Prim "mo:prim";
actor a {

  public func m() : async () {
    Prim.debugPrint(debug_show {
      cycles = Prim.cyclesAvailable();
      deadline = Prim.replyDeadline()
    });
  };

  func sync() : () {
      Prim.debugPrint("f()");
  };

  func fstar() : async* () {
    Prim.debugPrint("fstar()");
    await (with cycles=200; timeout = 400) m();
    ignore (with cycles=400; timeout = 800) m();
  };

  func f() : async () {
    Prim.debugPrint("f()");
    await (with cycles=600; timeout = 1200) m();
    ignore (with cycles=800; timeout = 1600) m();
  };

  public func go() : async () {
      await (with cycles=100; timeout = 200) m();
      sync(); // some effect
      ignore      sync(); // some effect
      let _ = fstar(); // no effect
      ignore fstar(); // no effect
      await* fstar(); // some effect

      let _ = f(); // some effect
      ignore f(); // some effect
      await f(); // some effect

  };

};
```
output:
```
debug.print: {cycles = 100; deadline = 1_755_789_114_000_000_000}
debug.print: f()
debug.print: f()
debug.print: fstar()
debug.print: {cycles = 200; deadline = 1_755_789_214_000_000_000}
debug.print: {cycles = 400; deadline = 1_755_789_214_000_000_000}
debug.print: f()
debug.print: f()
debug.print: f()
debug.print: {cycles = 600; deadline = 1_755_789_214_000_000_000}
debug.print: {cycles = 600; deadline = 1_755_789_214_000_000_000}
debug.print: {cycles = 600; deadline = 1_755_789_214_000_000_000}
debug.print: {cycles = 800; deadline = 1_755_789_214_000_000_000}
debug.print: {cycles = 800; deadline = 1_755_789_214_000_000_000}
debug.print: {cycles = 800; deadline = 1_755_789_214_000_000_000}
ingress Completed: Reply: 0x4449444c0000
```