### PR TITLE
feat: Add optimized dotprod over blobs in the RTS

### DIFF
--- a/rts/motoko-rts/src/text.rs
+++ b/rts/motoko-rts/src/text.rs
@@ -366,6 +366,22 @@ pub unsafe extern "C" fn blob_compare(s1: Value, s2: Value) -> isize {
     }
 }
 
+/// Dot product of two int8 vectors stored as blobs, over the common prefix
+/// length, with wrapping i32 accumulation. Exposed as `Prim.blobDotInt8` for
+/// embedding/similarity workloads where the per-element cost of a Motoko-level
+/// loop dominates.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn blob_dot_int8(a: Value, b: Value) -> i32 {
+    let n = min(text_size(a), text_size(b)).as_usize();
+    let s1 = core::slice::from_raw_parts(a.as_blob().payload_const() as *const i8, n);
+    let s2 = core::slice::from_raw_parts(b.as_blob().payload_const() as *const i8, n);
+    let mut acc: i32 = 0;
+    for (&x, &y) in s1.iter().zip(s2.iter()) {
+        acc = acc.wrapping_add(x as i32 * y as i32);
+    }
+    acc
+}
+
 /// Length in characters
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn text_len(text: Value) -> usize {

--- a/src/codegen/compile_classical.ml
+++ b/src/codegen/compile_classical.ml
@@ -1108,6 +1108,7 @@ module RTS = struct
     add_rts_import "continuation_count" [] [I32Type];
     add_rts_import "continuation_table_size" [] [I32Type];
     add_rts_import "blob_of_text" [I32Type] [I32Type];
+    add_rts_import "blob_dot_int8" [I32Type; I32Type] [I32Type];
     add_rts_import "text_compare" [I32Type; I32Type] [I32Type];
     add_rts_import "text_concat" [I32Type; I32Type] [I32Type];
     add_rts_import "text_iter_done" [I32Type] [I32Type];
@@ -11782,6 +11783,12 @@ and compile_prim_invocation (env : E.t) ae p es at =
     compile_exp_vanilla env ae e1 ^^
     compile_exp_vanilla env ae e2 ^^
     Blob.compare env None
+
+  | OtherPrim "blob_dot_int8", [e1; e2] ->
+    SR.UnboxedWord32 Type.Int32,
+    compile_exp_vanilla env ae e1 ^^
+    compile_exp_vanilla env ae e2 ^^
+    E.call_rts env "blob_dot_int8"
 
   | OtherPrim "blob_size", [e] ->
     SR.Vanilla, compile_exp_vanilla env ae e ^^ Blob.len_nat env

--- a/src/codegen/compile_enhanced.ml
+++ b/src/codegen/compile_enhanced.ml
@@ -1202,6 +1202,7 @@ module RTS = struct
     add_rts_import "continuation_count" [] [I64Type];
     add_rts_import "continuation_table_size" [] [I64Type];
     add_rts_import "blob_of_text" [I64Type] [I64Type];
+    add_rts_import "blob_dot_int8" [I64Type; I64Type] [I32Type];
     add_rts_import "text_compare" [I64Type; I64Type] [I64Type];
     add_rts_import "text_concat" [I64Type; I64Type] [I64Type];
     add_rts_import "text_iter_done" [I64Type] [I64Type];
@@ -12125,6 +12126,14 @@ and compile_prim_invocation (env : E.t) ae p es at =
     compile_exp_vanilla env ae e2 ^^
     Blob.compare env None ^^
     TaggedSmallWord.msb_adjust Type.Int8
+
+  | OtherPrim "blob_dot_int8", [e1; e2] ->
+    SR.UnboxedWord64 Type.Int32,
+    compile_exp_vanilla env ae e1 ^^
+    compile_exp_vanilla env ae e2 ^^
+    E.call_rts env "blob_dot_int8" ^^
+    G.i (Convert (Wasm_exts.Values.I64 I64Op.ExtendSI32)) ^^
+    TaggedSmallWord.msb_adjust Type.Int32
 
   | OtherPrim "blob_size", [e] ->
     SR.Vanilla, compile_exp_vanilla env ae e ^^ Blob.len_nat env

--- a/src/mo_values/prim.ml
+++ b/src/mo_values/prim.ml
@@ -305,6 +305,18 @@ let prim trap =
                             (let a, b = Value.as_blob a, Value.as_blob b in
                              if a = b then 0 else if a < b then -1 else 1)))
      | _ -> assert false)
+  | "blob_dot_int8" -> fun _ v k ->
+    (match Value.as_tup v with
+     | [a; b] ->
+       let a, b = Value.as_blob a, Value.as_blob b in
+       let n = min (String.length a) (String.length b) in
+       let sx s i = let c = Char.code s.[i] in if c < 128 then c else c - 256 in
+       let acc = ref 0l in
+       for i = 0 to n - 1 do
+         acc := Int32.add !acc (Int32.mul (Int32.of_int (sx a i)) (Int32.of_int (sx b i)))
+       done;
+       k (Int32 (Int_32.of_int32 !acc))
+     | _ -> assert false)
   | "text_iter" -> fun _ v k ->
     let s = Lib.Utf8.decode (Value.as_text v) in
     let i = Seq.map (fun c -> Char c) (List.to_seq s) in

--- a/src/prelude/prim.mo
+++ b/src/prelude/prim.mo
@@ -482,6 +482,7 @@ func charIsAlphabetic(c : Char) : Bool = (prim "char_is_alphabetic" : Char -> Bo
 // Blob functions
 
 func blobCompare(b1 : Blob, b2 : Blob) : Int8 = (prim "blob_compare" : (Blob, Blob) -> Int8)(b1, b2);
+func blobDotInt8(b1 : Blob, b2 : Blob) : Int32 = (prim "blob_dot_int8" : (Blob, Blob) -> Int32)(b1, b2);
 func hashBlob(b : Blob) : Nat32 { (prim "crc32Hash" : Blob -> Nat32) b };
 
 // Text conversion

--- a/test/fail/ok/no-timer-canc.tc-human.ok
+++ b/test/fail/ok/no-timer-canc.tc-human.ok
@@ -66,6 +66,7 @@ error[M0119]: object field cancelTimer is not contained in expected type
     arrayMutToBlob : (a : [var Nat8]) -> Blob;
     arrayToBlob : (a : [Nat8]) -> Blob;
     blobCompare : (b1 : Blob, b2 : Blob) -> Int8;
+    blobDotInt8 : (b1 : Blob, b2 : Blob) -> Int32;
     blobOfPrincipal : (id : Principal) -> Blob;
     blobToArray : (b : Blob) -> [Nat8];
     blobToArrayMut : (b : Blob) -> [var Nat8];

--- a/test/fail/ok/no-timer-canc.tc.ok
+++ b/test/fail/ok/no-timer-canc.tc.ok
@@ -66,6 +66,7 @@ no-timer-canc.mo:3.10-3.21: type error [M0119], object field cancelTimer is not 
     arrayMutToBlob : (a : [var Nat8]) -> Blob;
     arrayToBlob : (a : [Nat8]) -> Blob;
     blobCompare : (b1 : Blob, b2 : Blob) -> Int8;
+    blobDotInt8 : (b1 : Blob, b2 : Blob) -> Int32;
     blobOfPrincipal : (id : Principal) -> Blob;
     blobToArray : (b : Blob) -> [Nat8];
     blobToArrayMut : (b : Blob) -> [var Nat8];

--- a/test/fail/ok/no-timer-set.tc-human.ok
+++ b/test/fail/ok/no-timer-set.tc-human.ok
@@ -66,6 +66,7 @@ error[M0119]: object field setTimer is not contained in expected type
     arrayMutToBlob : (a : [var Nat8]) -> Blob;
     arrayToBlob : (a : [Nat8]) -> Blob;
     blobCompare : (b1 : Blob, b2 : Blob) -> Int8;
+    blobDotInt8 : (b1 : Blob, b2 : Blob) -> Int32;
     blobOfPrincipal : (id : Principal) -> Blob;
     blobToArray : (b : Blob) -> [Nat8];
     blobToArrayMut : (b : Blob) -> [var Nat8];

--- a/test/fail/ok/no-timer-set.tc.ok
+++ b/test/fail/ok/no-timer-set.tc.ok
@@ -66,6 +66,7 @@ no-timer-set.mo:3.10-3.18: type error [M0119], object field setTimer is not cont
     arrayMutToBlob : (a : [var Nat8]) -> Blob;
     arrayToBlob : (a : [Nat8]) -> Blob;
     blobCompare : (b1 : Blob, b2 : Blob) -> Int8;
+    blobDotInt8 : (b1 : Blob, b2 : Blob) -> Int32;
     blobOfPrincipal : (id : Principal) -> Blob;
     blobToArray : (b : Blob) -> [Nat8];
     blobToArrayMut : (b : Blob) -> [var Nat8];

--- a/test/fail/ok/suggest-long-ai.tc-human.ok
+++ b/test/fail/ok/suggest-long-ai.tc-human.ok
@@ -66,6 +66,7 @@ error[M0072]: field stableM does not exist in type:
     arrayMutToBlob : (a : [var Nat8]) -> Blob;
     arrayToBlob : (a : [Nat8]) -> Blob;
     blobCompare : (b1 : Blob, b2 : Blob) -> Int8;
+    blobDotInt8 : (b1 : Blob, b2 : Blob) -> Int32;
     blobOfPrincipal : (id : Principal) -> Blob;
     blobToArray : (b : Blob) -> [Nat8];
     blobToArrayMut : (b : Blob) -> [var Nat8];

--- a/test/fail/ok/suggest-long-ai.tc.ok
+++ b/test/fail/ok/suggest-long-ai.tc.ok
@@ -66,6 +66,7 @@ suggest-long-ai.mo:4.6-4.13: type error [M0072], field stableM does not exist in
     arrayMutToBlob : (a : [var Nat8]) -> Blob;
     arrayToBlob : (a : [Nat8]) -> Blob;
     blobCompare : (b1 : Blob, b2 : Blob) -> Int8;
+    blobDotInt8 : (b1 : Blob, b2 : Blob) -> Int32;
     blobOfPrincipal : (id : Principal) -> Blob;
     blobToArray : (b : Blob) -> [Nat8];
     blobToArrayMut : (b : Blob) -> [var Nat8];

--- a/test/fail/ok/suggest-short-ai.tc-human.ok
+++ b/test/fail/ok/suggest-short-ai.tc-human.ok
@@ -66,6 +66,7 @@ error[M0072]: field s does not exist in type:
     arrayMutToBlob : (a : [var Nat8]) -> Blob;
     arrayToBlob : (a : [Nat8]) -> Blob;
     blobCompare : (b1 : Blob, b2 : Blob) -> Int8;
+    blobDotInt8 : (b1 : Blob, b2 : Blob) -> Int32;
     blobOfPrincipal : (id : Principal) -> Blob;
     blobToArray : (b : Blob) -> [Nat8];
     blobToArrayMut : (b : Blob) -> [var Nat8];

--- a/test/fail/ok/suggest-short-ai.tc.ok
+++ b/test/fail/ok/suggest-short-ai.tc.ok
@@ -66,6 +66,7 @@ suggest-short-ai.mo:4.6-4.7: type error [M0072], field s does not exist in type:
     arrayMutToBlob : (a : [var Nat8]) -> Blob;
     arrayToBlob : (a : [Nat8]) -> Blob;
     blobCompare : (b1 : Blob, b2 : Blob) -> Int8;
+    blobDotInt8 : (b1 : Blob, b2 : Blob) -> Int32;
     blobOfPrincipal : (id : Principal) -> Blob;
     blobToArray : (b : Blob) -> [Nat8];
     blobToArrayMut : (b : Blob) -> [var Nat8];


### PR DESCRIPTION
`Prim.blobDotInt8 : (Blob, Blob) -> Int32` — wrapping int8 dot product over two blobs (common prefix length), one Rust loop in the RTS. Wired through both codegen backends and the interpreter.

Motivation: on-chain scoring of int8 embeddings. Measured on a 10K×1024 int8 corpus under PocketIC: 19.1 instrs/MAC vs 242.3 for the best pure-Motoko loop (12.7×); the whole-corpus scoring ceiling in a query call moves from ~20K to ~255K vectors.

TODO before ready: tests, Changelog entry, API review (region-direct and SIMD variants are follow-up candidates).