### PR TITLE
test: repro M0267 false positive when --stable-baseline records an applied migration

### DIFF
--- a/test/fail/enhanced-migration/baselines/legacy-with-x-and-y.most
+++ b/test/fail/enhanced-migration/baselines/legacy-with-x-and-y.most
@@ -1,0 +1,8 @@
+// Version: 3.0.0
+actor ({
+  in x : Nat;
+  stable var y : Nat
+}, {
+  stable x : Nat;
+  stable var y : Nat
+}) ;

--- a/test/fail/enhanced-migration/baselines/with-y-at-m1.most
+++ b/test/fail/enhanced-migration/baselines/with-y-at-m1.most
@@ -1,0 +1,7 @@
+// Version: 4.0.0
+{
+  "m1" : {x : Nat} -> {}
+}
+actor  {
+  stable var y : Nat
+};

--- a/test/fail/enhanced-migration/enh-mig-test4/m1.mo
+++ b/test/fail/enhanced-migration/enh-mig-test4/m1.mo
@@ -1,0 +1,4 @@
+module {
+    // Drop field x.
+    public func migration(_ : { x : Nat }) : {} { {} };
+};

--- a/test/fail/multi-migration-baseline-drop-applied.mo
+++ b/test/fail/multi-migration-baseline-drop-applied.mo
@@ -1,0 +1,12 @@
+//MOC-FLAG --enhanced-orthogonal-persistence --default-persistent-actors --enhanced-migration enhanced-migration/enh-mig-test4
+//MOC-FLAG --stable-baseline enhanced-migration/baselines/with-y-at-m1.most
+//MOC-FLAG -A=M0194
+
+// Same project as multi-migration-baseline-drop-pending.mo, one deploy
+// later: the baseline is now this code's own signature — chain ends in "m1"
+// and x is gone from its post actor. The upgrade skips m1 and x is never
+// demanded — yet the initial-required check replays the chain against the
+// baseline post and reports M0267 for x.
+actor {
+    var y : Nat;
+};

--- a/test/fail/multi-migration-baseline-drop-pending.mo
+++ b/test/fail/multi-migration-baseline-drop-pending.mo
@@ -1,0 +1,11 @@
+//MOC-FLAG --enhanced-orthogonal-persistence --default-persistent-actors --enhanced-migration enhanced-migration/enh-mig-test4
+//MOC-FLAG --stable-baseline enhanced-migration/baselines/legacy-with-x-and-y.most
+//MOC-FLAG -A=M0194
+
+// The project started with the legacy `(with migration = ...)` syntax and is
+// converted to enhanced migration with a single-entry chain: m1 drops x.
+// The baseline is the legacy deployment (still has x), so m1 is pending and
+// x is explained by the previous version → M0254 warnings only.
+actor {
+    var y : Nat;
+};

--- a/test/fail/ok/multi-migration-baseline-drop-applied.tc-human.ok
+++ b/test/fail/ok/multi-migration-baseline-drop-applied.tc-human.ok
@@ -1,0 +1,14 @@
+error[M0267]: initial actor requires field `x` of type
+  Nat; not found in the previous version — write a migration that produces it
+    ┌─ multi-migration-baseline-drop-applied.mo:10:1
+  9 │    // baseline post and reports M0267 for x.
+ 10 │ ╭  actor {
+ 11 │ │      var y : Nat;
+ 12 │ │  };
+    │ ╰──^ 
+ 13 │    
+warning[M0254]: initial actor requires field `y` of type
+  var Nat
+    ┌─ enhanced-migration/enh-mig-test4/m1.mo:1:1
+  1 │  module {
+    │  ^ 

--- a/test/fail/ok/multi-migration-baseline-drop-applied.tc-human.ret.ok
+++ b/test/fail/ok/multi-migration-baseline-drop-applied.tc-human.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/fail/ok/multi-migration-baseline-drop-applied.tc.ok
+++ b/test/fail/ok/multi-migration-baseline-drop-applied.tc.ok
@@ -1,0 +1,4 @@
+multi-migration-baseline-drop-applied.mo:10.1-12.2: type error [M0267], initial actor requires field `x` of type
+  Nat; not found in the previous version — write a migration that produces it
+enhanced-migration/enh-mig-test4/m1.mo:0.1: warning [M0254], initial actor requires field `y` of type
+  var Nat

--- a/test/fail/ok/multi-migration-baseline-drop-applied.tc.ret.ok
+++ b/test/fail/ok/multi-migration-baseline-drop-applied.tc.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/fail/ok/multi-migration-baseline-drop-pending.tc-human.ok
+++ b/test/fail/ok/multi-migration-baseline-drop-pending.tc-human.ok
@@ -1,0 +1,10 @@
+warning[M0254]: initial actor requires field `x` of type
+  Nat
+    ┌─ enhanced-migration/enh-mig-test4/m1.mo:1:1
+  1 │  module {
+    │  ^ 
+warning[M0254]: initial actor requires field `y` of type
+  var Nat
+    ┌─ enhanced-migration/enh-mig-test4/m1.mo:1:1
+  1 │  module {
+    │  ^ 

--- a/test/fail/ok/multi-migration-baseline-drop-pending.tc.ok
+++ b/test/fail/ok/multi-migration-baseline-drop-pending.tc.ok
@@ -1,0 +1,4 @@
+enhanced-migration/enh-mig-test4/m1.mo:0.1: warning [M0254], initial actor requires field `x` of type
+  Nat
+enhanced-migration/enh-mig-test4/m1.mo:0.1: warning [M0254], initial actor requires field `y` of type
+  var Nat


### PR DESCRIPTION
`moc --stable-baseline` with `--enhanced-migration` wrongly rejects a project whose baseline already records the chain's migration as applied. The initial-required partition in `check_enhanced_migration_chain` (`src/mo_frontend/typing.ml`) replays the full chain and demands the first migration's `OldActor` fields exist in the baseline's post actor — ignoring the baseline's applied-migration label, so fields the migration consumed and dropped trigger M0267 even though the upgrade would skip that migration entirely. The stable-compat check right next to it honors the label via `T.pre mig_lab_opt`, which is why the same project passes when the label is not yet recorded.

The repro is the smallest realistic lifecycle: a project converted from the legacy `(with migration = ...)` syntax to enhanced migration with a single-entry chain, where `m1` drops field `x`.

- `multi-migration-baseline-drop-pending.mo` — checked against the legacy v3.0.0 baseline (still has `x`): passes, M0254 warnings only.
- `multi-migration-baseline-drop-applied.mo` — the identical project one deploy later, checked against its own emitted signature (the `with-y-at-m1.most` fixture is `moc --stable-types` output verbatim, chain ending in `"m1"`, `x` gone): errors with M0267 on `x`, exit 1.

This means every enhanced-migration project hits a hard check failure on the second deploy after any field-dropping migration, unless tooling keeps the full chain forever — which cannot scale. It is the failure behind the AGE-425 TrueLink incident, where mops' check-limit trimming surfaced the same replay against a post-migration baseline.

The `.ok` files deliberately capture today's buggy output; the fix (making the M0267/M0254 partition respect the baseline's migration label, as `T.pre` already does) flips `drop-applied` to warnings-only via `make accept`. Repro only — the fix is out of scope here and will follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)