### PR TITLE
fix: implement Candid rule `service <actortype> <: principal`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 * motoko (`moc`)
 
+  * bugfix: implement the new Candid subtyping rule `service <actortype> <: principal`
+    (dfinity/candid#748): service references now decode at type `Principal`, both when
+    decoded directly and in deferred subtype checks on function references (#6275).
+
   * chore: multi-value Wasm codegen is now always on;
     `--(no-)experimental-multi-value` are kept for CLI compatibility but have
     no effect (#6266).

--- a/rts/motoko-rts/src/idl.rs
+++ b/rts/motoko-rts/src/idl.rs
@@ -1219,6 +1219,8 @@ pub(crate) unsafe fn sub(
                 }
                 return true;
             }
+            // rule: `service <actortype> <: principal`
+            (IDL_CON_service, IDL_REF_principal) => return true,
             (IDL_CON_service, IDL_CON_service) => {
                 let mut n1 = leb128_decode(&mut tb1);
                 let n2 = leb128_decode(&mut tb2);

--- a/src/codegen/compile_classical.ml
+++ b/src/codegen/compile_classical.ml
@@ -8055,13 +8055,24 @@ module MakeSerialization (Strm : Stream) = struct
       | Prim Blob ->
         with_blob_typ env (read_blob ())
       | Prim Principal ->
-        with_prim_typ t
-        begin
+        (* rule: `service <actortype> <: principal`, so also accept a service reference *)
+        let read_principal_data () =
           read_byte_tagged
             [ E.trap_with env "IDL error: unexpected principal reference"
             ; read_principal Tagged.P ()
             ]
-        end
+        in
+        check_prim_typ t ^^
+        G.if1 I32Type
+          (read_principal_data ())
+          begin
+            check_composite_typ get_idltyp idl_service ^^
+            G.if1 I32Type
+              (read_principal_data ())
+              ( skip get_idltyp ^^
+                coercion_failed ("IDL error: unexpected IDL type when parsing " ^ string_of_typ t)
+              )
+          end
       | Prim Text ->
         with_prim_typ t (read_text ())
       | Tup [] -> (* e(()) = null *)

--- a/src/codegen/compile_enhanced.ml
+++ b/src/codegen/compile_enhanced.ml
@@ -8502,13 +8502,24 @@ module Serialization = struct
           Internals.dedup env          (* Call dedup *)
         )
       | Prim Principal ->
-        with_prim_typ t
-        begin
+        (* rule: `service <actortype> <: principal`, so also accept a service reference *)
+        let read_principal_data () =
           read_byte_tagged
             [ E.trap_with env "IDL error: unexpected principal reference"
             ; read_principal Tagged.P ()
             ]
-        end
+        in
+        check_prim_typ t ^^
+        E.if1 I64Type
+          (read_principal_data ())
+          begin
+            check_composite_typ get_idltyp idl_service ^^
+            E.if1 I64Type
+              (read_principal_data ())
+              ( skip get_idltyp ^^
+                coercion_failed ("IDL error: unexpected IDL type when parsing " ^ string_of_typ t)
+              )
+          end
       | Prim Text ->
         with_prim_typ t (read_text ())
       | Tup [] -> (* e(()) = null *)

--- a/test/run/idl-service-principal.mo
+++ b/test/run/idl-service-principal.mo
@@ -1,0 +1,45 @@
+import Prim "mo:⛔";
+
+// Candid rule `service <actortype> <: principal`:
+// service references decode at type `principal`, but not vice versa.
+
+type S = actor { m : shared () -> async S };
+type P = actor { m : shared () -> async Principal };
+
+let a = actor "w7x7r-cok77-xa" : actor {};
+let s = actor "w7x7r-cok77-xa" : S;
+let sp = actor "w7x7r-cok77-xa" : P;
+
+// a service reference value decodes at principal
+do {
+  let p : ?Principal = from_candid (to_candid (a));
+  assert p == ?Prim.principalOfActor a;
+};
+
+// a recursive service type still decodes at principal
+do {
+  let p : ?Principal = from_candid (to_candid (s));
+  assert p == ?Prim.principalOfActor s;
+};
+
+// a principal value does not decode at a service type
+do {
+  let x : ?(actor {}) = from_candid (to_candid (Prim.principalOfActor a));
+  assert x == null;
+};
+
+// deferred subtype check: func () -> (service ...) decodes at func () -> (principal)
+do {
+  let g : ?(shared () -> async Principal) = from_candid (to_candid (s.m));
+  assert g == ?(sp.m);
+};
+
+// ... but func () -> (principal) does not decode at func () -> (service ...)
+do {
+  let g : ?(shared () -> async S) = from_candid (to_candid (sp.m));
+  assert g == null;
+};
+
+//SKIP run
+//SKIP run-ir
+//SKIP run-low


### PR DESCRIPTION
The daily flake.lock update ([#6269](https://github.com/caffeinelabs/motoko/pull/6269)) has been failing for ~5 days: the bumped `candid-src` includes [dfinity/candid#748](https://github.com/dfinity/candid/pull/748), which added the Candid spec rule `service <actortype> <: principal` along with conformance tests, and `moc`-compiled code rejected the new coercion. Six `test-candid` cases trapped: `reference:31/32/42` (a service reference value decodes at type `principal`) and `subtypes:162/164/170` (the deferred subtype check on function references, `func () -> (service …) <: func () -> (principal)`).

Both places that implement Candid subtyping for decoding learn the new rule:

- the RTS `sub` check (`rts/motoko-rts/src/idl.rs`) accepts `(service, principal)`, covering higher-order function-reference checks;
- `Prim Principal` deserialization in both codegen backends accepts a `service` wire type in addition to `principal` (a service reference has the identical value encoding, so it is read as principal bytes).

The reverse direction (`principal </: service`) remains rejected, as the spec requires. The stable-compatibility relation (`memory_compatible`) is intentionally untouched — persistence subtyping is a separate relation with its own invariants.

Verified against both candid test-suite pins: the currently locked rev passes 456/456 (this PR does not need the flake bump), and the new rev passes 467/467 (previously 6 failures), so [#6269](https://github.com/caffeinelabs/motoko/pull/6269) can land once this merges. New `test/run/idl-service-principal.mo` covers both directions in both persistence modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)