### PR TITLE
feat: validate the migration directory against the deployed history recorded by `--stable-baseline`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,14 @@
 
 * motoko (`moc`)
 
+  * feat: with `--stable-baseline` and `--enhanced-migration`, the migration
+    directory is now validated against the migration history the baseline
+    records as already applied: a deployed migration that was deleted (unless
+    all older ones are deleted too), edited in place, or a local migration
+    backdated to sort before the deployed head reports the new M0268
+    diagnostic, a warning treated as an error by default (demote with
+    `-W=M0268`, silence with `-A=M0268`) (#6325).
+
   * bugfix: with `--stable-baseline` and `--enhanced-migration`, the M0254/M0267
     check now honors the migrations the baseline records as already applied:
     requirements are computed at the chain's resume point instead of replaying

--- a/src/lang_utils/error_codes.ml
+++ b/src/lang_utils/error_codes.ml
@@ -270,7 +270,8 @@ let warning_codes = [
   "M0244", None, "Mutable variable is never reassigned";
   "M0254", None, "Initial actor requires field";
   "M0265", None, "The `system` capability is not required by this mixin";
-  "M0266", None, "floating-point literal has more precision than its type can represent"
+  "M0266", None, "floating-point literal has more precision than its type can represent";
+  "M0268", None, "Migration directory disagrees with the deployed history recorded by the stable baseline"
   ]
 
 let try_find_explanation code =

--- a/src/mo_config/flags.ml
+++ b/src/mo_config/flags.ml
@@ -98,6 +98,7 @@ let default_warning_levels = M.empty
   |> M.add "M0235" Allow (* don't deprecate for non-caffeine *)
   |> M.add "M0236" Allow (* don't suggest contextual dot notation *)
   |> M.add "M0237" Allow (* don't report redundant explicit arguments *)
+  |> M.add "M0268" (Error : lint_level) (* diverging from the deployed migration history is a deployment hazard *)
 
 let warning_levels = ref default_warning_levels
 

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -4678,6 +4678,57 @@ and check_migration_function env typ at =
       "expected non-generic, local function type, but migration expression produces type%a"
       display_typ_expand typ;
 
+(* Validate the migration directory against the deployed history recorded by
+   a Multi --stable-baseline.
+
+   On upgrade the chain resumes after the recorded head, so a recorded migration
+   may be deleted only along with every older one (trimming), a kept one must
+   still have its recorded type, and a local migration sorting before the head
+   without being part of the history can never run. Each disagreement warns
+   M0268 — an error by default — against the offending file.
+   Both the directory and the recorded chain are sorted by the labels the
+   migrations run in, so a single merge walk aligns them. *)
+
+and check_migration_history env chain recorded at =
+  let file_at file =
+    let file_pos = { no_pos with file } in { left = file_pos; right = file_pos }
+  in
+  let missing rf =
+    warn env at "M0268"
+      "deployed migration `%s` is missing from the migration directory; only the oldest migrations may be trimmed away"
+      rf.T.lab
+  in
+  (* matched: a recorded migration is present locally, so older recorded ones
+     can no longer pass as a trimmed prefix *)
+  let rec go matched locals recorded =
+    match locals, recorded with
+    | _, [] -> () (* remaining locals sort after the head: pending, unconstrained *)
+    | [], rf :: recorded' ->
+      if matched then missing rf;
+      go matched [] recorded'
+    | (file, _, typ) :: locals', rf :: recorded' ->
+      let lab = T.migration_lab_of_filename file in
+      let cmp = String.compare lab rf.T.lab in
+      if cmp = 0 then begin
+        if not (T.eq typ rf.T.typ) then
+          warn env (file_at file) "M0268"
+            "migration `%s` no longer matches the deployed history: it now has type%a\nbut the stable baseline records%a"
+            lab display_typ typ display_typ rf.T.typ;
+        go true locals' recorded'
+      end
+      else if cmp < 0 then begin
+        warn env (file_at file) "M0268"
+          "migration `%s` is not part of the deployed history recorded by the stable baseline"
+          lab;
+        go matched locals' recorded
+      end
+      else begin
+        if matched then missing rf;
+        go matched locals recorded'
+      end
+  in
+  go false chain recorded
+
 (* Validate the enhanced migration chain from --enhanced-migration directory.
 
    Each incremental step v_i -> m_{i+1} -> v_{i+1} has the same semantics as
@@ -4701,6 +4752,10 @@ and check_enhanced_migration_chain env chain stab_tfs at =
      let post_tfs, mig_lab_opt = T.post s in
      Some post_tfs, mig_lab_opt
  in
+ (match env.stable_baseline_sig with
+  | Some (T.Multi { chain = recorded; _ }) ->
+    check_migration_history env chain recorded at
+  | _ -> ());
  let check_chain chain post =
    let mfs = List.rev chain in
    (* When the baseline already applied one of the chain's migrations, the upgrade resumes

--- a/test/fail/em-baseline-history-mismatch.mo
+++ b/test/fail/em-baseline-history-mismatch.mo
@@ -1,0 +1,12 @@
+//MOC-FLAG --enhanced-orthogonal-persistence --default-persistent-actors --enhanced-migration enhanced-migration/enh-mig-history
+//MOC-FLAG -A=M0194
+//MOC-FLAG --stable-baseline enhanced-migration/baselines/history-mismatch.most
+
+// The directory drifted from the recorded history in all three diagnosed ways:
+// m0 is backdated (sorts before the deployed head m3 but never ran), m1 was
+// edited after it ran, and m2 was deleted although the newer m3 is kept.
+// Each reports M0268. m4 is pending and free to differ; the chain walk and
+// the baseline boundary themselves are consistent and stay silent.
+actor {
+    let a : Nat;
+};

--- a/test/fail/em-baseline-trimmed-history.mo
+++ b/test/fail/em-baseline-trimmed-history.mo
@@ -1,0 +1,11 @@
+//MOC-FLAG --enhanced-orthogonal-persistence --default-persistent-actors --enhanced-migration enhanced-migration/enh-mig-test4
+//MOC-FLAG -A=M0194
+//MOC-FLAG --stable-baseline enhanced-migration/baselines/trimmed-history.most
+
+// The oldest deployed migration m0 is trimmed away — a legal trim: the kept
+// m1 and m2 still match their recorded types, so the history check is silent
+// and so is the rest of the baseline check.
+actor {
+    let b : Nat;
+    var c : Nat;
+};

--- a/test/fail/enhanced-migration/baselines/history-mismatch.most
+++ b/test/fail/enhanced-migration/baselines/history-mismatch.most
@@ -1,0 +1,9 @@
+// Version: 4.0.0
+{
+  "m1" : {} -> {a : Nat};
+  "m2" : {a : Nat} -> {a : Nat};
+  "m3" : {a : Nat} -> {b : Nat}
+}
+actor  {
+  stable b : Nat
+};

--- a/test/fail/enhanced-migration/baselines/trimmed-history.most
+++ b/test/fail/enhanced-migration/baselines/trimmed-history.most
@@ -1,0 +1,10 @@
+// Version: 4.0.0
+{
+  "m0" : {x : Nat} -> {a : Nat};
+  "m1" : {a : Nat} -> {a : Nat; b : Nat};
+  "m2" : {a : Nat} -> {}
+}
+actor  {
+  stable b : Nat;
+  stable var c : Nat
+};

--- a/test/fail/enhanced-migration/enh-mig-history/m0.mo
+++ b/test/fail/enhanced-migration/enh-mig-history/m0.mo
@@ -1,0 +1,4 @@
+module {
+    // Keep a.
+    public func migration(old : { a : Nat }) : { a : Nat } { old };
+};

--- a/test/fail/enhanced-migration/enh-mig-history/m1.mo
+++ b/test/fail/enhanced-migration/enh-mig-history/m1.mo
@@ -1,0 +1,4 @@
+module {
+    // Keep a; the baseline records this migration as {} -> {a : Nat}.
+    public func migration(old : { a : Nat }) : { a : Nat } { old };
+};

--- a/test/fail/enhanced-migration/enh-mig-history/m3.mo
+++ b/test/fail/enhanced-migration/enh-mig-history/m3.mo
@@ -1,0 +1,4 @@
+module {
+    // Rename a to b.
+    public func migration(old : { a : Nat }) : { b : Nat } { { b = old.a } };
+};

--- a/test/fail/enhanced-migration/enh-mig-history/m4.mo
+++ b/test/fail/enhanced-migration/enh-mig-history/m4.mo
@@ -1,0 +1,4 @@
+module {
+    // Rename b back to a.
+    public func migration(old : { b : Nat }) : { a : Nat } { { a = old.b } };
+};

--- a/test/fail/ok/em-baseline-history-mismatch.tc-human.ok
+++ b/test/fail/ok/em-baseline-history-mismatch.tc-human.ok
@@ -1,0 +1,19 @@
+error[M0268]: migration `m0` is not part of the deployed history recorded by the stable baseline
+    ┌─ enhanced-migration/enh-mig-history/m0.mo:1:1
+  1 │  module {
+    │  ^ 
+error[M0268]: migration `m1` no longer matches the deployed history: it now has type
+  (old : {a : Nat}) -> {a : Nat}
+but the stable baseline records
+  {} -> {a : Nat}
+    ┌─ enhanced-migration/enh-mig-history/m1.mo:1:1
+  1 │  module {
+    │  ^ 
+error[M0268]: deployed migration `m2` is missing from the migration directory; only the oldest migrations may be trimmed away
+    ┌─ em-baseline-history-mismatch.mo:10:1
+  9 │    // the baseline boundary themselves are consistent and stay silent.
+ 10 │ ╭  actor {
+ 11 │ │      let a : Nat;
+ 12 │ │  };
+    │ ╰──^ 
+ 13 │    

--- a/test/fail/ok/em-baseline-history-mismatch.tc-human.ret.ok
+++ b/test/fail/ok/em-baseline-history-mismatch.tc-human.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/fail/ok/em-baseline-history-mismatch.tc.ok
+++ b/test/fail/ok/em-baseline-history-mismatch.tc.ok
@@ -1,0 +1,6 @@
+enhanced-migration/enh-mig-history/m0.mo:0.1: type error [M0268], migration `m0` is not part of the deployed history recorded by the stable baseline
+enhanced-migration/enh-mig-history/m1.mo:0.1: type error [M0268], migration `m1` no longer matches the deployed history: it now has type
+  (old : {a : Nat}) -> {a : Nat}
+but the stable baseline records
+  {} -> {a : Nat}
+em-baseline-history-mismatch.mo:10.1-12.2: type error [M0268], deployed migration `m2` is missing from the migration directory; only the oldest migrations may be trimmed away

--- a/test/fail/ok/em-baseline-history-mismatch.tc.ret.ok
+++ b/test/fail/ok/em-baseline-history-mismatch.tc.ret.ok
@@ -1,0 +1,1 @@
+Return code 1

--- a/test/fail/ok/warn-help.tc-human.ok
+++ b/test/fail/ok/warn-help.tc-human.ok
@@ -42,5 +42,6 @@ M0244 (W) Mutable variable is never reassigned
 M0254 (W) Initial actor requires field
 M0265 (W) The `system` capability is not required by this mixin
 M0266 (W) floating-point literal has more precision than its type can represent
+M0268 (E) Migration directory disagrees with the deployed history recorded by the stable baseline
 
 Legend: A - allowed (warning disabled); W - warn (warning enabled); E - error (treated as error)

--- a/test/fail/ok/warn-help.tc.ok
+++ b/test/fail/ok/warn-help.tc.ok
@@ -42,5 +42,6 @@ M0244 (W) Mutable variable is never reassigned
 M0254 (W) Initial actor requires field
 M0265 (W) The `system` capability is not required by this mixin
 M0266 (W) floating-point literal has more precision than its type can represent
+M0268 (E) Migration directory disagrees with the deployed history recorded by the stable baseline
 
 Legend: A - allowed (warning disabled); W - warn (warning enabled); E - error (treated as error)


### PR DESCRIPTION
A `Multi`-version `.most` baseline records the chain of migrations that produced the deployed state, but nothing checked that the local migration directory still agrees with it. Each way the two can drift is a real deployment hazard, and none was diagnosed:

* a deployed migration **deleted** while newer ones are kept — no local file accounts for a step that ran;
* a deployed migration **edited in place** — the file no longer describes what the canister actually did;
* a local migration **backdated** to sort before the deployed head — it can never run, because the upgrade resumes past it.

With `--stable-baseline` and `--enhanced-migration`, the directory is now merge-walked against the recorded chain (both are sorted by the labels migrations run in), and each disagreement reports **M0268 against the offending file**:

```
m0.mo:  M0268  migration `m0` is not part of the deployed history recorded by the stable baseline
m1.mo:  M0268  migration `m1` no longer matches the deployed history: it now has type
                 (old : {a : Nat}) -> {a : Nat}
               but the stable baseline records
                 {} -> {a : Nat}
main.mo:M0268  deployed migration `m2` is missing from the migration directory;
               only the oldest migrations may be trimmed away
```

M0268 is a warning that **defaults to error**, so a user who diverges intentionally has an escape hatch (`-W=M0268` demotes, `-A=M0268` silences) without losing the chain walk's own validation. Trimming away only the *oldest* recorded migrations stays legal and silent, as do pending migrations sorting after the head.

## What is unchanged

The chain walk and the baseline boundary sweep are untouched — this check only layers on top, and is inert without a `Multi` baseline. The duplicate M0169/M0170/M0263/M0267 reports at the baseline boundary are out of scope here; [#6281](https://github.com/caffeinelabs/motoko/pull/6281) explores that separately. Split out of [#6281](https://github.com/caffeinelabs/motoko/pull/6281) for clean review, with an independent implementation.

The `em-baseline-history-mismatch` test hits all three drift modes at once; `em-baseline-trimmed-history` pins that a legal trim stays silent (as a silent test, it has no `.ok` files by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
