### PR TITLE
docs: fix typo in CI documentation

### DIFF
--- a/CI.md
+++ b/CI.md
@@ -104,7 +104,7 @@ Hydra job status page, and the there is a stable link for the latest build of
 `master` and of each PR.
 
 **Implementation (external):**
-The latest `master` version of the file is availble at
+The latest `master` version of the file is available at
 [https://dfinity.github.io/motoko/](https://dfinity.github.io/motoko/).
 The reports are calculated in PRs (so failures would be caught), but are not
 hosted anywhere.


### PR DESCRIPTION
This PR fixes a simple typo in CI.md:
- `availble` → `available`

No functional changes, just documentation improvement.