### PR TITLE
moc.js: add `resetExtraFlags` API

### DIFF
--- a/src/js/common.ml
+++ b/src/js/common.ml
@@ -81,6 +81,19 @@ let js_set_extra_flags flags =
   let tokens = flags |> Js.to_array |> Array.map Js.to_string in
   parse_extra_flags tokens
 
+let js_reset_extra_flags () =
+  Flags.print_warnings := true;
+  Flags.warnings_are_errors := false;
+  Flags.warning_levels := Flags.default_warning_levels;
+  Flags.error_detail := 4;
+  Flags.error_recovery := false;
+  Flags.error_format := Flags.Plain;
+  Flags.ai_errors := false;
+  Flags.all_libs := false;
+  Flags.implicit_package := None;
+  Flags.actors := Flags.RequirePersistentActors;
+  Flags.enhanced_migration := None
+
 let js_set_run_step_limit limit =
   Mo_interpreter.Interpret.step_limit := limit
 

--- a/src/js/common.ml
+++ b/src/js/common.ml
@@ -81,18 +81,32 @@ let js_set_extra_flags flags =
   let tokens = flags |> Js.to_array |> Array.map Js.to_string in
   parse_extra_flags tokens
 
+let js_clear_extra_flag name =
+  match name with
+  | "--hide-warnings" -> Flags.print_warnings := true
+  | "-Werror" -> Flags.warnings_are_errors := false
+  | "-A" | "-W" | "-E" -> Flags.warning_levels := Flags.default_warning_levels
+  | "--error-detail" -> Flags.error_detail := 4
+  | "--error-recovery" -> Flags.error_recovery := false
+  | "--error-format" -> Flags.error_format := Flags.Plain
+  | "--ai-errors" -> Flags.ai_errors := false
+  | "--all-libs" -> Flags.all_libs := false
+  | "--implicit-package" -> Flags.implicit_package := None
+  | "--enhanced-migration" -> Flags.enhanced_migration := None
+  | "--default-persistent-actors"
+  | "--require-persistent-actors"
+  | "--legacy-actors" -> Flags.actors := Flags.RequirePersistentActors
+  | _ -> failwith (Printf.sprintf "clearExtraFlag: unknown flag %s" name)
+
+let all_extra_flag_names = [
+  "--hide-warnings"; "-Werror"; "-W";
+  "--error-detail"; "--error-recovery"; "--error-format";
+  "--ai-errors"; "--all-libs"; "--implicit-package";
+  "--enhanced-migration"; "--require-persistent-actors";
+]
+
 let js_reset_extra_flags () =
-  Flags.print_warnings := true;
-  Flags.warnings_are_errors := false;
-  Flags.warning_levels := Flags.default_warning_levels;
-  Flags.error_detail := 4;
-  Flags.error_recovery := false;
-  Flags.error_format := Flags.Plain;
-  Flags.ai_errors := false;
-  Flags.all_libs := false;
-  Flags.implicit_package := None;
-  Flags.actors := Flags.RequirePersistentActors;
-  Flags.enhanced_migration := None
+  List.iter js_clear_extra_flag all_extra_flag_names
 
 let js_set_run_step_limit limit =
   Mo_interpreter.Interpret.step_limit := limit

--- a/src/js/moc_js.ml
+++ b/src/js/moc_js.ml
@@ -17,6 +17,7 @@ let () =
       val version = js_version
       method setProjectRoot path = Flags.js_project_root := Some (Js.to_string path)
       method setExtraFlags argv = js_set_extra_flags argv
+      method resetExtraFlags () = js_reset_extra_flags ()
       method saveFile name content = js_save_file name content
       method removeFile name = js_remove_file name
       method renameFile oldpath newpath = js_rename_file oldpath newpath

--- a/src/js/moc_js.ml
+++ b/src/js/moc_js.ml
@@ -18,6 +18,7 @@ let () =
       method setProjectRoot path = Flags.js_project_root := Some (Js.to_string path)
       method setExtraFlags argv = js_set_extra_flags argv
       method resetExtraFlags () = js_reset_extra_flags ()
+      method clearExtraFlag name = js_clear_extra_flag (Js.to_string name)
       method saveFile name content = js_save_file name content
       method removeFile name = js_remove_file name
       method renameFile oldpath newpath = js_rename_file oldpath newpath

--- a/test/test-moc.js
+++ b/test/test-moc.js
@@ -288,3 +288,35 @@ assert.throws(
   () => Motoko.setExtraFlags(["-W=MMM"]),
   /moc: invalid warning code: MMM/
 );
+
+// js_of_ocaml note: `method m () = ...` compiles to a 2-arity function
+// (this + unit). Calling from JS requires a dummy argument to avoid partial
+// application. This matches how node-motoko's invoke() calls these methods.
+const resetFlags = () => Motoko.resetExtraFlags(0);
+
+// resetExtraFlags restores moc.js-default error detail (4)
+Motoko.setExtraFlags(["--error-detail", "0"]);
+const lowDetailResult = Motoko.check("bad.mo");
+assert.equal(lowDetailResult.diagnostics.length, 1);
+assert(
+  !lowDetailResult.diagnostics[0].message.includes("expected one of"),
+  "with --error-detail 0 the message should omit expected tokens"
+);
+resetFlags();
+const restoredDetailResult = Motoko.check("bad.mo");
+assert.equal(restoredDetailResult.diagnostics.length, 1);
+assert(
+  restoredDetailResult.diagnostics[0].message.includes("expected one of"),
+  "after resetExtraFlags, error detail should be restored to 4"
+);
+
+// resetExtraFlags then setExtraFlags: old flags don't bleed
+Motoko.setExtraFlags(["--error-detail", "0"]);
+resetFlags();
+Motoko.setExtraFlags(["--all-libs"]);
+const afterResetAndSet = Motoko.check("bad.mo");
+assert(
+  afterResetAndSet.diagnostics[0].message.includes("expected one of"),
+  "--error-detail 0 should not bleed through resetExtraFlags into subsequent setExtraFlags"
+);
+resetFlags();

--- a/test/test-moc.js
+++ b/test/test-moc.js
@@ -294,29 +294,35 @@ assert.throws(
 // application. This matches how node-motoko's invoke() calls these methods.
 const resetFlags = () => Motoko.resetExtraFlags(0);
 
-// resetExtraFlags restores moc.js-default error detail (4)
+// clearExtraFlag clears a single flag by CLI name
 Motoko.setExtraFlags(["--error-detail", "0"]);
-const lowDetailResult = Motoko.check("bad.mo");
-assert.equal(lowDetailResult.diagnostics.length, 1);
+assert(!Motoko.check("bad.mo").diagnostics[0].message.includes("expected one of"));
+Motoko.clearExtraFlag("--error-detail");
 assert(
-  !lowDetailResult.diagnostics[0].message.includes("expected one of"),
-  "with --error-detail 0 the message should omit expected tokens"
+  Motoko.check("bad.mo").diagnostics[0].message.includes("expected one of"),
+  "clearExtraFlag should restore --error-detail to moc.js default (4)"
 );
+
+// clearExtraFlag throws on unknown flag
+assert.throws(
+  () => Motoko.clearExtraFlag("--nonexistent"),
+  /clearExtraFlag: unknown flag/
+);
+
+// resetExtraFlags resets all flags at once
+Motoko.setExtraFlags(["--error-detail", "0"]);
 resetFlags();
-const restoredDetailResult = Motoko.check("bad.mo");
-assert.equal(restoredDetailResult.diagnostics.length, 1);
 assert(
-  restoredDetailResult.diagnostics[0].message.includes("expected one of"),
-  "after resetExtraFlags, error detail should be restored to 4"
+  Motoko.check("bad.mo").diagnostics[0].message.includes("expected one of"),
+  "resetExtraFlags should restore --error-detail to moc.js default (4)"
 );
 
 // resetExtraFlags then setExtraFlags: old flags don't bleed
 Motoko.setExtraFlags(["--error-detail", "0"]);
 resetFlags();
 Motoko.setExtraFlags(["--all-libs"]);
-const afterResetAndSet = Motoko.check("bad.mo");
 assert(
-  afterResetAndSet.diagnostics[0].message.includes("expected one of"),
-  "--error-detail 0 should not bleed through resetExtraFlags into subsequent setExtraFlags"
+  Motoko.check("bad.mo").diagnostics[0].message.includes("expected one of"),
+  "--error-detail 0 should not bleed through resetExtraFlags"
 );
 resetFlags();


### PR DESCRIPTION
## Problem

`setExtraFlags(["--enhanced-migration=migrations"])` sets `Flags.enhanced_migration := Some "migrations"`. A subsequent `setExtraFlags(["--all-libs"])` does **not** clear `enhanced_migration` — it stays `Some "migrations"` forever. There is no way to "unset" a flag once set via `setExtraFlags`.

This breaks multi-canister projects (e.g. in the VS Code extension) where only some canisters use `--enhanced-migration`. Flags from one canister's type-check bleed into the next.

## Fix

Two new APIs on the moc.js `Motoko` object:

### `clearExtraFlag(name)`

Clears a single flag by its CLI name (the same format used in `mops.toml` and `setExtraFlags`). Throws on unknown flag names.

```js
Motoko.clearExtraFlag("--enhanced-migration");  // resets to None
Motoko.clearExtraFlag("--error-detail");        // resets to 4 (moc.js default)
Motoko.clearExtraFlag("--nonexistent");          // throws
```

Supported flags: `--hide-warnings`, `-Werror`, `-A`/`-W`/`-E`, `--error-detail`, `--error-recovery`, `--error-format`, `--ai-errors`, `--all-libs`, `--implicit-package`, `--enhanced-migration`, `--default-persistent-actors`/`--require-persistent-actors`/`--legacy-actors`.

### `resetExtraFlags()`

Resets **all** flags touchable by `setExtraFlags` back to their moc.js defaults. Implemented by iterating over all known flag names and calling the same clear logic. Convenience method for the common pattern: `resetExtraFlags()` then `setExtraFlags(perCanisterFlags)`.

Flags managed by dedicated APIs (`setProjectRoot`, `addPackage`, `setCandidPath`, etc.) are intentionally not touched by either method.

## Caveat — js_of_ocaml calling convention

`method m () = ...` in js_of_ocaml compiles to a 2-arity JS function (`this` + unit). Calling `Motoko.resetExtraFlags()` with 0 arguments triggers OCaml currying and returns a partial application. Callers must pass a dummy argument: `Motoko.resetExtraFlags(0)`. Same applies to the existing `clearPackage`. node-motoko's `invoke()` handles this transparently.

## Downstream changes needed

- **node-motoko**: expose `clearExtraFlag(name)` via `invoke('clearExtraFlag', false, [name])` and `resetExtraFlags()` via `invoke('resetExtraFlags', false, [])`
- **vscode-motoko**: call `resetExtraFlags()` then `setExtraFlags(perCanisterFlags)` before each type-check, or use surgical `clearExtraFlag("--enhanced-migration")` when switching canisters

## Test plan

- [x] `clearExtraFlag("--error-detail")` restores detail to 4 after `setExtraFlags(["--error-detail", "0"])`
- [x] `clearExtraFlag("--nonexistent")` throws
- [x] `resetExtraFlags` restores all flags
- [x] Flags don't bleed through `resetExtraFlags` into subsequent `setExtraFlags`
- [x] Verified locally with `dune build` + `node`
- [ ] CI: `nix build .#js.moc` runs `test/test-moc.js` end-to-end