### PR TITLE
fix: bound Candid `blob`/`text` length before allocating from it

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,10 +5,7 @@
   * improvement: RTS weak reference interaction with the incremental GC: weak
     reference reads now go through a load barrier (#6296).
 
-  * bugfix: when decoding a Candid `blob` or `text`, the claimed length is now
-    bounded by the bytes remaining in the message before allocating from it, so
-    a short message can no longer provoke a multi-gigabyte allocation, nor a
-    read past the end of the message (#6311).
+  * bugfix: when decoding a Candid `blob` or `text`, bound the claimed length (#6311).
 
 ## 1.14.0 (2026-08-11)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,11 @@
   * improvement: RTS weak reference interaction with the incremental GC: weak
     reference reads now go through a load barrier (#6296).
 
+  * bugfix: when decoding a Candid `blob` or `text`, the claimed length is now
+    bounded by the bytes remaining in the message before allocating from it, so
+    a short message can no longer provoke a multi-gigabyte allocation, nor a
+    read past the end of the message (#6311).
+
 ## 1.14.0 (2026-08-11)
 
 * motoko (`moc`)

--- a/src/codegen/compile_classical.ml
+++ b/src/codegen/compile_classical.ml
@@ -3089,6 +3089,15 @@ module ReadBuf = struct
     G.i (Compare (Wasm.Values.I32 I64Op.LeU)) ^^
     E.else_trap_with env "IDL error: out of bounds read"
 
+  (* Read a LEB128 byte count and bound it by the bytes left in the buffer.
+     The blob-like payloads (blob, text, principal) allocate from this count, so
+     it has to be checked _before_ that allocation, not just before the copy. *)
+  let read_byte_count env get_buf =
+    let (set_len, get_len) = new_local env "len" in
+    read_leb128 env get_buf ^^ set_len ^^
+    check_space env get_buf get_len ^^
+    get_len
+
   let check_page_end env get_buf incr_delta =
     get_ptr get_buf ^^ compile_bitand_const 0xFFFFl ^^
     incr_delta ^^
@@ -7759,7 +7768,7 @@ module MakeSerialization (Strm : Stream) = struct
       let read_blob () =
         let (set_len, get_len) = new_local env "len" in
         let (set_x, get_x) = new_local env "x" in
-        ReadBuf.read_leb128 env get_data_buf ^^ set_len ^^
+        ReadBuf.read_byte_count env get_data_buf ^^ set_len ^^
 
         Blob.alloc env Tagged.B get_len ^^ set_x ^^
         get_x ^^ Blob.payload_ptr_unskewed env ^^
@@ -7770,7 +7779,7 @@ module MakeSerialization (Strm : Stream) = struct
       let read_principal sort () =
         let (set_len, get_len) = new_local env "len" in
         let (set_x, get_x) = new_local env "x" in
-        ReadBuf.read_leb128 env get_data_buf ^^ set_len ^^
+        ReadBuf.read_byte_count env get_data_buf ^^ set_len ^^
 
         (* at most 29 bytes, according to
            https://sdk.dfinity.org/docs/interface-spec/index.html#principal
@@ -7786,7 +7795,7 @@ module MakeSerialization (Strm : Stream) = struct
 
       let read_text () =
         let (set_len, get_len) = new_local env "len" in
-        ReadBuf.read_leb128 env get_data_buf ^^ set_len ^^
+        ReadBuf.read_byte_count env get_data_buf ^^ set_len ^^
         let (set_ptr, get_ptr) = new_local env "x" in
         ReadBuf.get_ptr get_data_buf ^^ set_ptr ^^
         ReadBuf.advance get_data_buf get_len ^^

--- a/src/codegen/compile_classical.ml
+++ b/src/codegen/compile_classical.ml
@@ -3093,7 +3093,7 @@ module ReadBuf = struct
      The blob-like payloads (blob, text, principal) allocate from this count, so
      it has to be checked _before_ that allocation, not just before the copy. *)
   let read_byte_count env get_buf =
-    let (set_len, get_len) = new_local env "len" in
+    let set_len, get_len = new_local env "len" in
     read_leb128 env get_buf ^^ set_len ^^
     check_space env get_buf get_len ^^
     get_len

--- a/src/codegen/compile_enhanced.ml
+++ b/src/codegen/compile_enhanced.ml
@@ -2923,6 +2923,15 @@ module ReadBuf = struct
     compile_comparison I64Op.LeU ^^
     E.else_trap_with env "IDL error: out of bounds read"
 
+  (* Read a LEB128 byte count and bound it by the bytes left in the buffer.
+     The blob-like payloads (blob, text, principal) allocate from this count, so
+     it has to be checked _before_ that allocation, not just before the copy. *)
+  let read_byte_count env get_buf =
+    let (set_len, get_len) = new_local env "len" in
+    read_leb128 env get_buf ^^ set_len ^^
+    check_space env get_buf get_len ^^
+    get_len
+
   let check_page_end env get_buf incr_delta =
     get_ptr get_buf ^^ compile_bitand_const 0xFFFFL ^^
     incr_delta ^^
@@ -8202,7 +8211,7 @@ module Serialization = struct
       let read_blob () =
         let (set_len, get_len) = new_local env "len" in
         let (set_x, get_x) = new_local env "x" in
-        ReadBuf.read_leb128 env get_data_buf ^^ set_len ^^
+        ReadBuf.read_byte_count env get_data_buf ^^ set_len ^^
 
         Blob.alloc env Tagged.B get_len ^^ set_x ^^
         get_x ^^ Blob.payload_ptr_unskewed env ^^
@@ -8213,7 +8222,7 @@ module Serialization = struct
       let read_principal sort () =
         let (set_len, get_len) = new_local env "len" in
         let (set_x, get_x) = new_local env "x" in
-        ReadBuf.read_leb128 env get_data_buf ^^ set_len ^^
+        ReadBuf.read_byte_count env get_data_buf ^^ set_len ^^
 
         (* at most 29 bytes, according to
            https://sdk.dfinity.org/docs/interface-spec/index.html#principal
@@ -8229,7 +8238,7 @@ module Serialization = struct
 
       let read_text () =
         let (set_len, get_len) = new_local env "len" in
-        ReadBuf.read_leb128 env get_data_buf ^^ set_len ^^
+        ReadBuf.read_byte_count env get_data_buf ^^ set_len ^^
         let (set_ptr, get_ptr) = new_local env "x" in
         ReadBuf.get_ptr get_data_buf ^^ set_ptr ^^
         ReadBuf.advance get_data_buf get_len ^^

--- a/src/codegen/compile_enhanced.ml
+++ b/src/codegen/compile_enhanced.ml
@@ -2927,7 +2927,7 @@ module ReadBuf = struct
      The blob-like payloads (blob, text, principal) allocate from this count, so
      it has to be checked _before_ that allocation, not just before the copy. *)
   let read_byte_count env get_buf =
-    let (set_len, get_len) = new_local env "len" in
+    let set_len, get_len = new_local env "len" in
     read_leb128 env get_buf ^^ set_len ^^
     check_space env get_buf get_len ^^
     get_len

--- a/test/bench/ok/candid-subtype-cost.drun-run.ok
+++ b/test/bench/ok/candid-subtype-cost.drun-run.ok
@@ -1,5 +1,5 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-debug.print: {cycles = 1_119_260; heap_bytes = +33_888}
+debug.print: {cycles = 1_133_596; heap_bytes = +33_888}
 ingress Completed: Reply: 0x4449444c0000
 ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/issue-6300.mo
+++ b/test/run-drun/issue-6300.mo
@@ -1,0 +1,34 @@
+//MOC-ENV MOC_UNLOCK_PRIM=yesplease
+import Prim "mo:⛔";
+
+// The blob-like payloads must bound their LEB128 length against the bytes left
+// in the message before allocating from it (`principal` always did, capping at
+// 29 bytes). Both payloads below claim ~3.25 GiB and then stop, so decoding has
+// to fail on the length, not grow the heap to the claimed size first.
+
+actor {
+
+  func deserBlob(x : Blob) : Blob = (prim "deserialize" : Blob -> Blob) x;
+  func deserText(x : Blob) : Text = (prim "deserialize" : Blob -> Text) x;
+
+  public func go () : async () {
+    try {
+      await async { ignore deserBlob "DIDL\01\6d\7b\01\00\80\80\80\80\0d" };
+      assert false
+    }
+    catch e {
+      Prim.debugPrint(Prim.errorMessage(e));
+    };
+    try {
+      await async { ignore deserText "DIDL\00\01\71\80\80\80\80\0d" };
+      assert false
+    }
+    catch e {
+      Prim.debugPrint(Prim.errorMessage(e));
+    }
+  }
+}
+//SKIP run
+//SKIP run-ir
+//SKIP run-low
+//CALL ingress go "DIDL\x00\x00"

--- a/test/run-drun/issue-6300.mo
+++ b/test/run-drun/issue-6300.mo
@@ -3,29 +3,57 @@ import Prim "mo:⛔";
 
 // The blob-like payloads must bound their LEB128 length against the bytes left
 // in the message before allocating from it (`principal` always did, capping at
-// 29 bytes). Both payloads below claim ~3.25 GiB and then stop, so decoding has
-// to fail on the length, not grow the heap to the claimed size first.
+// 29 bytes). The window shrinks as arguments are read, so the lengths claimed
+// across a message cannot add up to more than the message itself.
 
 actor {
 
   func deserBlob(x : Blob) : Blob = (prim "deserialize" : Blob -> Blob) x;
   func deserText(x : Blob) : Text = (prim "deserialize" : Blob -> Text) x;
+  func deser3(x : Blob) : (Blob, Blob, Blob) =
+    (prim "deserialize" : Blob -> (Blob, Blob, Blob)) x;
+  func deser7(x : Blob) : (Blob, Blob, Blob, Blob, Blob, Blob, Blob) =
+    (prim "deserialize" : Blob -> (Blob, Blob, Blob, Blob, Blob, Blob, Blob)) x;
+
+  // seven blobs, each claiming 0x1F0000 = 1.9 MiB (so each on its own stays
+  // below the message size limit, while together they are far above it), with
+  // no payload bytes at all
+  let seven : [Nat8] = [0x44,0x49,0x44,0x4c, 0x01,0x6d,0x7b,
+                        0x07,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                        0x80,0x80,0xfc,0x00, 0x80,0x80,0xfc,0x00, 0x80,0x80,0xfc,0x00,
+                        0x80,0x80,0xfc,0x00, 0x80,0x80,0xfc,0x00, 0x80,0x80,0xfc,0x00,
+                        0x80,0x80,0xfc,0x00];
+
+  // three blobs, of which the first honestly carries its 900 bytes; the second
+  // then claims 900 more, which the shrunken window no longer holds
+  let prefix : [Nat8] = [0x44,0x49,0x44,0x4c, 0x01,0x6d,0x7b, 0x03,0x00,0x00,0x00, 0x84,0x07];
+  let cumulative : [Nat8] = Prim.Array_tabulate<Nat8>(prefix.size() + 900 + 2, func i =
+    if (i < prefix.size()) prefix[i]
+    else if (i < prefix.size() + 900) 0x41
+    else if (i == prefix.size() + 900) 0x84
+    else 0x07);
+
+  // the same shape, honestly encoded, must still decode
+  let honest : [Nat8] = [0x44,0x49,0x44,0x4c, 0x01,0x6d,0x7b, 0x03,0x00,0x00,0x00,
+                         0x03,0x41,0x41,0x41, 0x03,0x42,0x42,0x42, 0x03,0x43,0x43,0x43];
+
+  func expectTrap(what : Text, decode : () -> ()) : async () {
+    try {
+      await async { decode() };
+      assert false
+    }
+    catch e {
+      Prim.debugPrint(what # ": " # Prim.errorMessage(e));
+    }
+  };
 
   public func go () : async () {
-    try {
-      await async { ignore deserBlob "DIDL\01\6d\7b\01\00\80\80\80\80\0d" };
-      assert false
-    }
-    catch e {
-      Prim.debugPrint(Prim.errorMessage(e));
-    };
-    try {
-      await async { ignore deserText "DIDL\00\01\71\80\80\80\80\0d" };
-      assert false
-    }
-    catch e {
-      Prim.debugPrint(Prim.errorMessage(e));
-    }
+    // claims ~3.25 GiB and stops
+    await expectTrap("blob", func () = ignore deserBlob "DIDL\01\6d\7b\01\00\80\80\80\80\0d");
+    await expectTrap("text", func () = ignore deserText "DIDL\00\01\71\80\80\80\80\0d");
+    await expectTrap("seven", func () = ignore deser7 (Prim.arrayToBlob seven));
+    await expectTrap("cumulative", func () = ignore deser3 (Prim.arrayToBlob cumulative));
+    Prim.debugPrint(debug_show (deser3 (Prim.arrayToBlob honest)));
   }
 }
 //SKIP run

--- a/test/run-drun/ok/issue-6300.drun-run.ok
+++ b/test/run-drun/ok/issue-6300.drun-run.ok
@@ -1,0 +1,7 @@
+ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
+ingress Completed: Reply: 0x4449444c0000
+debug.print: IC0503: Error from Canister rwlgt-iiaaa-aaaaa-aaaaa-cai: Canister called `ic0.trap` with message: 'IDL error: out of bounds read'.
+Consider gracefully handling failures from this canister or altering the canister to handle exceptions. See documentation: https://docs.internetcomputer.org/references/execution-errors#trapped-explicitly
+debug.print: IC0503: Error from Canister rwlgt-iiaaa-aaaaa-aaaaa-cai: Canister called `ic0.trap` with message: 'IDL error: out of bounds read'.
+Consider gracefully handling failures from this canister or altering the canister to handle exceptions. See documentation: https://docs.internetcomputer.org/references/execution-errors#trapped-explicitly
+ingress Completed: Reply: 0x4449444c0000

--- a/test/run-drun/ok/issue-6300.drun-run.ok
+++ b/test/run-drun/ok/issue-6300.drun-run.ok
@@ -1,7 +1,12 @@
 ingress Completed: Reply: 0x4449444c016c01b3c4b1f204680100010a00000000000000000101
 ingress Completed: Reply: 0x4449444c0000
-debug.print: IC0503: Error from Canister rwlgt-iiaaa-aaaaa-aaaaa-cai: Canister called `ic0.trap` with message: 'IDL error: out of bounds read'.
+debug.print: blob: IC0503: Error from Canister rwlgt-iiaaa-aaaaa-aaaaa-cai: Canister called `ic0.trap` with message: 'IDL error: out of bounds read'.
 Consider gracefully handling failures from this canister or altering the canister to handle exceptions. See documentation: https://docs.internetcomputer.org/references/execution-errors#trapped-explicitly
-debug.print: IC0503: Error from Canister rwlgt-iiaaa-aaaaa-aaaaa-cai: Canister called `ic0.trap` with message: 'IDL error: out of bounds read'.
+debug.print: text: IC0503: Error from Canister rwlgt-iiaaa-aaaaa-aaaaa-cai: Canister called `ic0.trap` with message: 'IDL error: out of bounds read'.
 Consider gracefully handling failures from this canister or altering the canister to handle exceptions. See documentation: https://docs.internetcomputer.org/references/execution-errors#trapped-explicitly
+debug.print: seven: IC0503: Error from Canister rwlgt-iiaaa-aaaaa-aaaaa-cai: Canister called `ic0.trap` with message: 'IDL error: out of bounds read'.
+Consider gracefully handling failures from this canister or altering the canister to handle exceptions. See documentation: https://docs.internetcomputer.org/references/execution-errors#trapped-explicitly
+debug.print: cumulative: IC0503: Error from Canister rwlgt-iiaaa-aaaaa-aaaaa-cai: Canister called `ic0.trap` with message: 'IDL error: out of bounds read'.
+Consider gracefully handling failures from this canister or altering the canister to handle exceptions. See documentation: https://docs.internetcomputer.org/references/execution-errors#trapped-explicitly
+debug.print: ("\41\41\41", "\42\42\42", "\43\43\43")
 ingress Completed: Reply: 0x4449444c0000


### PR DESCRIPTION
Fixes #6300.

## What was wrong

`read_blob` in the Candid deserializer read the LEB128 byte count and then
allocated a blob of that size, leaving the bounds check to
`ReadBuf.read_blob`'s `check_space` — which only runs *after* the allocation:

```
ReadBuf.read_leb128 env get_data_buf ^^ set_len ^^
Blob.alloc env Tagged.B get_len ^^ set_x ^^      (* <-- allocates the claimed size *)
…
ReadBuf.read_blob env get_data_buf get_len       (* <-- check_space traps here *)
```

`read_text` was worse: it never checked at all. It `advance`d the buffer by the
claimed length (`advance` does no checking) and handed the range to
`utf8_validate`, which then read past the end of the message.

`read_principal` was the one that got it right, capping at 29 bytes before
allocating.

## Measured, before the fix

The new test's 11-byte `blob` payload, claiming ~3.25 GiB and then stopping:

```
Canister exceeded its current Wasm memory limit of 3221225472 bytes.
The peak Wasm memory usage was 3491823616 bytes.
```

and its `text` counterpart:

```
'RTS error: utf8_validate: string is not UTF-8'
```

— i.e. the validator was reading past the end of the message and only stopped
because the adjacent heap bytes weren't valid UTF-8.

## The fix

One shared helper on the streaming reader, next to the `check_space` it reuses:

```ocaml
let read_byte_count env get_buf =
  let (set_len, get_len) = new_local env "len" in
  read_leb128 env get_buf ^^ set_len ^^
  check_space env get_buf get_len ^^
  get_len
```

`read_blob`, `read_text` and `read_principal` all take their length through it,
in both backends. Failure stays a hard trap — the right answer for malicious
Candid — it just happens before the allocation now, so a bogus length costs
nothing beyond the LEB read. Both payloads above now fail with
`IDL error: out of bounds read`.

Note that this bounds *cumulative* allocation by the message size too. The data
buffer is set up once for the whole message and every read advances it, so the
window shrinks: a successful read consumes exactly the bytes it allocated, and
the only pointer reset in the deserializer — `read_alias` — is forward-only
(negative offsets trap as `"Odd offset"`) and memoized, so an aliased value
cannot be decoded twice. Measured on two multi-argument messages, both of which
trap with nothing allocated (2 MiB heap before and after):

* seven blobs each claiming 1.9 MiB — individually plausible against the 2 MiB
  message limit, together ~13 MiB — with no payload bytes: traps on the first
* three blobs where the first honestly carries its 900 bytes and the second then
  claims 900 more: traps on the second, against the shrunken window

The honestly encoded variant of that shape still decodes, as a control.

## Not a permanent leak

The issue reports the growth as permanent. It isn't: the decode always ends in a
hard trap (including under `from_candid`, which does not soften this into
`null`), and the IC rolls the trapped message's memory growth back. Measured
with `Prim.rts_memory_size()` around the trapping call: 2 MiB before, 2 MiB
after, with the 3.25 GiB spike in between. The impact was a self-inflicted
transient OOM plus the out-of-bounds read, not a retained allocation.

## Testing

* new `test/run-drun/issue-6300.mo`, covering both the `blob` and the `text` payload
* `test/run-drun` (498), `test/run`, `test/run-deser` all green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
