### PR TITLE
feat: validate the migration directory against the deployed history recorded by `--stable-baseline`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,19 @@
     write-a-migration hint is only offered when adding a migration file can
     actually fix the field (#6318).
 
+  * feat: with `--stable-baseline` and `--enhanced-migration`, the migration
+    directory is now checked against the history the baseline records. The oldest
+    migrations may be trimmed away once they have been applied, but one that was
+    edited, backdated or deleted after deployment is an error (M0268) — where
+    before it surfaced as a puzzling complaint about the stable variables it
+    produced, or went unnoticed entirely.
+
+    Migrations the baseline records as applied are no longer re-checked as
+    incremental steps: their composition is history, and what the actor has to fit
+    is the deployed state the baseline describes. A problem with a stable variable
+    such a migration produced is therefore reported once, against that state and
+    pointing at the offending declaration, instead of twice (#6281).
+
 ## 1.14.1 (2026-08-17)
 
 * motoko (`moc`)

--- a/Changelog.md
+++ b/Changelog.md
@@ -17,15 +17,15 @@
   * feat: with `--stable-baseline` and `--enhanced-migration`, the migration
     directory is now checked against the history the baseline records. The oldest
     migrations may be trimmed away once they have been applied, but one that was
-    edited, backdated or deleted after deployment is an error (M0268) — where
-    before it surfaced as a puzzling complaint about the stable variables it
-    produced, or went unnoticed entirely.
+    edited, backdated or deleted after deployment is reported with M0268 — an
+    error by default, demotable to a warning with `-W=M0268` or silenced with
+    `-A=M0268` for directories that intentionally diverge.
 
-    Migrations the baseline records as applied are no longer re-checked as
-    incremental steps: their composition is history, and what the actor has to fit
-    is the deployed state the baseline describes. A problem with a stable variable
-    such a migration produced is therefore reported once, against that state and
-    pointing at the offending declaration, instead of twice (#6281).
+    In addition, a problem with a stable variable that an applied migration
+    consumes or produces is no longer reported twice — once by the migration
+    chain check and once against the deployed state. The chain check's error
+    stands, and the baseline only adds errors for fields the local chain does
+    not itself vouch for (#6281).
 
 ## 1.14.1 (2026-08-17)
 

--- a/src/lang_utils/error_codes.ml
+++ b/src/lang_utils/error_codes.ml
@@ -223,7 +223,6 @@ let error_codes : (string * string option) list =
     "M0263", None; (* Migration function requires a stable variable that the previous version does not provide *)
     "M0264", None; (* mixin include requires system capability *)
     "M0267", None; (* Initial actor or chain resume point requires field; the baseline does not explain it (e.g. added with no migration) *)
-    "M0268", None; (* Migration directory disagrees with the deployed history recorded by --stable-baseline *)
   ]
 
 (** Message codes that can be both used as warnings and errors *)
@@ -271,7 +270,8 @@ let warning_codes = [
   "M0244", None, "Mutable variable is never reassigned";
   "M0254", None, "Initial actor requires field";
   "M0265", None, "The `system` capability is not required by this mixin";
-  "M0266", None, "floating-point literal has more precision than its type can represent"
+  "M0266", None, "floating-point literal has more precision than its type can represent";
+  "M0268", None, "Migration directory disagrees with the deployed history recorded by --stable-baseline" (* Warn or Error *)
   ]
 
 let try_find_explanation code =

--- a/src/lang_utils/error_codes.ml
+++ b/src/lang_utils/error_codes.ml
@@ -223,6 +223,7 @@ let error_codes : (string * string option) list =
     "M0263", None; (* Migration function requires a stable variable that the previous version does not provide *)
     "M0264", None; (* mixin include requires system capability *)
     "M0267", None; (* Initial actor or chain resume point requires field; the baseline does not explain it (e.g. added with no migration) *)
+    "M0268", None; (* Migration directory disagrees with the deployed history recorded by --stable-baseline *)
   ]
 
 (** Message codes that can be both used as warnings and errors *)

--- a/src/mo_config/flags.ml
+++ b/src/mo_config/flags.ml
@@ -98,6 +98,7 @@ let default_warning_levels = M.empty
   |> M.add "M0235" Allow (* don't deprecate for non-caffeine *)
   |> M.add "M0236" Allow (* don't suggest contextual dot notation *)
   |> M.add "M0237" Allow (* don't report redundant explicit arguments *)
+  |> M.add "M0268" (Error : lint_level) (* a migration directory that disagrees with the deployed history is an error unless demoted *)
 
 let warning_levels = ref default_warning_levels
 

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -4687,11 +4687,11 @@ and check_migration_function env typ at =
    all remaining stable fields are deemed necessary and `required` from the previous version
    (like the other inputs to migration functions).
 
-   A --stable-baseline splits the chain in two. Migrations after the one it records as
-   most recently applied are pending: they still have to compose, so they are walked
-   backwards from the actor as above. The rest have already run — their composition is
-   history, and what the actor must fit is the deployed state the baseline describes —
-   so they are matched against the history it records instead.
+   The walk stands on the local chain alone: the produced wasm may also install fresh,
+   replaying every migration. A --stable-baseline only adds diagnostics for the upgrade
+   of the deployed canister it describes: the migration directory must still agree with
+   the history it records (M0268, an error unless demoted), and the fields the upgrade
+   demands at its resume point must be explained by the deployed state.
 
    This code is deliberately similar to check_chain in check_stab_sig below but produces more
    error messages.
@@ -4707,35 +4707,99 @@ and check_enhanced_migration_chain env chain stab_tfs at =
      let post_tfs, mig_lab_opt = T.post s in
      Some post_tfs, mig_lab_opt
  in
+ (* the local migrations the baseline records as already applied *)
+ let applied =
+   match baseline_mig_lab with
+   | None -> []
+   | Some head ->
+     List.filter (fun (file, _, _) -> T.migration_lab_of_filename file <= head) chain
+ in
+ (* fields an applied migration consumes or produces: the walk checks these at their own
+    step with per-version provenance, so the baseline sweep skips them and only speaks
+    about fields the local chain merely passes through *)
+ let touched =
+   applied |> List.concat_map (fun (_, _, typ) ->
+     if T.is_migration typ
+     then let (dom, rng) = T.as_migration typ in List.map (fun tf -> tf.T.lab) (dom @ rng)
+     else [])
+ in
+ let untouched = List.filter (fun tf -> not (List.mem tf.T.lab touched)) in
+ (* the applied ones must still be the files that ran: the local chain may omit the
+    oldest of them, but nothing else may differ *)
+ let rec check_history mfs bfs =
+   match mfs with
+   | [] -> () (* the oldest migrations may be trimmed away entirely *)
+   | (file, _, typ)::mfs1 ->
+     let file_at = let file_pos = { no_pos with file = file} in {left = file_pos; right=file_pos} in
+     let lab = T.migration_lab_of_filename file in
+     (* nothing local accounts for the deployed migrations that sort after this one *)
+     let rec drain bfs =
+       match bfs with
+       | bf::bfs1 when lab < bf.T.lab ->
+         warn env at "M0268"
+           "deployed migration `%s` is missing from the migration directory; only the oldest migrations may be trimmed away"
+           bf.T.lab;
+         drain bfs1
+       | bfs -> bfs
+     in
+     let bfs = drain bfs in
+     match bfs with
+     | bf::bfs1 when lab = bf.T.lab ->
+       if T.is_migration typ && not (T.eq typ bf.T.typ) then
+         warn env file_at "M0268"
+           "migration `%s` no longer matches the deployed history: it now has type%a\nbut the stable baseline records%a"
+           lab display_typ typ display_typ bf.T.typ;
+       check_history mfs1 bfs1
+     | bfs ->
+       warn env file_at "M0268"
+         "migration `%s` is not part of the deployed history recorded by the stable baseline"
+         lab;
+       check_history mfs1 bfs
+ in
+ let deployed =
+   (* the migrations that produced the deployed state, newest first *)
+   match env.stable_baseline_sig with
+   | Some (T.Multi {chain; _}) -> List.rev chain
+   | Some (T.Single _ | T.PrePost _) | None -> []
+ in
+ check_history (List.rev applied) deployed;
  let check_chain chain post =
-   let pending, applied =
-     match baseline_mig_lab with
-     | None -> chain, []
-     | Some head ->
-       List.partition (fun (file, _, _) -> T.migration_lab_of_filename file > head) chain
-   in
-   let mfs = List.rev pending in
-   let rec check_pending step_at post mfs =
+   let mfs = List.rev chain in
+   (* When the baseline already applied one of the chain's migrations, the upgrade resumes
+      after it (see T.pre), so the fields demanded from the baseline are those at the resume
+      point, not the initial actor's; `resume` captures that point during the backward walk. *)
+   let rec check_mfs step_at post resume mfs =
      match mfs with
      | [] ->
        (* Without a baseline the demand is unverifiable, so each field warns M0254.
           A baseline settles both directions in one sweep: explained fields are
           silent, unexplained fields error with M0267, and deployed fields
           nothing demands error with M0169. *)
+       let demanded, resume_lab =
+         match resume with
+         | Some (resume_post, lab) -> resume_post, Some lab
+         | None -> post, None
+       in
        (match baseline_post with
         | None ->
-          post |> List.iter (fun tf ->
+          demanded |> List.iter (fun tf ->
             warn env step_at "M0254"
               "initial actor requires field `%s` of type%a"
               tf.T.lab display_typ tf.T.typ)
         | Some baseline ->
           (* the chain's own input demand, computed without the actor fields:
              a missing field in it is not fixable by a new migration file *)
-          let chain_input = Stability.chain_input_fields baseline_mig_lab chain in
-          Stability.match_stab_em_fields env.msgs at baseline_mig_lab chain_input baseline post)
+          let chain_input = Stability.chain_input_fields resume_lab chain in
+          Stability.match_stab_em_fields env.msgs at resume_lab chain_input
+            (untouched baseline) (untouched demanded))
      | (file, _, typ)::mfs1 ->
         let file_at = let file_pos = { no_pos with file = file} in {left = file_pos; right=file_pos} in
         let mf = T.{lab = T.migration_lab_of_filename file; typ; src = T.empty_src } in
+        let resume =
+          if resume = None && baseline_mig_lab = Some mf.T.lab
+          then Some (post, mf.T.lab)
+          else resume
+        in
         (* is this a migration function *)
         let (dom_mf, rng_mf) = check_migration_function env mf.T.typ file_at in
         let out =
@@ -4754,51 +4818,10 @@ and check_enhanced_migration_chain env chain stab_tfs at =
         (* calculate the previous post and iterate *)
         let pre = T.pre_fields mf.T.typ post in
         let prev_post = List.map (fun (_required, tf) -> tf) pre in
-        check_pending file_at prev_post mfs1
+        check_mfs file_at prev_post resume mfs1
    in
-   (* the applied ones must still be the files that ran: the local chain may omit the
-      oldest of them, but nothing else may differ *)
-   let rec check_applied mfs bfs =
-     match mfs with
-     | [] -> () (* the oldest migrations may be trimmed away entirely *)
-     | (file, _, typ)::mfs1 ->
-       let file_at = let file_pos = { no_pos with file = file} in {left = file_pos; right=file_pos} in
-       let lab = T.migration_lab_of_filename file in
-       (* nothing local accounts for the deployed migrations that sort after this one *)
-       let rec drain bfs =
-         match bfs with
-         | bf::bfs1 when lab < bf.T.lab ->
-           local_error env at "M0268"
-             "deployed migration `%s` is missing from the migration directory; only the oldest migrations may be trimmed away"
-             bf.T.lab;
-           drain bfs1
-         | bfs -> bfs
-       in
-       let bfs = drain bfs in
-       (* is this a migration function *)
-       ignore (check_migration_function env typ file_at);
-       match bfs with
-       | bf::bfs1 when lab = bf.T.lab ->
-         if T.is_migration typ && not (T.eq typ bf.T.typ) then
-           local_error env file_at "M0268"
-             "migration `%s` no longer matches the deployed history: it now has type%a\nbut the stable baseline records%a"
-             lab display_typ typ display_typ bf.T.typ;
-         check_applied mfs1 bfs1
-       | bfs ->
-         local_error env file_at "M0268"
-           "migration `%s` is not part of the deployed history recorded by the stable baseline"
-           lab;
-         check_applied mfs1 bfs
-   in
-   let deployed =
-     (* the migrations that produced the deployed state, newest first *)
-     match env.stable_baseline_sig with
-     | Some (T.Multi {chain; _}) -> List.rev chain
-     | Some (T.Single _ | T.PrePost _) | None -> []
-   in
-   check_applied (List.rev applied) deployed;
-   (* the pending migrations compose to produce post *)
-   check_pending at post mfs
+   (* all migrations compose to produce post *)
+   check_mfs at post None mfs
  in
  check_chain chain stab_tfs
 

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -4687,58 +4687,47 @@ and check_migration_function env typ at =
    all remaining stable fields are deemed necessary and `required` from the previous version
    (like the other inputs to migration functions).
 
+   A --stable-baseline splits the chain in two. Migrations after the one it records as
+   most recently applied are pending: they still have to compose, so they are walked
+   backwards from the actor as above. The rest have already run — their composition is
+   history, and what the actor must fit is the deployed state the baseline describes —
+   so they are matched against the history it records instead.
+
    This code is deliberately similar to check_chain in check_stab_sig below but produces more
    error messages.
  *)
 
 and check_enhanced_migration_chain env chain stab_tfs at =
  if chain = [] then () else
- let baseline_post, baseline_mig_lab =
-   (* .most baseline tells us which fields are deployed and what is the most recent applied migration *)
+ (* the deployed state: which stable fields the canister holds, which migrations
+    produced them (newest first, as the walk visits them) and the most recent of those *)
+ let baseline_post, deployed, deployed_head =
    match env.stable_baseline_sig with
-   | None -> None, None
+   | None -> None, [], None
    | Some s ->
      let post_tfs, mig_lab_opt = T.post s in
-     Some post_tfs, mig_lab_opt
+     Some post_tfs,
+     (match s with
+      | T.Multi {chain; _} -> List.rev chain
+      | T.Single _ | T.PrePost _ -> []),
+     mig_lab_opt
  in
+ let file_at file = let file_pos = { no_pos with file } in {left = file_pos; right = file_pos} in
  let check_chain chain post =
-   let mfs = List.rev chain in
-   (* When the baseline already applied one of the chain's migrations, the upgrade resumes
-      after it (see T.pre), so the fields demanded from the baseline are those at the resume
-      point, not the initial actor's; `resume` captures that point during the backward walk. *)
-   let rec check_mfs step_at post resume mfs =
+   let pending, applied =
+     match deployed_head with
+     | None -> chain, []
+     | Some head ->
+       List.partition (fun (file, _, _) -> T.migration_lab_of_filename file > head) chain
+   in
+   (* each pending migration composes with the state its successor demands *)
+   let rec check_pending step_at post mfs =
      match mfs with
-     | [] ->
-       (* Without a baseline the demand is unverifiable, so each field warns M0254.
-          A baseline settles both directions in one sweep: explained fields are
-          silent, unexplained fields error with M0267, and deployed fields
-          nothing demands error with M0169. *)
-       let demanded, resume_lab =
-         match resume with
-         | Some (resume_post, lab) -> resume_post, Some lab
-         | None -> post, None
-       in
-       (match baseline_post with
-        | None ->
-          demanded |> List.iter (fun tf ->
-            warn env step_at "M0254"
-              "initial actor requires field `%s` of type%a"
-              tf.T.lab display_typ tf.T.typ)
-        | Some baseline ->
-          (* the chain's own input demand, computed without the actor fields:
-             a missing field in it is not fixable by a new migration file *)
-          let chain_input = Stability.chain_input_fields resume_lab chain in
-          Stability.match_stab_em_fields env.msgs at resume_lab chain_input baseline demanded)
+     | [] -> step_at, post
      | (file, _, typ)::mfs1 ->
-        let file_at = let file_pos = { no_pos with file = file} in {left = file_pos; right=file_pos} in
         let mf = T.{lab = T.migration_lab_of_filename file; typ; src = T.empty_src } in
-        let resume =
-          if resume = None && baseline_mig_lab = Some mf.T.lab
-          then Some (post, mf.T.lab)
-          else resume
-        in
         (* is this a migration function *)
-        let (dom_mf, rng_mf) = check_migration_function env mf.T.typ file_at in
+        let (dom_mf, rng_mf) = check_migration_function env mf.T.typ (file_at file) in
         let out =
           rng_mf @
             (List.filter (fun tf ->
@@ -4755,10 +4744,60 @@ and check_enhanced_migration_chain env chain stab_tfs at =
         (* calculate the previous post and iterate *)
         let pre = T.pre_fields mf.T.typ post in
         let prev_post = List.map (fun (_required, tf) -> tf) pre in
-        check_mfs file_at prev_post resume mfs1
+        check_pending (file_at file) prev_post mfs1
    in
-   (* all migrations compose to produce post *)
-   check_mfs at post None mfs
+   (* the applied ones must still be the files that ran: the local chain may omit the
+      oldest of them, but nothing else may differ *)
+   let error_unrecorded file lab =
+     local_error env (file_at file) "M0268"
+       "migration `%s` is not part of the deployed history recorded by the stable baseline"
+       lab
+   in
+   let rec check_applied mfs bfs =
+     match mfs with
+     | [] -> () (* the oldest migrations may be trimmed away entirely *)
+     | (file, _, typ)::mfs1 ->
+       let lab = T.migration_lab_of_filename file in
+       (* nothing local accounts for the deployed migrations that sort after this one *)
+       let rec drain bfs =
+         match bfs with
+         | bf::bfs1 when lab < bf.T.lab ->
+           local_error env at "M0268"
+             "deployed migration `%s` is missing from the migration directory; only the oldest migrations may be trimmed away"
+             bf.T.lab;
+           drain bfs1
+         | bfs -> bfs
+       in
+       let bfs = drain bfs in
+       (* is this a migration function *)
+       ignore (check_migration_function env typ (file_at file));
+       match bfs with
+       | bf::bfs1 when lab = bf.T.lab ->
+         if T.is_migration typ && not (T.eq typ bf.T.typ) then
+           local_error env (file_at file) "M0268"
+             "migration `%s` no longer matches the deployed history: it now has type%a\nbut the stable baseline records%a"
+             lab display_typ typ display_typ bf.T.typ;
+         check_applied mfs1 bfs1
+       | bfs ->
+         error_unrecorded file lab;
+         check_applied mfs1 bfs
+   in
+   let step_at, demanded = check_pending at post (List.rev pending) in
+   check_applied (List.rev applied) deployed;
+   (* `demanded` is what the deployed state has to supply. Without a baseline that is
+      unverifiable, so each field warns M0254; with one, explained fields are silent,
+      unexplained ones error with M0267 and deployed fields nothing demands error with M0169. *)
+   match baseline_post with
+   | None ->
+     demanded |> List.iter (fun tf ->
+       warn env step_at "M0254"
+         "initial actor requires field `%s` of type%a"
+         tf.T.lab display_typ tf.T.typ)
+   | Some baseline ->
+     (* the chain's own input demand, computed without the actor fields:
+        a missing field in it is not fixable by a new migration file *)
+     let chain_input = Stability.chain_input_fields deployed_head chain in
+     Stability.match_stab_em_fields env.msgs at deployed_head chain_input baseline demanded
  in
  check_chain chain stab_tfs
 

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -4699,35 +4699,45 @@ and check_migration_function env typ at =
 
 and check_enhanced_migration_chain env chain stab_tfs at =
  if chain = [] then () else
- (* the deployed state: which stable fields the canister holds, which migrations
-    produced them (newest first, as the walk visits them) and the most recent of those *)
- let baseline_post, deployed, deployed_head =
+ let baseline_post, baseline_mig_lab =
+   (* .most baseline tells us which fields are deployed and what is the most recent applied migration *)
    match env.stable_baseline_sig with
-   | None -> None, [], None
+   | None -> None, None
    | Some s ->
      let post_tfs, mig_lab_opt = T.post s in
-     Some post_tfs,
-     (match s with
-      | T.Multi {chain; _} -> List.rev chain
-      | T.Single _ | T.PrePost _ -> []),
-     mig_lab_opt
+     Some post_tfs, mig_lab_opt
  in
- let file_at file = let file_pos = { no_pos with file } in {left = file_pos; right = file_pos} in
  let check_chain chain post =
    let pending, applied =
-     match deployed_head with
+     match baseline_mig_lab with
      | None -> chain, []
      | Some head ->
        List.partition (fun (file, _, _) -> T.migration_lab_of_filename file > head) chain
    in
-   (* each pending migration composes with the state its successor demands *)
+   let mfs = List.rev pending in
    let rec check_pending step_at post mfs =
      match mfs with
-     | [] -> step_at, post
+     | [] ->
+       (* Without a baseline the demand is unverifiable, so each field warns M0254.
+          A baseline settles both directions in one sweep: explained fields are
+          silent, unexplained fields error with M0267, and deployed fields
+          nothing demands error with M0169. *)
+       (match baseline_post with
+        | None ->
+          post |> List.iter (fun tf ->
+            warn env step_at "M0254"
+              "initial actor requires field `%s` of type%a"
+              tf.T.lab display_typ tf.T.typ)
+        | Some baseline ->
+          (* the chain's own input demand, computed without the actor fields:
+             a missing field in it is not fixable by a new migration file *)
+          let chain_input = Stability.chain_input_fields baseline_mig_lab chain in
+          Stability.match_stab_em_fields env.msgs at baseline_mig_lab chain_input baseline post)
      | (file, _, typ)::mfs1 ->
+        let file_at = let file_pos = { no_pos with file = file} in {left = file_pos; right=file_pos} in
         let mf = T.{lab = T.migration_lab_of_filename file; typ; src = T.empty_src } in
         (* is this a migration function *)
-        let (dom_mf, rng_mf) = check_migration_function env mf.T.typ (file_at file) in
+        let (dom_mf, rng_mf) = check_migration_function env mf.T.typ file_at in
         let out =
           rng_mf @
             (List.filter (fun tf ->
@@ -4744,19 +4754,15 @@ and check_enhanced_migration_chain env chain stab_tfs at =
         (* calculate the previous post and iterate *)
         let pre = T.pre_fields mf.T.typ post in
         let prev_post = List.map (fun (_required, tf) -> tf) pre in
-        check_pending (file_at file) prev_post mfs1
+        check_pending file_at prev_post mfs1
    in
    (* the applied ones must still be the files that ran: the local chain may omit the
       oldest of them, but nothing else may differ *)
-   let error_unrecorded file lab =
-     local_error env (file_at file) "M0268"
-       "migration `%s` is not part of the deployed history recorded by the stable baseline"
-       lab
-   in
    let rec check_applied mfs bfs =
      match mfs with
      | [] -> () (* the oldest migrations may be trimmed away entirely *)
      | (file, _, typ)::mfs1 ->
+       let file_at = let file_pos = { no_pos with file = file} in {left = file_pos; right=file_pos} in
        let lab = T.migration_lab_of_filename file in
        (* nothing local accounts for the deployed migrations that sort after this one *)
        let rec drain bfs =
@@ -4770,34 +4776,29 @@ and check_enhanced_migration_chain env chain stab_tfs at =
        in
        let bfs = drain bfs in
        (* is this a migration function *)
-       ignore (check_migration_function env typ (file_at file));
+       ignore (check_migration_function env typ file_at);
        match bfs with
        | bf::bfs1 when lab = bf.T.lab ->
          if T.is_migration typ && not (T.eq typ bf.T.typ) then
-           local_error env (file_at file) "M0268"
+           local_error env file_at "M0268"
              "migration `%s` no longer matches the deployed history: it now has type%a\nbut the stable baseline records%a"
              lab display_typ typ display_typ bf.T.typ;
          check_applied mfs1 bfs1
        | bfs ->
-         error_unrecorded file lab;
+         local_error env file_at "M0268"
+           "migration `%s` is not part of the deployed history recorded by the stable baseline"
+           lab;
          check_applied mfs1 bfs
    in
-   let step_at, demanded = check_pending at post (List.rev pending) in
+   let deployed =
+     (* the migrations that produced the deployed state, newest first *)
+     match env.stable_baseline_sig with
+     | Some (T.Multi {chain; _}) -> List.rev chain
+     | Some (T.Single _ | T.PrePost _) | None -> []
+   in
    check_applied (List.rev applied) deployed;
-   (* `demanded` is what the deployed state has to supply. Without a baseline that is
-      unverifiable, so each field warns M0254; with one, explained fields are silent,
-      unexplained ones error with M0267 and deployed fields nothing demands error with M0169. *)
-   match baseline_post with
-   | None ->
-     demanded |> List.iter (fun tf ->
-       warn env step_at "M0254"
-         "initial actor requires field `%s` of type%a"
-         tf.T.lab display_typ tf.T.typ)
-   | Some baseline ->
-     (* the chain's own input demand, computed without the actor fields:
-        a missing field in it is not fixable by a new migration file *)
-     let chain_input = Stability.chain_input_fields deployed_head chain in
-     Stability.match_stab_em_fields env.msgs at deployed_head chain_input baseline demanded
+   (* the pending migrations compose to produce post *)
+   check_pending at post mfs
  in
  check_chain chain stab_tfs
 

--- a/test/fail/em-baseline-with-bad-dropped-lossy-at-m2-fully-trimmed.mo
+++ b/test/fail/em-baseline-with-bad-dropped-lossy-at-m2-fully-trimmed.mo
@@ -1,0 +1,10 @@
+//MOC-FLAG --enhanced-orthogonal-persistence --default-persistent-actors --enhanced-migration enhanced-migration/enh-mig-fullytrimmed
+//MOC-FLAG --stable-baseline enhanced-migration/baselines/with-bad-dropped-lossy-at-m2.most
+//MOC-FLAG -A=M0194
+
+// The deployed history m1, m2 (see with-bad-dropped-lossy-at-m2.most) is trimmed away entirely;
+// only the new m3 remains. m3 consumes `bad` and `dropped` from the deployed
+// state; the actor then drops the carried `lossy`.
+actor {
+    let bad : Nat;
+};

--- a/test/fail/em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch-demoted.mo
+++ b/test/fail/em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch-demoted.mo
@@ -1,0 +1,13 @@
+//MOC-FLAG --enhanced-orthogonal-persistence --default-persistent-actors --enhanced-migration enhanced-migration/enh-mig-history
+//MOC-FLAG --stable-baseline enhanced-migration/baselines/with-bad-dropped-lossy-at-m2.most
+//MOC-FLAG -A=M0194 -W=M0268
+
+// Same divergent directory as the -history-mismatch test, with the history
+// check demoted to a warning via -W=M0268: the escape hatch reports the
+// disagreements without failing on them, while the chain walk's own errors
+// still stand.
+actor {
+    let bad : Int;
+    let dropped : Nat;
+    let lossy : { a : Nat; b : Nat };
+};

--- a/test/fail/em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch.mo
+++ b/test/fail/em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch.mo
@@ -1,0 +1,14 @@
+//MOC-FLAG --enhanced-orthogonal-persistence --default-persistent-actors --enhanced-migration enhanced-migration/enh-mig-history
+//MOC-FLAG --stable-baseline enhanced-migration/baselines/with-bad-dropped-lossy-at-m2.most
+//MOC-FLAG -A=M0194
+
+// Three ways the migration directory can disagree with the deployed history
+// (see with-bad-dropped-lossy-at-m2.most): `m0` is backdated (sorts before the head but is not
+// recorded), `m1` was edited after deploy (produces Int, the history records
+// Nat), and the deployed head `m2` was deleted, which is not a prefix trim.
+// The actor itself matches the deployed state exactly.
+actor {
+    let bad : Int;
+    let dropped : Nat;
+    let lossy : { a : Nat; b : Nat };
+};

--- a/test/fail/em-baseline-with-bad-dropped-lossy-at-m2.mo
+++ b/test/fail/em-baseline-with-bad-dropped-lossy-at-m2.mo
@@ -1,0 +1,13 @@
+//MOC-FLAG --enhanced-orthogonal-persistence --default-persistent-actors --enhanced-migration enhanced-migration/enh-mig-trimmed
+//MOC-FLAG --stable-baseline enhanced-migration/baselines/with-bad-dropped-lossy-at-m2.most
+//MOC-FLAG -A=M0194
+
+// The deployed history is m1, m2 (see with-bad-dropped-lossy-at-m2.most); the local directory
+// keeps only m2 — a legal prefix trim. Against the deployed state the actor
+// retypes `bad`, drops `dropped`, narrows `lossy`, and declares `consumed`,
+// which the deployed state does not have.
+actor {
+    let bad : Nat;
+    let consumed : Nat;
+    let lossy : { a : Nat };
+};

--- a/test/fail/em-baseline-with-consumed-at-m1.mo
+++ b/test/fail/em-baseline-with-consumed-at-m1.mo
@@ -1,0 +1,10 @@
+//MOC-FLAG --enhanced-orthogonal-persistence --default-persistent-actors --enhanced-migration enhanced-migration/enh-mig-newstep
+//MOC-FLAG --stable-baseline enhanced-migration/baselines/with-consumed-at-m1.most
+//MOC-FLAG -A=M0194
+
+// m2 is new since the deploy (see with-consumed-at-m1.most): it requires a field the
+// deployed state lacks and misdeclares the type of one it has. The actor
+// matches m2's output.
+actor {
+    let done : Nat;
+};

--- a/test/fail/enhanced-migration/baselines/with-bad-dropped-lossy-at-m2.most
+++ b/test/fail/enhanced-migration/baselines/with-bad-dropped-lossy-at-m2.most
@@ -1,0 +1,12 @@
+// Version: 4.0.0
+{
+  "m1" : {} -> {consumed : Nat};
+  "m2" :
+    (old : {consumed : Nat}) ->
+      {bad : Int; dropped : Nat; lossy : {a : Nat; b : Nat}}
+}
+actor  {
+  stable bad : Int;
+  stable dropped : Nat;
+  stable lossy : {a : Nat; b : Nat}
+};

--- a/test/fail/enhanced-migration/baselines/with-consumed-at-m1.most
+++ b/test/fail/enhanced-migration/baselines/with-consumed-at-m1.most
@@ -1,0 +1,7 @@
+// Version: 4.0.0
+{
+  "m1" : {} -> {consumed : Nat}
+}
+actor  {
+  stable consumed : Nat
+};

--- a/test/fail/enhanced-migration/enh-mig-fullytrimmed/m3.mo
+++ b/test/fail/enhanced-migration/enh-mig-fullytrimmed/m3.mo
@@ -1,0 +1,6 @@
+module {
+    // Convert bad and drop dropped, both deployed by the trimmed-away history.
+    public func migration(old : { bad : Int; dropped : Nat }) : { bad : Nat } {
+        { bad = old.dropped };
+    };
+};

--- a/test/fail/enhanced-migration/enh-mig-history/m0.mo
+++ b/test/fail/enhanced-migration/enh-mig-history/m0.mo
@@ -1,0 +1,4 @@
+module {
+    // Sorts before the deployed history's first migration.
+    public func migration(_ : {}) : { sneaky : Nat } { { sneaky = 0 } };
+};

--- a/test/fail/enhanced-migration/enh-mig-history/m1.mo
+++ b/test/fail/enhanced-migration/enh-mig-history/m1.mo
@@ -1,0 +1,4 @@
+module {
+    // Edited after deploy: the recorded history produces consumed : Nat.
+    public func migration(_ : {}) : { consumed : Int } { { consumed = 0 } };
+};

--- a/test/fail/enhanced-migration/enh-mig-newstep/m1.mo
+++ b/test/fail/enhanced-migration/enh-mig-newstep/m1.mo
@@ -1,0 +1,4 @@
+module {
+    // Introduce field consumed.
+    public func migration(_ : {}) : { consumed : Nat } { { consumed = 0 } };
+};

--- a/test/fail/enhanced-migration/enh-mig-newstep/m2.mo
+++ b/test/fail/enhanced-migration/enh-mig-newstep/m2.mo
@@ -1,0 +1,8 @@
+module {
+    // New since the deploy: requires a field the deployed state lacks and
+    // misdeclares the type of one it has.
+    public func migration(old : { consumed : Bool; nonexistent : Text })
+      : { done : Nat } {
+        { done = if (old.consumed) 1 else 0 };
+    };
+};

--- a/test/fail/enhanced-migration/enh-mig-trimmed/m2.mo
+++ b/test/fail/enhanced-migration/enh-mig-trimmed/m2.mo
@@ -1,0 +1,7 @@
+module {
+    // Consume consumed, produce bad, dropped and lossy.
+    public func migration(old : { consumed : Nat })
+      : { bad : Int; dropped : Nat; lossy : { a : Nat; b : Nat } } {
+        { bad = old.consumed; dropped = 0; lossy = { a = 0; b = 0 } };
+    };
+};

--- a/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-fully-trimmed.tc-human.ok
+++ b/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-fully-trimmed.tc-human.ok
@@ -1,4 +1,4 @@
-error[M0169]: stable variable `lossy` of version `m2` cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
+error[M0169]: stable variable `lossy` of the previous version cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
 See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
     ┌─ em-baseline-with-bad-dropped-lossy-at-m2-fully-trimmed.mo:8:1
   7 │    // state; the actor then drops the carried `lossy`.

--- a/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-fully-trimmed.tc-human.ok
+++ b/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-fully-trimmed.tc-human.ok
@@ -1,4 +1,4 @@
-error[M0169]: stable variable `lossy` of the previous version cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
+error[M0169]: stable variable `lossy` of version `m2` cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
 See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
     ┌─ em-baseline-with-bad-dropped-lossy-at-m2-fully-trimmed.mo:8:1
   7 │    // state; the actor then drops the carried `lossy`.

--- a/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-fully-trimmed.tc-human.ok
+++ b/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-fully-trimmed.tc-human.ok
@@ -1,0 +1,9 @@
+error[M0169]: stable variable `lossy` of the previous version cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
+    ┌─ em-baseline-with-bad-dropped-lossy-at-m2-fully-trimmed.mo:8:1
+  7 │    // state; the actor then drops the carried `lossy`.
+  8 │ ╭  actor {
+  9 │ │      let bad : Nat;
+ 10 │ │  };
+    │ ╰──^ 
+ 11 │    

--- a/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-fully-trimmed.tc-human.ret.ok
+++ b/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-fully-trimmed.tc-human.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-fully-trimmed.tc.ok
+++ b/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-fully-trimmed.tc.ok
@@ -1,0 +1,2 @@
+em-baseline-with-bad-dropped-lossy-at-m2-fully-trimmed.mo:8.1-10.2: Compatibility error [M0169], stable variable `lossy` of the previous version cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/

--- a/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-fully-trimmed.tc.ok
+++ b/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-fully-trimmed.tc.ok
@@ -1,2 +1,2 @@
-em-baseline-with-bad-dropped-lossy-at-m2-fully-trimmed.mo:8.1-10.2: Compatibility error [M0169], stable variable `lossy` of version `m2` cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
+em-baseline-with-bad-dropped-lossy-at-m2-fully-trimmed.mo:8.1-10.2: Compatibility error [M0169], stable variable `lossy` of the previous version cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
 See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/

--- a/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-fully-trimmed.tc.ok
+++ b/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-fully-trimmed.tc.ok
@@ -1,2 +1,2 @@
-em-baseline-with-bad-dropped-lossy-at-m2-fully-trimmed.mo:8.1-10.2: Compatibility error [M0169], stable variable `lossy` of the previous version cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
+em-baseline-with-bad-dropped-lossy-at-m2-fully-trimmed.mo:8.1-10.2: Compatibility error [M0169], stable variable `lossy` of version `m2` cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
 See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/

--- a/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-fully-trimmed.tc.ret.ok
+++ b/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-fully-trimmed.tc.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch-demoted.tc-human.ok
+++ b/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch-demoted.tc-human.ok
@@ -1,0 +1,37 @@
+warning[M0268]: deployed migration `m2` is missing from the migration directory; only the oldest migrations may be trimmed away
+    ┌─ em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch-demoted.mo:9:1
+  8 │    // still stand.
+  9 │ ╭  actor {
+ 10 │ │      let bad : Int;
+ 11 │ │      let dropped : Nat;
+ 12 │ │      let lossy : { a : Nat; b : Nat };
+ 13 │ │  };
+    │ ╰──^ 
+ 14 │    
+warning[M0268]: migration `m1` no longer matches the deployed history: it now has type
+  {} -> {consumed : Int}
+but the stable baseline records
+  {} -> {consumed : Nat}
+    ┌─ enhanced-migration/enh-mig-history/m1.mo:1:1
+  1 │  module {
+    │  ^ 
+warning[M0268]: migration `m0` is not part of the deployed history recorded by the stable baseline
+    ┌─ enhanced-migration/enh-mig-history/m0.mo:1:1
+  1 │  module {
+    │  ^ 
+error[M0169]: stable variable `consumed` of version `m1` cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
+    ┌─ em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch-demoted.mo:9:1
+  8 │    // still stand.
+  9 │ ╭  actor {
+ 10 │ │      let bad : Int;
+ 11 │ │      let dropped : Nat;
+ 12 │ │      let lossy : { a : Nat; b : Nat };
+ 13 │ │  };
+    │ ╰──^ 
+ 14 │    
+error[M0169]: stable variable `sneaky` of version `m0` cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
+    ┌─ enhanced-migration/enh-mig-history/m1.mo:1:1
+  1 │  module {
+    │  ^ 

--- a/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch-demoted.tc-human.ret.ok
+++ b/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch-demoted.tc-human.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch-demoted.tc.ok
+++ b/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch-demoted.tc.ok
@@ -1,0 +1,10 @@
+em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch-demoted.mo:9.1-13.2: warning [M0268], deployed migration `m2` is missing from the migration directory; only the oldest migrations may be trimmed away
+enhanced-migration/enh-mig-history/m1.mo:0.1: warning [M0268], migration `m1` no longer matches the deployed history: it now has type
+  {} -> {consumed : Int}
+but the stable baseline records
+  {} -> {consumed : Nat}
+enhanced-migration/enh-mig-history/m0.mo:0.1: warning [M0268], migration `m0` is not part of the deployed history recorded by the stable baseline
+em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch-demoted.mo:9.1-13.2: Compatibility error [M0169], stable variable `consumed` of version `m1` cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
+enhanced-migration/enh-mig-history/m1.mo:0.1: Compatibility error [M0169], stable variable `sneaky` of version `m0` cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/

--- a/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch-demoted.tc.ret.ok
+++ b/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch-demoted.tc.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch.tc-human.ok
+++ b/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch.tc-human.ok
@@ -19,3 +19,19 @@ error[M0268]: migration `m0` is not part of the deployed history recorded by the
     ┌─ enhanced-migration/enh-mig-history/m0.mo:1:1
   1 │  module {
     │  ^ 
+error[M0169]: stable variable `consumed` of version `m1` cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
+    ┌─ em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch.mo:10:1
+  9 │    // The actor itself matches the deployed state exactly.
+ 10 │ ╭  actor {
+ 11 │ │      let bad : Int;
+ 12 │ │      let dropped : Nat;
+ 13 │ │      let lossy : { a : Nat; b : Nat };
+ 14 │ │  };
+    │ ╰──^ 
+ 15 │    
+error[M0169]: stable variable `sneaky` of version `m0` cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
+    ┌─ enhanced-migration/enh-mig-history/m1.mo:1:1
+  1 │  module {
+    │  ^ 

--- a/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch.tc-human.ok
+++ b/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch.tc-human.ok
@@ -1,5 +1,4 @@
-error[M0169]: stable variable `consumed` of version `m1` cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
-See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
+error[M0268]: deployed migration `m2` is missing from the migration directory; only the oldest migrations may be trimmed away
     ┌─ em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch.mo:10:1
   9 │    // The actor itself matches the deployed state exactly.
  10 │ ╭  actor {
@@ -9,8 +8,14 @@ See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhan
  14 │ │  };
     │ ╰──^ 
  15 │    
-error[M0169]: stable variable `sneaky` of version `m0` cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
-See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
+error[M0268]: migration `m1` no longer matches the deployed history: it now has type
+  {} -> {consumed : Int}
+but the stable baseline records
+  {} -> {consumed : Nat}
     ┌─ enhanced-migration/enh-mig-history/m1.mo:1:1
+  1 │  module {
+    │  ^ 
+error[M0268]: migration `m0` is not part of the deployed history recorded by the stable baseline
+    ┌─ enhanced-migration/enh-mig-history/m0.mo:1:1
   1 │  module {
     │  ^ 

--- a/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch.tc-human.ok
+++ b/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch.tc-human.ok
@@ -1,0 +1,16 @@
+error[M0169]: stable variable `consumed` of version `m1` cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
+    ┌─ em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch.mo:10:1
+  9 │    // The actor itself matches the deployed state exactly.
+ 10 │ ╭  actor {
+ 11 │ │      let bad : Int;
+ 12 │ │      let dropped : Nat;
+ 13 │ │      let lossy : { a : Nat; b : Nat };
+ 14 │ │  };
+    │ ╰──^ 
+ 15 │    
+error[M0169]: stable variable `sneaky` of version `m0` cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
+    ┌─ enhanced-migration/enh-mig-history/m1.mo:1:1
+  1 │  module {
+    │  ^ 

--- a/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch.tc-human.ret.ok
+++ b/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch.tc-human.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch.tc.ok
+++ b/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch.tc.ok
@@ -1,4 +1,6 @@
-em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch.mo:10.1-14.2: Compatibility error [M0169], stable variable `consumed` of version `m1` cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
-See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
-enhanced-migration/enh-mig-history/m1.mo:0.1: Compatibility error [M0169], stable variable `sneaky` of version `m0` cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
-See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
+em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch.mo:10.1-14.2: type error [M0268], deployed migration `m2` is missing from the migration directory; only the oldest migrations may be trimmed away
+enhanced-migration/enh-mig-history/m1.mo:0.1: type error [M0268], migration `m1` no longer matches the deployed history: it now has type
+  {} -> {consumed : Int}
+but the stable baseline records
+  {} -> {consumed : Nat}
+enhanced-migration/enh-mig-history/m0.mo:0.1: type error [M0268], migration `m0` is not part of the deployed history recorded by the stable baseline

--- a/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch.tc.ok
+++ b/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch.tc.ok
@@ -4,3 +4,7 @@ enhanced-migration/enh-mig-history/m1.mo:0.1: type error [M0268], migration `m1`
 but the stable baseline records
   {} -> {consumed : Nat}
 enhanced-migration/enh-mig-history/m0.mo:0.1: type error [M0268], migration `m0` is not part of the deployed history recorded by the stable baseline
+em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch.mo:10.1-14.2: Compatibility error [M0169], stable variable `consumed` of version `m1` cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
+enhanced-migration/enh-mig-history/m1.mo:0.1: Compatibility error [M0169], stable variable `sneaky` of version `m0` cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/

--- a/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch.tc.ok
+++ b/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch.tc.ok
@@ -1,0 +1,4 @@
+em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch.mo:10.1-14.2: Compatibility error [M0169], stable variable `consumed` of version `m1` cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
+enhanced-migration/enh-mig-history/m1.mo:0.1: Compatibility error [M0169], stable variable `sneaky` of version `m0` cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/

--- a/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch.tc.ret.ok
+++ b/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2-history-mismatch.tc.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2.tc-human.ok
+++ b/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2.tc-human.ok
@@ -10,15 +10,26 @@ Previous type
  in `bad`.
 Write an explicit migration function to convert it.
 See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
-    ┌─ em-baseline-with-bad-dropped-lossy-at-m2.mo:10:9
- 10 │      let bad : Nat;
-    │          ^^^ 
-error[M0267]: upgrade resuming after migration `m2` requires field `consumed` of type
-  Nat; not found in the previous version — write a migration that produces it.
+    ┌─ em-baseline-with-bad-dropped-lossy-at-m2.mo:9:1
+  8 │    // which the deployed state does not have.
+  9 │ ╭  actor {
+ 10 │ │      let bad : Nat;
+ 11 │ │      let consumed : Nat;
+ 12 │ │      let lossy : { a : Nat };
+ 13 │ │  };
+    │ ╰──^ 
+ 14 │    
+error[M0263]: version `m2` does not contain the stable variable `consumed`. The migration function cannot require this variable as input.
 See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
-    ┌─ em-baseline-with-bad-dropped-lossy-at-m2.mo:11:9
- 11 │      let consumed : Nat;
-    │          ^^^^^^^^ 
+    ┌─ em-baseline-with-bad-dropped-lossy-at-m2.mo:9:1
+  8 │    // which the deployed state does not have.
+  9 │ ╭  actor {
+ 10 │ │      let bad : Nat;
+ 11 │ │      let consumed : Nat;
+ 12 │ │      let lossy : { a : Nat };
+ 13 │ │  };
+    │ ╰──^ 
+ 14 │    
 error[M0169]: stable variable `dropped` of version `m2` cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
 See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
     ┌─ em-baseline-with-bad-dropped-lossy-at-m2.mo:9:1
@@ -40,6 +51,12 @@ Previous type
  of `lossy`.
 The data can only be dropped by an explicit migration function.
 See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
-    ┌─ em-baseline-with-bad-dropped-lossy-at-m2.mo:12:9
- 12 │      let lossy : { a : Nat };
-    │          ^^^^^ 
+    ┌─ em-baseline-with-bad-dropped-lossy-at-m2.mo:9:1
+  8 │    // which the deployed state does not have.
+  9 │ ╭  actor {
+ 10 │ │      let bad : Nat;
+ 11 │ │      let consumed : Nat;
+ 12 │ │      let lossy : { a : Nat };
+ 13 │ │  };
+    │ ╰──^ 
+ 14 │    

--- a/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2.tc-human.ok
+++ b/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2.tc-human.ok
@@ -10,68 +10,6 @@ Previous type
  in `bad`.
 Write an explicit migration function to convert it.
 See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
-    ┌─ em-baseline-with-bad-dropped-lossy-at-m2.mo:9:1
-  8 │    // which the deployed state does not have.
-  9 │ ╭  actor {
- 10 │ │      let bad : Nat;
- 11 │ │      let consumed : Nat;
- 12 │ │      let lossy : { a : Nat };
- 13 │ │  };
-    │ ╰──^ 
- 14 │    
-error[M0263]: version `m2` does not contain the stable variable `consumed`. The migration function cannot require this variable as input.
-See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
-    ┌─ em-baseline-with-bad-dropped-lossy-at-m2.mo:9:1
-  8 │    // which the deployed state does not have.
-  9 │ ╭  actor {
- 10 │ │      let bad : Nat;
- 11 │ │      let consumed : Nat;
- 12 │ │      let lossy : { a : Nat };
- 13 │ │  };
-    │ ╰──^ 
- 14 │    
-error[M0169]: stable variable `dropped` of version `m2` cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
-See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
-    ┌─ em-baseline-with-bad-dropped-lossy-at-m2.mo:9:1
-  8 │    // which the deployed state does not have.
-  9 │ ╭  actor {
- 10 │ │      let bad : Nat;
- 11 │ │      let consumed : Nat;
- 12 │ │      let lossy : { a : Nat };
- 13 │ │  };
-    │ ╰──^ 
- 14 │    
-error[M0216]: stable variable `lossy` implicitly drops data of version `m2`.
-Previous type
-  {a : Nat; b : Nat}
- is not a stable subtype of
-  {a : Nat}
- because field `b` is missing from expected type 
-  {a : Nat}
- of `lossy`.
-The data can only be dropped by an explicit migration function.
-See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
-    ┌─ em-baseline-with-bad-dropped-lossy-at-m2.mo:9:1
-  8 │    // which the deployed state does not have.
-  9 │ ╭  actor {
- 10 │ │      let bad : Nat;
- 11 │ │      let consumed : Nat;
- 12 │ │      let lossy : { a : Nat };
- 13 │ │  };
-    │ ╰──^ 
- 14 │    
-error[M0170]: stable variable `bad` is not compatible with version `m2`.
-Previous type
-  Int
- is not a subtype of
-  Nat
- because the type 
-  Int
- is not compatible with type 
-  Nat
- in `bad`.
-Write an explicit migration function to convert it.
-See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
     ┌─ em-baseline-with-bad-dropped-lossy-at-m2.mo:10:9
  10 │      let bad : Nat;
     │          ^^^ 

--- a/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2.tc-human.ok
+++ b/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2.tc-human.ok
@@ -1,0 +1,107 @@
+error[M0170]: stable variable `bad` is not compatible with version `m2`.
+Previous type
+  Int
+ is not a subtype of
+  Nat
+ because the type 
+  Int
+ is not compatible with type 
+  Nat
+ in `bad`.
+Write an explicit migration function to convert it.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
+    ┌─ em-baseline-with-bad-dropped-lossy-at-m2.mo:9:1
+  8 │    // which the deployed state does not have.
+  9 │ ╭  actor {
+ 10 │ │      let bad : Nat;
+ 11 │ │      let consumed : Nat;
+ 12 │ │      let lossy : { a : Nat };
+ 13 │ │  };
+    │ ╰──^ 
+ 14 │    
+error[M0263]: version `m2` does not contain the stable variable `consumed`. The migration function cannot require this variable as input.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
+    ┌─ em-baseline-with-bad-dropped-lossy-at-m2.mo:9:1
+  8 │    // which the deployed state does not have.
+  9 │ ╭  actor {
+ 10 │ │      let bad : Nat;
+ 11 │ │      let consumed : Nat;
+ 12 │ │      let lossy : { a : Nat };
+ 13 │ │  };
+    │ ╰──^ 
+ 14 │    
+error[M0169]: stable variable `dropped` of version `m2` cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
+    ┌─ em-baseline-with-bad-dropped-lossy-at-m2.mo:9:1
+  8 │    // which the deployed state does not have.
+  9 │ ╭  actor {
+ 10 │ │      let bad : Nat;
+ 11 │ │      let consumed : Nat;
+ 12 │ │      let lossy : { a : Nat };
+ 13 │ │  };
+    │ ╰──^ 
+ 14 │    
+error[M0216]: stable variable `lossy` implicitly drops data of version `m2`.
+Previous type
+  {a : Nat; b : Nat}
+ is not a stable subtype of
+  {a : Nat}
+ because field `b` is missing from expected type 
+  {a : Nat}
+ of `lossy`.
+The data can only be dropped by an explicit migration function.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
+    ┌─ em-baseline-with-bad-dropped-lossy-at-m2.mo:9:1
+  8 │    // which the deployed state does not have.
+  9 │ ╭  actor {
+ 10 │ │      let bad : Nat;
+ 11 │ │      let consumed : Nat;
+ 12 │ │      let lossy : { a : Nat };
+ 13 │ │  };
+    │ ╰──^ 
+ 14 │    
+error[M0170]: stable variable `bad` is not compatible with version `m2`.
+Previous type
+  Int
+ is not a subtype of
+  Nat
+ because the type 
+  Int
+ is not compatible with type 
+  Nat
+ in `bad`.
+Write an explicit migration function to convert it.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
+    ┌─ em-baseline-with-bad-dropped-lossy-at-m2.mo:10:9
+ 10 │      let bad : Nat;
+    │          ^^^ 
+error[M0267]: upgrade resuming after migration `m2` requires field `consumed` of type
+  Nat; not found in the previous version — write a migration that produces it.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
+    ┌─ em-baseline-with-bad-dropped-lossy-at-m2.mo:11:9
+ 11 │      let consumed : Nat;
+    │          ^^^^^^^^ 
+error[M0169]: stable variable `dropped` of version `m2` cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
+    ┌─ em-baseline-with-bad-dropped-lossy-at-m2.mo:9:1
+  8 │    // which the deployed state does not have.
+  9 │ ╭  actor {
+ 10 │ │      let bad : Nat;
+ 11 │ │      let consumed : Nat;
+ 12 │ │      let lossy : { a : Nat };
+ 13 │ │  };
+    │ ╰──^ 
+ 14 │    
+error[M0216]: stable variable `lossy` implicitly drops data of version `m2`.
+Previous type
+  {a : Nat; b : Nat}
+ is not a stable subtype of
+  {a : Nat}
+ because field `b` is missing from expected type 
+  {a : Nat}
+ of `lossy`.
+The data can only be dropped by an explicit migration function.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
+    ┌─ em-baseline-with-bad-dropped-lossy-at-m2.mo:12:9
+ 12 │      let lossy : { a : Nat };
+    │          ^^^^^ 

--- a/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2.tc-human.ret.ok
+++ b/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2.tc-human.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2.tc.ok
+++ b/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2.tc.ok
@@ -1,4 +1,4 @@
-em-baseline-with-bad-dropped-lossy-at-m2.mo:10.9-10.12: Compatibility error [M0170], stable variable `bad` is not compatible with version `m2`.
+em-baseline-with-bad-dropped-lossy-at-m2.mo:9.1-13.2: Compatibility error [M0170], stable variable `bad` is not compatible with version `m2`.
 Previous type
   Int
  is not a subtype of
@@ -10,12 +10,11 @@ Previous type
  in `bad`.
 Write an explicit migration function to convert it.
 See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
-em-baseline-with-bad-dropped-lossy-at-m2.mo:11.9-11.17: type error [M0267], upgrade resuming after migration `m2` requires field `consumed` of type
-  Nat; not found in the previous version — write a migration that produces it.
+em-baseline-with-bad-dropped-lossy-at-m2.mo:9.1-13.2: Compatibility error [M0263], version `m2` does not contain the stable variable `consumed`. The migration function cannot require this variable as input.
 See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
 em-baseline-with-bad-dropped-lossy-at-m2.mo:9.1-13.2: Compatibility error [M0169], stable variable `dropped` of version `m2` cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
 See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
-em-baseline-with-bad-dropped-lossy-at-m2.mo:12.9-12.14: Compatibility error [M0216], stable variable `lossy` implicitly drops data of version `m2`.
+em-baseline-with-bad-dropped-lossy-at-m2.mo:9.1-13.2: Compatibility error [M0216], stable variable `lossy` implicitly drops data of version `m2`.
 Previous type
   {a : Nat; b : Nat}
  is not a stable subtype of

--- a/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2.tc.ok
+++ b/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2.tc.ok
@@ -1,29 +1,3 @@
-em-baseline-with-bad-dropped-lossy-at-m2.mo:9.1-13.2: Compatibility error [M0170], stable variable `bad` is not compatible with version `m2`.
-Previous type
-  Int
- is not a subtype of
-  Nat
- because the type 
-  Int
- is not compatible with type 
-  Nat
- in `bad`.
-Write an explicit migration function to convert it.
-See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
-em-baseline-with-bad-dropped-lossy-at-m2.mo:9.1-13.2: Compatibility error [M0263], version `m2` does not contain the stable variable `consumed`. The migration function cannot require this variable as input.
-See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
-em-baseline-with-bad-dropped-lossy-at-m2.mo:9.1-13.2: Compatibility error [M0169], stable variable `dropped` of version `m2` cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
-See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
-em-baseline-with-bad-dropped-lossy-at-m2.mo:9.1-13.2: Compatibility error [M0216], stable variable `lossy` implicitly drops data of version `m2`.
-Previous type
-  {a : Nat; b : Nat}
- is not a stable subtype of
-  {a : Nat}
- because field `b` is missing from expected type 
-  {a : Nat}
- of `lossy`.
-The data can only be dropped by an explicit migration function.
-See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
 em-baseline-with-bad-dropped-lossy-at-m2.mo:10.9-10.12: Compatibility error [M0170], stable variable `bad` is not compatible with version `m2`.
 Previous type
   Int

--- a/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2.tc.ok
+++ b/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2.tc.ok
@@ -1,0 +1,53 @@
+em-baseline-with-bad-dropped-lossy-at-m2.mo:9.1-13.2: Compatibility error [M0170], stable variable `bad` is not compatible with version `m2`.
+Previous type
+  Int
+ is not a subtype of
+  Nat
+ because the type 
+  Int
+ is not compatible with type 
+  Nat
+ in `bad`.
+Write an explicit migration function to convert it.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
+em-baseline-with-bad-dropped-lossy-at-m2.mo:9.1-13.2: Compatibility error [M0263], version `m2` does not contain the stable variable `consumed`. The migration function cannot require this variable as input.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
+em-baseline-with-bad-dropped-lossy-at-m2.mo:9.1-13.2: Compatibility error [M0169], stable variable `dropped` of version `m2` cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
+em-baseline-with-bad-dropped-lossy-at-m2.mo:9.1-13.2: Compatibility error [M0216], stable variable `lossy` implicitly drops data of version `m2`.
+Previous type
+  {a : Nat; b : Nat}
+ is not a stable subtype of
+  {a : Nat}
+ because field `b` is missing from expected type 
+  {a : Nat}
+ of `lossy`.
+The data can only be dropped by an explicit migration function.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
+em-baseline-with-bad-dropped-lossy-at-m2.mo:10.9-10.12: Compatibility error [M0170], stable variable `bad` is not compatible with version `m2`.
+Previous type
+  Int
+ is not a subtype of
+  Nat
+ because the type 
+  Int
+ is not compatible with type 
+  Nat
+ in `bad`.
+Write an explicit migration function to convert it.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
+em-baseline-with-bad-dropped-lossy-at-m2.mo:11.9-11.17: type error [M0267], upgrade resuming after migration `m2` requires field `consumed` of type
+  Nat; not found in the previous version — write a migration that produces it.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
+em-baseline-with-bad-dropped-lossy-at-m2.mo:9.1-13.2: Compatibility error [M0169], stable variable `dropped` of version `m2` cannot be implicitly discarded. The variable can only be dropped by an explicit migration function.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
+em-baseline-with-bad-dropped-lossy-at-m2.mo:12.9-12.14: Compatibility error [M0216], stable variable `lossy` implicitly drops data of version `m2`.
+Previous type
+  {a : Nat; b : Nat}
+ is not a stable subtype of
+  {a : Nat}
+ because field `b` is missing from expected type 
+  {a : Nat}
+ of `lossy`.
+The data can only be dropped by an explicit migration function.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/

--- a/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2.tc.ret.ok
+++ b/test/fail/ok/em-baseline-with-bad-dropped-lossy-at-m2.tc.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/fail/ok/em-baseline-with-consumed-at-m1.tc-human.ok
+++ b/test/fail/ok/em-baseline-with-consumed-at-m1.tc-human.ok
@@ -10,13 +10,9 @@ Previous type
  in `consumed`.
 Write an explicit migration function to convert it.
 See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
-    ┌─ em-baseline-with-consumed-at-m1.mo:8:1
-  7 │    // matches m2's output.
-  8 │ ╭  actor {
-  9 │ │      let done : Nat;
- 10 │ │  };
-    │ ╰──^ 
- 11 │    
+    ┌─ enhanced-migration/enh-mig-newstep/m2.mo:1:1
+  1 │  module {
+    │  ^ 
 error[M0267]: the migration chain requires field `nonexistent` of type
   Text as input; the previous version must provide it.
 See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/

--- a/test/fail/ok/em-baseline-with-consumed-at-m1.tc-human.ok
+++ b/test/fail/ok/em-baseline-with-consumed-at-m1.tc-human.ok
@@ -10,21 +10,6 @@ Previous type
  in `consumed`.
 Write an explicit migration function to convert it.
 See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
-    ┌─ enhanced-migration/enh-mig-newstep/m2.mo:1:1
-  1 │  module {
-    │  ^ 
-error[M0170]: stable variable `consumed` is not compatible with version `m1`.
-Previous type
-  Nat
- is not a subtype of
-  Bool
- because the type 
-  Nat
- is not compatible with type 
-  Bool
- in `consumed`.
-Write an explicit migration function to convert it.
-See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
     ┌─ em-baseline-with-consumed-at-m1.mo:8:1
   7 │    // matches m2's output.
   8 │ ╭  actor {

--- a/test/fail/ok/em-baseline-with-consumed-at-m1.tc-human.ok
+++ b/test/fail/ok/em-baseline-with-consumed-at-m1.tc-human.ok
@@ -1,0 +1,44 @@
+error[M0170]: stable variable `consumed` is not compatible with version `m1`.
+Previous type
+  Nat
+ is not a subtype of
+  Bool
+ because the type 
+  Nat
+ is not compatible with type 
+  Bool
+ in `consumed`.
+Write an explicit migration function to convert it.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
+    ┌─ enhanced-migration/enh-mig-newstep/m2.mo:1:1
+  1 │  module {
+    │  ^ 
+error[M0170]: stable variable `consumed` is not compatible with version `m1`.
+Previous type
+  Nat
+ is not a subtype of
+  Bool
+ because the type 
+  Nat
+ is not compatible with type 
+  Bool
+ in `consumed`.
+Write an explicit migration function to convert it.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
+    ┌─ em-baseline-with-consumed-at-m1.mo:8:1
+  7 │    // matches m2's output.
+  8 │ ╭  actor {
+  9 │ │      let done : Nat;
+ 10 │ │  };
+    │ ╰──^ 
+ 11 │    
+error[M0267]: the migration chain requires field `nonexistent` of type
+  Text as input; the previous version must provide it.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
+    ┌─ em-baseline-with-consumed-at-m1.mo:8:1
+  7 │    // matches m2's output.
+  8 │ ╭  actor {
+  9 │ │      let done : Nat;
+ 10 │ │  };
+    │ ╰──^ 
+ 11 │    

--- a/test/fail/ok/em-baseline-with-consumed-at-m1.tc-human.ret.ok
+++ b/test/fail/ok/em-baseline-with-consumed-at-m1.tc-human.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/fail/ok/em-baseline-with-consumed-at-m1.tc.ok
+++ b/test/fail/ok/em-baseline-with-consumed-at-m1.tc.ok
@@ -1,15 +1,3 @@
-enhanced-migration/enh-mig-newstep/m2.mo:0.1: Compatibility error [M0170], stable variable `consumed` is not compatible with version `m1`.
-Previous type
-  Nat
- is not a subtype of
-  Bool
- because the type 
-  Nat
- is not compatible with type 
-  Bool
- in `consumed`.
-Write an explicit migration function to convert it.
-See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
 em-baseline-with-consumed-at-m1.mo:8.1-10.2: Compatibility error [M0170], stable variable `consumed` is not compatible with version `m1`.
 Previous type
   Nat

--- a/test/fail/ok/em-baseline-with-consumed-at-m1.tc.ok
+++ b/test/fail/ok/em-baseline-with-consumed-at-m1.tc.ok
@@ -1,4 +1,4 @@
-em-baseline-with-consumed-at-m1.mo:8.1-10.2: Compatibility error [M0170], stable variable `consumed` is not compatible with version `m1`.
+enhanced-migration/enh-mig-newstep/m2.mo:0.1: Compatibility error [M0170], stable variable `consumed` is not compatible with version `m1`.
 Previous type
   Nat
  is not a subtype of

--- a/test/fail/ok/em-baseline-with-consumed-at-m1.tc.ok
+++ b/test/fail/ok/em-baseline-with-consumed-at-m1.tc.ok
@@ -1,0 +1,27 @@
+enhanced-migration/enh-mig-newstep/m2.mo:0.1: Compatibility error [M0170], stable variable `consumed` is not compatible with version `m1`.
+Previous type
+  Nat
+ is not a subtype of
+  Bool
+ because the type 
+  Nat
+ is not compatible with type 
+  Bool
+ in `consumed`.
+Write an explicit migration function to convert it.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
+em-baseline-with-consumed-at-m1.mo:8.1-10.2: Compatibility error [M0170], stable variable `consumed` is not compatible with version `m1`.
+Previous type
+  Nat
+ is not a subtype of
+  Bool
+ because the type 
+  Nat
+ is not compatible with type 
+  Bool
+ in `consumed`.
+Write an explicit migration function to convert it.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/
+em-baseline-with-consumed-at-m1.mo:8.1-10.2: type error [M0267], the migration chain requires field `nonexistent` of type
+  Text as input; the previous version must provide it.
+See https://docs.internetcomputer.org/languages/motoko/fundamentals/actors/enhanced-multi-migration/

--- a/test/fail/ok/em-baseline-with-consumed-at-m1.tc.ret.ok
+++ b/test/fail/ok/em-baseline-with-consumed-at-m1.tc.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/fail/ok/warn-help.tc-human.ok
+++ b/test/fail/ok/warn-help.tc-human.ok
@@ -42,5 +42,6 @@ M0244 (W) Mutable variable is never reassigned
 M0254 (W) Initial actor requires field
 M0265 (W) The `system` capability is not required by this mixin
 M0266 (W) floating-point literal has more precision than its type can represent
+M0268 (E) Migration directory disagrees with the deployed history recorded by --stable-baseline
 
 Legend: A - allowed (warning disabled); W - warn (warning enabled); E - error (treated as error)

--- a/test/fail/ok/warn-help.tc.ok
+++ b/test/fail/ok/warn-help.tc.ok
@@ -42,5 +42,6 @@ M0244 (W) Mutable variable is never reassigned
 M0254 (W) Initial actor requires field
 M0265 (W) The `system` capability is not required by this mixin
 M0266 (W) floating-point literal has more precision than its type can represent
+M0268 (E) Migration directory disagrees with the deployed history recorded by --stable-baseline
 
 Legend: A - allowed (warning disabled); W - warn (warning enabled); E - error (treated as error)


### PR DESCRIPTION
`--stable-baseline` takes a `.most` file recording what the deployed canister
actually looks like — including, for enhanced migration, the chain of migrations
that ran to get it there. The design premise of this PR: **the full-chain walk is
the core check and stands on the local chain alone** (the produced wasm may
install canisters fresh, replaying every migration), while the baseline only
layers extra diagnostics on top for the typical use case — upgrading the live
canister it describes. The walk is untouched; the additions are:

## M0268: the directory must agree with the recorded history

The two can drift, and each way of drifting is a real deployment hazard:

* a migration **deleted** after deployment — no local file accounts for the step
  that produced the deployed state;
* a migration **edited in place** after it ran — the file no longer describes
  what the canister actually did;
* a migration **backdated** to sort before the deployed head — it can never run
  on upgrade, because the resume point is already past it.

None of these were diagnosed. `check_history` compares the local files with the
recorded chain: already-applied migrations may be trimmed away, but only the
oldest ones, and the rest must be the files that ran. Disagreements report
**M0268 against the offending file** — a warning that **defaults to error**, so
a user who intentionally diverges has an escape hatch (`-W=M0268` demotes,
`-A=M0268` silences) without losing the walk's own validation:

```
main.mo:M0268  deployed migration `m2` is missing from the migration directory;
               only the oldest migrations may be trimmed away
m1.mo:  M0268  migration `m1` no longer matches the deployed history: it now has type
                 {} -> {consumed : Int}
               but the stable baseline records
                 {} -> {consumed : Nat}
m0.mo:  M0268  migration `m0` is not part of the deployed history recorded by the stable baseline
```

The `-history-mismatch` test hits all three at once; `-demoted` pins the
`-W=M0268` escape hatch; `-fully-trimmed` pins that a legal trim stays silent.

## The duplicate this removes

The walk and the baseline boundary sweep overlapped: for a field an
already-applied migration consumes or produces, the walk's step check against
that migration's recorded story and the sweep's check against the deployed state
are the same comparison — so a retyped field reported M0170 twice, a dropped one
M0169 twice (byte-identical), a consumed-but-declared one M0263 *and* M0267.
Eight messages for four defects in the first test commit.

The **sweep yields to the walk**, never the other way around: it now skips the
fields any applied local migration mentions (`dom ∪ rng`) and only speaks about
fields the local chain merely passes through — supplied by trimmed history, or
predating the chain. One report per defect, carrying the walk's per-version
provenance. The whole change to the walk's code path is the two `untouched`
filters on the sweep call: `typing.ml` is **+65/−1** against master.

## Notes

* Supersedes #6276, whose tests are this PR's first commit; no test used a
  chain-bearing baseline whose head is also a local migration, which is why CI
  never saw either problem.
* Everything is gated on `--stable-baseline`: without it `applied` and `touched`
  are empty and `check_history` sees no recorded chain, so no other test moves —
  the full `test/fail` re-accept confirms only the four scenario tests (plus
  `warn-help`, which lists the new code) changed.
* The intermediate commits explored reporting from the sweep side instead (field
  spans on the offending declaration, at the cost of skipping the walk for
  applied migrations); review of the escape-hatch requirement settled on
  walk-primacy — see the commit trail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
