### PR TITLE
experiment: use prefix implicit keyword in patterns and types

### DIFF
--- a/doc/md/examples/grammar.txt
+++ b/doc/md/examples/grammar.txt
@@ -82,6 +82,8 @@
     <implicit> ':' <typ>
     <id> ':' <typ>
     <id_wild> ':' <typ>
+    <implicit> <id> ':' <typ>
+    <implicit> <id_wild> ':' <typ>
     <typ>
 
 <typ_args> ::= 
@@ -331,6 +333,7 @@
     <pat_un>
     <pat_bin> 'or' <pat_bin>
     <pat_bin> ':' <typ>
+    <implicit> <id> ':' <typ>
 
 <pat> ::= 
     <pat_bin>

--- a/src/mo_frontend/parser.mly
+++ b/src/mo_frontend/parser.mly
@@ -498,6 +498,8 @@ typ_item :
   | i=implicit COLON t = typ { Some i, t }
   | i=id COLON t=typ { Some i, t }
   | i=id_wild COLON t=typ { Some i, t }
+  | implicit i=id COLON t=typ { Some i, (NamedT (i, t) @! at $sloc) }
+  | implicit i=id_wild COLON t=typ { Some i, (NamedT (i, t) @! at $sloc) }
   | t=typ { None, t }
 
 typ_args :
@@ -944,6 +946,8 @@ pat_bin :
     { AltP(p1, p2) @! at $sloc }
   | p=pat_bin COLON t=typ
     { AnnotP(p, t) @! at $sloc }
+  | i=implicit x=id COLON t=typ
+    { AnnotP(VarP x @! x.at, (NamedT(i, t) @! at $sloc)) @! at $sloc }
 
 pat :
   | p=pat_bin

--- a/src/mo_frontend/parser.mly
+++ b/src/mo_frontend/parser.mly
@@ -498,8 +498,8 @@ typ_item :
   | i=implicit COLON t = typ { Some i, t }
   | i=id COLON t=typ { Some i, t }
   | i=id_wild COLON t=typ { Some i, t }
-  | implicit i=id COLON t=typ { Some i, (NamedT (i, t) @! at $sloc) }
-  | implicit i=id_wild COLON t=typ { Some i, (NamedT (i, t) @! at $sloc) }
+  | imp=implicit i=id COLON t=typ { Some i, (NamedT (imp, t) @! at $sloc) }
+  | imp=implicit i=id_wild COLON t=typ { Some i, (NamedT (imp, t) @! at $sloc) }
   | t=typ { None, t }
 
 typ_args :

--- a/test/fail/implicit-example-sugar.mo
+++ b/test/fail/implicit-example-sugar.mo
@@ -47,6 +47,17 @@ func test () {
   debugPrint(let _ = Pair.toText((1,2))); // implicit arguments
   debugPrint(let _ = Pair.toText((1,2))); // implicit arguments
 
+  // higher-order test
+  type F =
+    <T, U>(implicit toText : T -> Text,
+           implicit toText : U -> Text,
+           p : (T, U))
+    -> Text;
+
+  func _apply(f : F, p : (Nat, Int)) : Text {
+     f(p);
+  };
+
 };
 
 test();

--- a/test/fail/implicit-example-sugar.mo
+++ b/test/fail/implicit-example-sugar.mo
@@ -27,8 +27,8 @@ module Array {
 module Pair {
 
   public func toText<T,U>(
-    toTextT : (implicit : (toText : T -> Text)),
-    toTextU : (implicit : (toText : U -> Text)),
+    implicit toTextT : (toText : T -> Text),
+    implicit toTextU : (toText : U -> Text),
     p : (T, U))
     : Text {
       "(" # toTextT(p.0) # "," # toTextU(p.1) # ")"

--- a/test/fail/implicit-example-sugar.mo
+++ b/test/fail/implicit-example-sugar.mo
@@ -13,7 +13,7 @@ module Int {
 
 module Array {
 
-  public func toText<T>(as : [T], implicit toText : T -> Text) : Text {
+  public func toText<T>(as : [T], toText: (implicit : T -> Text)) : Text {
      var t = "";
      for (a in as.vals()) {
        t := t # (toText(a));
@@ -27,8 +27,8 @@ module Array {
 module Pair {
 
   public func toText<T,U>(
-    toTextT : (implicit (toText : T -> Text)),
-    toTextU : (implicit (toText : U -> Text)),
+    toTextT : (implicit : (toText : T -> Text)),
+    toTextU : (implicit : (toText : U -> Text)),
     p : (T, U))
     : Text {
       "(" # toTextT(p.0) # "," # toTextU(p.1) # ")"

--- a/test/fail/ok/implicit-example-sugar.tc.ok
+++ b/test/fail/ok/implicit-example-sugar.tc.ok
@@ -1,0 +1,1 @@
+implicit-example-sugar.mo:46.7-46.8: warning [M0194], unused identifier p (delete or rename to wildcard `_` or `_p`)


### PR DESCRIPTION
Builds on #5521, but allows prefix use of `implicit` in patterns and named type items (use in arguments and tuples)

- [x] merge parent with master
- [x] merge with parent
- [ ] adjust type pretty printer