### PR TITLE
chore: fix `candid` flake `narHash`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -4,7 +4,7 @@
       "flake": false,
       "locked": {
         "lastModified": 1762175579,
-        "narHash": "sha256-ChlkmnamNG6LfpxEW6GwES6xigYwFgdBgzoNLrq0zJ4=",
+        "narHash": "sha256-FeQjl70Yi3ZoJNI88dtTWaOG2ikhm/Xnk96KVKLEYZU=",
         "owner": "dfinity",
         "repo": "candid",
         "rev": "bc49504faf55fce75793a6501e61e7ace680d922",


### PR DESCRIPTION
After updating to `nix profile add nixpkgs/release-25.05#nix && nix profile upgrade nix`
```
$ nix --version
nix (Nix) 2.31.2
```

Looks like `nix (Nix) 2.28.5` and `nix-2.33.0pre20251121` both don't need this change, so this might be a bug in `2.31.2`.