### PR TITLE
feat: makes `system` capability available in mixin top-level

### DIFF
--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -4189,7 +4189,11 @@ and infer_dec env dec : T.typ =
     let t_pat, ve = infer_pat_exhaustive error env args in
     let env' = adjoin_vals env ve in
     let obj_sort : obj_sort = { it = T.Mixin ; at = no_region; note = { it = true; at = no_region; note = () } }  in
-    let t' = infer_obj { env' with check_unused = false } obj_sort None dec_fields dec.at in
+    let t' = infer_obj {
+      env' with check_unused = false;
+      (* HACK? If/When we add type parameters to mixins we can use a non-top_cap scope here. *)
+      async = C.SystemCap C.top_cap;
+    } obj_sort None dec_fields dec.at in
     T.normalize t'
   | TypD _ ->
     T.unit

--- a/test/fail/mixin-capabilities.mo
+++ b/test/fail/mixin-capabilities.mo
@@ -1,6 +1,5 @@
 import MixinCap "mixins/MixinCap";
-// checks MixinCap can't send and doesnot have system capability
-// Actually, one could allow system capability but fine not to.
+// checks MixinCap can't send but does have system capability
 persistent actor {
    include MixinCap(0);
    f<system>();

--- a/test/fail/ok/mixin-capabilities.tc.ok
+++ b/test/fail/ok/mixin-capabilities.tc.ok
@@ -1,4 +1,2 @@
-mixins/MixinCap.mo:4.4-4.15: type error [M0197], `system` capability required, but not available
- (need an enclosing async expression or function body or explicit `system` type parameter)
 mixins/MixinCap.mo:5.4-5.19: type error [M0038], misplaced await
 mixins/MixinCap.mo:5.10-5.18: type error [M0037], misplaced async expression; try enclosing in an async function


### PR DESCRIPTION
Fixes #5805 

Could consider making this more strict at some point by passing the capability as a type parameter on the include.

## Implementation notes

I conjured the `C.top_cap` from "ether" like we do for actor classes. If you'd rather have me find a spot to insert it in the parser like we do for actors, I can give that a try as well.