### PR TITLE
[experiment] arm64-linux-16 max-jobs=2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,12 @@ jobs:
       matrix:
         os: [ubuntu-24-large, arm64-linux-16]
         build_type: [release, debug]
+        include:
+          - os: ubuntu-24-large
+            max_jobs: auto
+          # arm64-linux-16 OOMs on three parallel ~3 GB derivation builds; serialise.
+          - os: arm64-linux-16
+            max_jobs: 1
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -73,6 +79,7 @@ jobs:
           test-target: ${{ matrix.build_type }}-systems-go
           test-name: ${{ matrix.os }}-${{ matrix.build_type }}-tests
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          max-jobs: ${{ matrix.max_jobs }}
 
       - name: Create GitHub App Token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
             max_jobs: auto
           # arm64-linux-16 OOMs on three parallel ~3 GB RTS-variant builds; serialise.
           - os: arm64-linux-16
-            max_jobs: 1
+            max_jobs: 2
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -61,7 +61,7 @@ jobs:
             max_jobs: auto
           # arm64-linux-16 OOMs on three parallel ~3 GB derivation builds; serialise.
           - os: arm64-linux-16
-            max_jobs: 1
+            max_jobs: 2
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/test-runner/src/run_test.rs
+++ b/test-runner/src/run_test.rs
@@ -1,5 +1,6 @@
 //! Runs Motoko test files (`.mo .drun .sh .wat .did .cmp`).
 //! CLI: `run-test [-adpitsrv] <file>...`.
+// cache-bust experiment: arm64 max-jobs=2 probe — revert before merging.
 
 use clap::Parser;
 use regex::Regex;


### PR DESCRIPTION
Probing whether two parallel ~3 GB derivation builds fit on the 16 GB runner. If green, we can relax PR #6089 from max-jobs=1 to max-jobs=2.

Stacked on top of #6089. Will close once we've learned.