### PR TITLE
experiment: weird stable upgrade failure

### DIFF
--- a/test/run-drun/ok/stable-closure.drun.ok
+++ b/test/run-drun/ok/stable-closure.drun.ok
@@ -1,0 +1,7 @@
+ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
+debug.print: version0
+ingress Completed: Reply: 0x4449444c0000
+ingress Err: IC0503: Error from Canister rwlgt-iiaaa-aaaaa-aaaaa-cai: Canister called `ic0.trap` with message: 'RTS error: Incompatible upgrade: Stable function C.get is missing in the new program version'.
+Consider gracefully handling failures from this canister or altering the canister to handle exceptions. See documentation: https://internetcomputer.org/docs/current/references/execution-errors#trapped-explicitly
+debug.print: version2
+ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/ok/stable-weirdness.drun.ok
+++ b/test/run-drun/ok/stable-weirdness.drun.ok
@@ -1,0 +1,5 @@
+ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
+debug.print: version0
+ingress Completed: Reply: 0x4449444c0000
+debug.print: version2
+ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/ok/stable-weirdness.drun.ok
+++ b/test/run-drun/ok/stable-weirdness.drun.ok
@@ -1,5 +1,7 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 debug.print: version0
 ingress Completed: Reply: 0x4449444c0000
+ingress Err: IC0503: Error from Canister rwlgt-iiaaa-aaaaa-aaaaa-cai: Canister called `ic0.trap` with message: 'RTS error: Incompatible upgrade: Stable function f is missing in the new program version'.
+Consider gracefully handling failures from this canister or altering the canister to handle exceptions. See documentation: https://internetcomputer.org/docs/current/references/execution-errors#trapped-explicitly
 debug.print: version2
 ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/stable-closure.drun
+++ b/test/run-drun/stable-closure.drun
@@ -1,0 +1,5 @@
+# ENHANCED-ORTHOGONAL-PERSISTENCE-ONLY
+# SKIP ic-ref-run
+install $ID stable-closure/version0.mo ""
+upgrade $ID stable-closure/version1.mo ""
+upgrade $ID stable-closure/version2.mo ""

--- a/test/run-drun/stable-closure/version0.mo
+++ b/test/run-drun/stable-closure/version0.mo
@@ -1,0 +1,10 @@
+import Prim "mo:prim";
+
+persistent actor {
+    persistent class C<T>(x : T) {
+      let a = (x, x);
+      public persistent func get() : (T,T) { a }
+    };
+    stable let o = C(0);
+    Prim.debugPrint "version0";
+}

--- a/test/run-drun/stable-closure/version1.mo
+++ b/test/run-drun/stable-closure/version1.mo
@@ -1,0 +1,12 @@
+import Prim "mo:prim";
+
+// fails as upgrade
+persistent actor {
+    persistent class C<T>(x : T) {
+      let a = (x, x);
+      public persistent func get() : (T,T) { a }
+    };
+    stable let o : C<Nat> = Prim.trap "impossible";
+    assert o.get() == (0,0);
+    Prim.debugPrint "version1";
+}

--- a/test/run-drun/stable-closure/version2.mo
+++ b/test/run-drun/stable-closure/version2.mo
@@ -1,0 +1,13 @@
+import Prim "mo:prim";
+
+// succeeds as upgrade
+persistent actor {
+    persistent class C<T>(x : T) {
+      let a = (x, x);
+      public persistent func get() : (T,T) { a }
+    };
+    stable let o : C<Nat> = Prim.trap "impossible";
+    stable let h : Any = C(1); // why do I need this?
+    assert o.get() == (0,0);
+    Prim.debugPrint "version2";
+}

--- a/test/run-drun/stable-weirdness.drun
+++ b/test/run-drun/stable-weirdness.drun
@@ -1,0 +1,7 @@
+# ENHANCED-ORTHOGONAL-PERSISTENCE-ONLY
+# SKIP ic-ref-run
+install $ID stable-weirdness/version0.mo ""
+#fails
+#upgrade $ID stable-weirdness/version1.mo ""
+#works
+upgrade $ID stable-weirdness/version2.mo ""

--- a/test/run-drun/stable-weirdness.drun
+++ b/test/run-drun/stable-weirdness.drun
@@ -2,6 +2,6 @@
 # SKIP ic-ref-run
 install $ID stable-weirdness/version0.mo ""
 #fails
-#upgrade $ID stable-weirdness/version1.mo ""
+upgrade $ID stable-weirdness/version1.mo ""
 #works
 upgrade $ID stable-weirdness/version2.mo ""

--- a/test/run-drun/stable-weirdness/version0.mo
+++ b/test/run-drun/stable-weirdness/version0.mo
@@ -1,0 +1,12 @@
+import Prim "mo:prim";
+
+persistent actor {
+    persistent func f() : {a : Int; b : Int} {
+        {a=0; b=0};
+    };
+
+    stable let g = f;
+    assert g().a == 0;
+
+    Prim.debugPrint "version0";
+}

--- a/test/run-drun/stable-weirdness/version1.mo
+++ b/test/run-drun/stable-weirdness/version1.mo
@@ -1,0 +1,16 @@
+import Prim "mo:prim";
+
+// why does upgrading tois fail? Both f and g are declared with the same type (but there is no-reference to f)
+
+persistent actor {
+    persistent func f() : {a: Int; b: Int} {
+        {a = 1; b = 1};
+    };
+
+
+    stable let g : persistent () -> {a:Int; b: Int} = Prim.trap "unreachable";
+    assert g().a == 1;
+    // stable let h : Any = f; // why does upgrade fail without this reference to f?
+    Prim.debugPrint "version1";
+
+}

--- a/test/run-drun/stable-weirdness/version2.mo
+++ b/test/run-drun/stable-weirdness/version2.mo
@@ -1,0 +1,14 @@
+import Prim "mo:prim";
+
+persistent actor {
+    persistent func f() : {a: Int; b: Int} {
+        {a = 1; b = 1};
+    };
+
+
+    stable let g : persistent () -> {a:Int; b: Int} = Prim.trap "unreachable";
+    assert g().a == 1;
+    stable let h : Any = f; // why does upgrade fail without this reference to f?
+    Prim.debugPrint "version2";
+
+}


### PR DESCRIPTION
I don't understand why upgrading from version0 to version1 fails, while version2 is ok. I'd expect the upgrade to version1 to be ok too:

(The only difference is that verson2 retains a use to persistent function f, but both define `f`.


version0.mo
```
import Prim "mo:prim";

persistent actor {
    persistent func f() : {a : Int; b : Int} {
        {a=0; b=0};
    };

    stable let g = f;
    assert g().a == 0;

    Prim.debugPrint "version0";
}
```
version1.mo
```
import Prim "mo:prim";

// why does upgrading tois fail? Both f and g are declared with the same type (but th
ere is no-reference to f)

persistent actor {
    persistent func f() : {a: Int; b: Int} {
        {a = 1; b = 1};
    };


    stable let g : persistent () -> {a:Int; b: Int} = Prim.trap "unreachable";
    assert g().a == 1;
    // stable let h : Any = f; // why does upgrade fail without this reference to f?
    Prim.debugPrint "version1";

}
```

version2.mo
```
import Prim "mo:prim";

persistent actor {
    persistent func f() : {a: Int; b: Int} {
        {a = 1; b = 1};
    };


    stable let g : persistent () -> {a:Int; b: Int} = Prim.trap "unreachable";
    assert g().a == 1;
    stable let h : Any = f; // why does upgrade fail without this reference to f?
    Prim.debugPrint "version2";

}
```

Output:
```
crusso@crusso-Virtual-Machine:~/motoko/test/run-drun$ more ok/stable-weirdness.drun.ok 
ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
debug.print: version0
ingress Completed: Reply: 0x4449444c0000
ingress Err: IC0503: Error from Canister rwlgt-iiaaa-aaaaa-aaaaa-cai: Canister called
 `ic0.trap` with message: 'RTS error: Incompatible upgrade: Stable function f is miss
ing in the new program version'.
Consider gracefully handling failures from this canister or altering the canister to 
handle exceptions. See documentation: https://internetcomputer.org/docs/current/refer
ences/execution-errors#trapped-explicitly
debug.print: version2
ingress Completed: Reply: 0x4449444c0000
```