### PR TITLE
ci: bump AI review Cursor model to grok-4.6

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -129,7 +129,7 @@ jobs:
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_TOKEN }}
           # Pinned frontier model; the account default ("Auto") routes to cheaper
           # models that produce shallow reviews.
-          REVIEW_MODEL: grok-4.5
+          REVIEW_MODEL: grok-4.6
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
grok-4.5 is superseded; the AI review workflow now pins `REVIEW_MODEL: grok-4.6` for the same reason it was pinned in the first place — the account-default "Auto" model routes to cheaper models that produce shallow reviews.

## What is unchanged

Everything else in the workflow — sandboxing, verdict parsing, comment posting, `REQUEST_CHANGES` gating — is untouched.