### PR TITLE
Deprecate `.vals()` and `system func preupgrade`/`postupgrade` (default-on warnings)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,11 @@
 
 * motoko (`moc`)
 
+  * feat: warn (default-on, M0269) that `.vals()` is deprecated in favor of
+    `.values()` on arrays and Blob, and warn (default-on, M0270) that
+    `system func preupgrade`/`postupgrade` are deprecated in favor of the
+    persistent upgrade machinery. Silence with `-A=M0269` / `-A=M0270`
+    (#6347).
   * bugfix: The contextual dot suggestion (`M0236`) no longer proposes
     rewriting `M.f(e, ...)` to `e.f(...)` when the rewrite would resolve
     differently: the suggestion now validates the rewritten callee against

--- a/doc/md/base-core-migration.md
+++ b/doc/md/base-core-migration.md
@@ -546,7 +546,7 @@ import Iter "mo:base/Iter";
 
 persistent actor{
   stable var mapEntries : [(Text, Nat)] = [];
-  let map = HashMap.fromIter<Text, Nat>(mapEntries.vals(), 10, Text.equal, Text.hash);
+  let map = HashMap.fromIter<Text, Nat>(mapEntries.values(), 10, Text.equal, Text.hash);
 
   system func preupgrade() {
     mapEntries := Iter.toArray(map.entries());
@@ -585,7 +585,7 @@ import Iter "mo:core/Iter";
   ) : {
     map : Map.Map<Text, Nat>;
   } = {
-    map = Map.fromIter(state.mapEntries.vals(), Text.compare);
+    map = Map.fromIter(state.mapEntries.values(), Text.compare);
   }
 )
 persistent actor{
@@ -699,7 +699,7 @@ persistent actor{
   };
 
   public query func getItems() : async [Item] {
-    Iter.toArray(textSet.vals(set));
+    Iter.toArray(textSet.values(set));
   };
 };
 ```
@@ -722,7 +722,7 @@ import Iter "mo:core/Iter";
   } {
     let compare = Text.compare;
     let textSet = OrderedSet.Make<App.Item>(compare);
-    let set = Set.fromIter(textSet.vals(state.set), compare);
+    let set = Set.fromIter(textSet.values(state.set), compare);
     { set };
   }
 )
@@ -825,7 +825,7 @@ import Iter "mo:base/Iter";
 
 persistent actor{
   stable var mapEntries : [(Text, Nat)] = [];
-  let map = TrieMap.fromEntries<Text, Nat>(mapEntries.vals(), Text.equal, Text.hash);
+  let map = TrieMap.fromEntries<Text, Nat>(mapEntries.values(), Text.equal, Text.hash);
 
   system func preupgrade() {
     mapEntries := Iter.toArray(map.entries());
@@ -929,7 +929,7 @@ import TrieSet "mo:base/TrieSet";
   ) : {
     set : Set.Set<Text>;
   } = {
-    set = Set.fromIter(TrieSet.toArray(state.set).vals(), Text.compare);
+    set = Set.fromIter(TrieSet.toArray(state.set).values(), Text.compare);
   }
 )
 persistent actorApp {

--- a/doc/md/fundamentals/control-flow/basic-control-flow.md
+++ b/doc/md/fundamentals/control-flow/basic-control-flow.md
@@ -33,7 +33,7 @@ Consider this function that computes the product of an array of integers.
 ```motoko no-repl
 func product(numbers : [Int]) : Int {
   var prod : Int = 1;
-  for (number in numbers.vals()) {
+  for (number in numbers.values()) {
     prod *= number;
   };
   prod; // The implicit result of the block and function
@@ -47,7 +47,7 @@ However, `prod` will remain `0` once it becomes `0` so you can save some work by
 ```motoko no-repl
 func product(numbers : [Int]) : Int {
   var prod : Int = 1;
-  for (number in numbers.vals()) {
+  for (number in numbers.values()) {
     prod *= number;
     if (prod == 0) return 0; // an early return can save work
   };
@@ -60,7 +60,7 @@ This also works with asynchronous functions that produce futures:
 ```motoko no-repl
 func asyncProduct(numbers : [Int]) : async Int {
   var prod : Int = 1;
-  for (number in numbers.vals()) {
+  for (number in numbers.values()) {
     prod *= number;
     if (prod == 0) return 0; // an early return completes the future
   };
@@ -152,7 +152,7 @@ Indeed, you can think of `return` as a `break` from the enclosing function.
 ```motoko no-repl
 func product(numbers : [Int]) : Int {
   var prod : Int = 1;
-  label l for (number in numbers.vals()) {
+  label l for (number in numbers.values()) {
     prod *= number;
     if (prod == 0) break l;
   };
@@ -166,7 +166,7 @@ If the block produces a non-`()` result, as in this minor refactoring, the `brea
 func product(numbers : [Int]) : Int {
   label result : Int {
     var prod : Int = 1;
-    for (number in numbers.vals()) {
+    for (number in numbers.values()) {
       prod *= number;
       if (prod == 0) break result 0;
     };
@@ -233,7 +233,7 @@ import Debug "mo:core/Debug";
 import Nat "mo:core/Nat";
 
 let numbers = [0, 1, 2, 3, 4];
-for (num in numbers.vals()) {
+for (num in numbers.values()) {
   Debug.print(Nat.toText(num));
 }
 ```
@@ -249,7 +249,7 @@ For example, computing the product we can skip a multiplication when the number 
 ```motoko no-repl
 func product(numbers : [Int]) : Int {
   var prod : Int = 1;
-  for (number in numbers.vals()) {
+  for (number in numbers.values()) {
     if (number == 1) continue;
     prod *= number;
   };
@@ -262,7 +262,7 @@ When you have nested loops and need to continue a specific outer loop, you can u
 ```motoko no-repl
 func product(numbers : [Int]) : Int {
   var prod : Int = 1;
-  label l for (number in numbers.vals()) {
+  label l for (number in numbers.values()) {
     if (number == 1) continue l;
     prod *= number;
   };

--- a/doc/md/fundamentals/control-flow/loops.md
+++ b/doc/md/fundamentals/control-flow/loops.md
@@ -98,7 +98,7 @@ import Debug "mo:core/Debug";
 
 let numbers = [0, 1, 2, 3, 4];
 
-for (num in numbers.vals()) {
+for (num in numbers.values()) {
   Debug.print(debug_show(num));
 };
 ```
@@ -110,7 +110,7 @@ import Debug "mo:core/Debug";
 
 let pairs = [(1, 2), (3, 4)];
 
-for ((fst, snd) in pairs.vals()) {
+for ((fst, snd) in pairs.values()) {
   Debug.print(debug_show(fst + snd));
 };
 ```

--- a/doc/md/fundamentals/implicit-parameters.md
+++ b/doc/md/fundamentals/implicit-parameters.md
@@ -320,7 +320,7 @@ import Order "mo:core/Order";
 // __record combiner: fold field-wise Order values, short-circuiting at first non-equal.
 // Thunks enable genuine short-circuiting — remaining fields are never evaluated.
 func compare(__record : [(Text, () -> Order.Order)]) : Order.Order {
-  for ((_, ordThunk) in __record.vals()) {
+  for ((_, ordThunk) in __record.values()) {
     let ord = ordThunk();
     if (ord != #equal) return ord
   };
@@ -366,7 +366,7 @@ Each per-element implicit has type `(ElemType_i, ElemType_i) -> E`. This enables
 // __tuple combiner: join per-element descriptions (evaluates all thunks)
 func describe(__tuple : [() -> Text]) : Text {
   var s = "("; var first = true;
-  for (t in __tuple.vals()) {
+  for (t in __tuple.values()) {
     if (not first) { s #= ", " };
     s #= t(); first := false
   };

--- a/doc/md/fundamentals/types/advanced-types.md
+++ b/doc/md/fundamentals/types/advanced-types.md
@@ -276,7 +276,7 @@ actor Publisher {
     };
 
     public shared func publish(message : Text) : async () {
-        for (sub in subscribers.vals()) {
+        for (sub in subscribers.values()) {
             let subActor = actor(Principal.toText(sub)) : actor { notify : (Text) -> async () };
             await subActor.notify(message);
         };

--- a/doc/md/fundamentals/types/function-types.md
+++ b/doc/md/fundamentals/types/function-types.md
@@ -321,7 +321,7 @@ A collection of values can be passed as a single array argument.
 ```motoko no-repl
   public func sum(numbers : [Nat]) : async Nat {
     var total : Nat = 0;
-    for (num in numbers.vals()) { total += num };
+    for (num in numbers.values()) { total += num };
     total;
   }
 ```

--- a/doc/md/fundamentals/types/mutable-arrays.md
+++ b/doc/md/fundamentals/types/mutable-arrays.md
@@ -207,7 +207,7 @@ func createTicTacToeBoard() : [var [var Text]] {
 
   // Function to print the board
   func printBoard() {
-    for (row in board.vals()) {
+    for (row in board.values()) {
       let rowText = Array.foldLeft<Text, Text>(Array.freeze<Text>(row), "", func(acc, cell) = acc # cell # " ");
       Debug.print(rowText)
     }

--- a/doc/md/fundamentals/types/type-conversions.md
+++ b/doc/md/fundamentals/types/type-conversions.md
@@ -172,7 +172,7 @@ import Text "mo:core/Text";
 persistent actor MapConverter {
   func arrayToMap(arr : [(Text, Nat)]) : HashMap.HashMap<Text, Nat> {
     let map = HashMap.HashMap<Text, Nat>(arr.size(), Text.equal, Text.hash);
-      for ((key, value) in arr.vals()) {
+      for ((key, value) in arr.values()) {
           map.put(key, value)
       };
       map

--- a/src/lang_utils/error_codes.ml
+++ b/src/lang_utils/error_codes.ml
@@ -271,8 +271,10 @@ let warning_codes = [
   "M0254", None, "Initial actor requires field";
   "M0265", None, "The `system` capability is not required by this mixin";
   "M0266", None, "floating-point literal has more precision than its type can represent";
-  "M0268", None, "Migration directory disagrees with the deployed history recorded by the stable baseline"
-  ]
+  "M0268", None, "Migration directory disagrees with the deployed history recorded by the stable baseline";
+  "M0269", None, "Deprecate `.vals()` in favor of `.values()`";
+  "M0270", None, "Deprecate `system func preupgrade`/`postupgrade`";
+]
 
 let try_find_explanation code =
   match List.find_opt (fun (c, _) -> String.equal c code) error_codes with

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -2312,7 +2312,7 @@ type 'a dot_callee_resolution =
 
 let warn_deprecated_vals env id fs =
   if id.it = "vals" && T.lookup_val_field_opt "values" fs <> None then
-    warn env id.at "M0269" "member `.vals()` is deprecated for caffeine; use `.values()` instead"
+    warn env id.at "M0269" "member `.vals()` is deprecated; use `.values()` instead"
 
 (* How a dot callee `e.f(...)` resolves: a function-typed field of the receiver shadows contextual dot.
    The single source of that precedence — [infer_callee] and the M0236 suggestion both resolve through it, so they cannot drift.
@@ -4608,7 +4608,7 @@ and check_system_fields env sort scope tfs dec_fields =
           if vis = System then
             begin
               if id.it = "preupgrade" || id.it = "postupgrade" then
-                warn env id.at "M0270" "system function `%s` is deprecated for caffeine; use the persistent-actor upgrade machinery (stable variables / migration functions) instead" id.it;
+                warn env id.at "M0270" "system function `%s` is deprecated; use migration functions instead" id.it;
               let (t1, _, _) = T.Env.find id.it scope.Scope.val_env in
               if not (sub env id.at t1 t) then
                 local_error env df.at "M0127" "system function %s is declared with type%a\ninstead of expected type%a" id.it

--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -2310,6 +2310,10 @@ type 'a dot_callee_resolution =
   (* Contextual dot resolution, with the field-access error to report when contextual dot fails too. *)
   | DotCtxDot of (ctx_dot_candidate, 'a context_dot_error) Result.t * (unit -> Diag.message)
 
+let warn_deprecated_vals env id fs =
+  if id.it = "vals" && T.lookup_val_field_opt "values" fs <> None then
+    warn env id.at "M0269" "member `.vals()` is deprecated for caffeine; use `.values()` instead"
+
 (* How a dot callee `e.f(...)` resolves: a function-typed field of the receiver shadows contextual dot.
    The single source of that precedence — [infer_callee] and the M0236 suggestion both resolve through it, so they cannot drift.
    [t1] is the promoted receiver type; [t0] the unpromoted one, only for error messages. *)
@@ -2958,8 +2962,10 @@ and try_infer_dot_exp env at exp id =
         "cannot infer type of forward field reference %s"
         id.it
     | Some(t) ->
-      if not env.pre then
+      if not env.pre then begin
         check_deprecation env at "field" id.it (T.lookup_val_deprecation id.it fs);
+        warn_deprecated_vals env id fs
+      end;
       Ok(t)
     | None ->
       Error (fun () -> dot_error_missing_field env id t0 fs)
@@ -3397,8 +3403,10 @@ and infer_callee env exp =
     | DotField (T.Pre, _) ->
       error env exp.at "M0071" "cannot infer type of forward field reference %s" id.it
     | DotField (t, fs) ->
-      if not env.pre then
+      if not env.pre then begin
         check_deprecation env exp.at "field" id.it (T.lookup_val_deprecation id.it fs);
+        warn_deprecated_vals env id fs
+      end;
       infer_exp_wrapper (fun _ _ -> t) T.as_immut env exp, None
     | DotCtxDot (Error (DotSuggestions mk_suggestions), mk_e) ->
       if env.pre && env.type_recovery then T.Non, None else
@@ -4599,6 +4607,8 @@ and check_system_fields env sort scope tfs dec_fields =
           (* TBR why does Stable.md require this to be a manifest function, not just any expression of appropriate type?  *)
           if vis = System then
             begin
+              if id.it = "preupgrade" || id.it = "postupgrade" then
+                warn env id.at "M0270" "system function `%s` is deprecated for caffeine; use the persistent-actor upgrade machinery (stable variables / migration functions) instead" id.it;
               let (t1, _, _) = T.Env.find id.it scope.Scope.val_env in
               if not (sub env id.at t1 t) then
                 local_error env df.at "M0127" "system function %s is declared with type%a\ninstead of expected type%a" id.it

--- a/test/bench/variant-switch.mo
+++ b/test/bench/variant-switch.mo
@@ -41,19 +41,19 @@ persistent actor Core {
 
   func sumTriples(ts : [(Text, Expr, Expr)]) : Nat {
     var n = 0;
-    for ((_, r, b) in ts.vals()) n += size r + size b;
+    for ((_, r, b) in ts.values()) n += size r + size b;
     n
   };
 
   func sumAlts(alts : [(Text, Expr)]) : Nat {
     var n = 0;
-    for ((_, e) in alts.vals()) n += size e;
+    for ((_, e) in alts.values()) n += size e;
     n
   };
 
   func sumArgs(args : [Expr]) : Nat {
     var n = 0;
-    for (e in args.vals()) n += size e;
+    for (e in args.values()) n += size e;
     n
   };
 
@@ -184,7 +184,7 @@ persistent actor Core {
     case (#Case (s, alts)) {
       switch (eval(s, env)) {
         case (#VCon (tag, _)) {
-          for ((altTag, altBody) in alts.vals()) {
+          for ((altTag, altBody) in alts.values()) {
             if (tag == altTag) return eval(altBody, env);
           };
           assert false; #VInt 0
@@ -228,7 +228,7 @@ persistent actor Core {
     case_  = func(scr, alts) = func(env) {
       switch (scr env) {
         case (#VCon (tag, _)) {
-          for ((altTag, altBody) in alts.vals()) {
+          for ((altTag, altBody) in alts.values()) {
             if (tag == altTag) return altBody env;
           };
           assert false; #VInt 0
@@ -315,14 +315,14 @@ persistent actor Core {
     var acc1 = 0;
     var i = 0;
     while (i < 10_000) {
-      for (d in week.vals()) { if (isWeekend d) acc1 += 1 };
+      for (d in week.values()) { if (isWeekend d) acc1 += 1 };
       i += 1;
     };
     let (_m1, n1) = counters();
     var acc2 = 0;
     var j = 0;
     while (j < 10_000) {
-      for (d in week.vals()) { if (isWeekendOr d) acc2 += 1 };
+      for (d in week.values()) { if (isWeekendOr d) acc2 += 1 };
       j += 1;
     };
     let (_m2, n2) = counters();
@@ -338,4 +338,3 @@ persistent actor Core {
 //CALL ingress evalBench 0x4449444C0000
 //CALL ingress weekdayBench 0x4449444C0000
 //CALL ingress getPerfData 0x4449444C0000
-//MOC-FLAG -A=M0269

--- a/test/bench/variant-switch.mo
+++ b/test/bench/variant-switch.mo
@@ -338,3 +338,4 @@ persistent actor Core {
 //CALL ingress evalBench 0x4449444C0000
 //CALL ingress weekdayBench 0x4449444C0000
 //CALL ingress getPerfData 0x4449444C0000
+//MOC-FLAG -A=M0269

--- a/test/fail/M0127.mo
+++ b/test/fail/M0127.mo
@@ -1,3 +1,4 @@
 actor {
   system func preupgrade(foo : Bool) {}
 }
+//MOC-FLAG -A=M0270

--- a/test/fail/deprecated-preupgrade.mo
+++ b/test/fail/deprecated-preupgrade.mo
@@ -1,0 +1,18 @@
+//MOC-FLAG -A=M0194,M0198
+
+// system func preupgrade/postupgrade are deprecated (M0270); heartbeat and
+// other system funcs must NOT warn. A module-level `func preupgrade` (not an
+// actor system field) must also NOT warn.
+
+module NonActor {
+  // plain functions; not actor system fields, so no M0270
+  func preupgrade() {};
+  func postupgrade() {};
+};
+
+actor {
+  system func preupgrade() {};
+  system func postupgrade() {};
+  system func heartbeat() : async () {};
+  public func greet() : async Text { "hi" }
+}

--- a/test/fail/deprecated-vals.mo
+++ b/test/fail/deprecated-vals.mo
@@ -1,0 +1,45 @@
+//MOC-FLAG -A=M0194,M0198
+
+// .vals() is deprecated (M0269) on arrays and Blob; .values() is the alias.
+// Both the value-position (`let it = x.vals()`) and the call-position
+// (`for (... in x.vals())`) spellings go through try_infer_dot_exp.
+
+import Prim "mo:⛔";
+
+do {
+  let a = [1, 2, 3];
+  let it = a.vals();            // value position, immutable array
+  ignore (it.next());
+  for (x in a.vals()) {}        // call position
+};
+
+do {
+  let m : [var Nat] = [var 1, 2, 3];
+  let it = m.vals();            // mutable array
+  ignore (it.next());
+  for (x in m.vals()) {}
+};
+
+do {
+  let b : Blob = "hi";
+  let it = b.vals();            // Blob
+  ignore (it.next());
+  for (x in b.vals()) {}
+};
+
+// .values() must NOT warn
+do {
+  let a = [1, 2, 3];
+  let it = a.values();
+  ignore (it.next());
+  for (x in a.values()) {}
+};
+
+do {
+  let b : Blob = "hi";
+  let it = b.values();
+  ignore (it.next());
+  for (x in b.values()) {}
+};
+
+Prim.debugPrint "ok";

--- a/test/fail/implicit-example.mo
+++ b/test/fail/implicit-example.mo
@@ -51,3 +51,5 @@ func test () {
 };
 
 test();
+
+//MOC-FLAG -A=M0269

--- a/test/fail/implicit-example.mo
+++ b/test/fail/implicit-example.mo
@@ -16,7 +16,7 @@ module Array {
 
   public func toText<T>(as : [T], toText : (implicit : T -> Text)) : Text {
      var t = "";
-     for (a in as.vals()) {
+     for (a in as.values()) {
        t := t # (toText(a));
      };
      t
@@ -52,4 +52,3 @@ func test () {
 
 test();
 
-//MOC-FLAG -A=M0269

--- a/test/fail/ok/deprecated-preupgrade.tc-human.ok
+++ b/test/fail/ok/deprecated-preupgrade.tc-human.ok
@@ -1,0 +1,8 @@
+warning[M0270]: system function `preupgrade` is deprecated for caffeine; use the persistent-actor upgrade machinery (stable variables / migration functions) instead
+    ┌─ deprecated-preupgrade.mo:14:15
+ 14 │    system func preupgrade() {};
+    │                ^^^^^^^^^^ 
+warning[M0270]: system function `postupgrade` is deprecated for caffeine; use the persistent-actor upgrade machinery (stable variables / migration functions) instead
+    ┌─ deprecated-preupgrade.mo:15:15
+ 15 │    system func postupgrade() {};
+    │                ^^^^^^^^^^^ 

--- a/test/fail/ok/deprecated-preupgrade.tc-human.ok
+++ b/test/fail/ok/deprecated-preupgrade.tc-human.ok
@@ -1,8 +1,8 @@
-warning[M0270]: system function `preupgrade` is deprecated for caffeine; use the persistent-actor upgrade machinery (stable variables / migration functions) instead
+warning[M0270]: system function `preupgrade` is deprecated; use migration functions instead
     ┌─ deprecated-preupgrade.mo:14:15
  14 │    system func preupgrade() {};
     │                ^^^^^^^^^^ 
-warning[M0270]: system function `postupgrade` is deprecated for caffeine; use the persistent-actor upgrade machinery (stable variables / migration functions) instead
+warning[M0270]: system function `postupgrade` is deprecated; use migration functions instead
     ┌─ deprecated-preupgrade.mo:15:15
  15 │    system func postupgrade() {};
     │                ^^^^^^^^^^^ 

--- a/test/fail/ok/deprecated-preupgrade.tc.ok
+++ b/test/fail/ok/deprecated-preupgrade.tc.ok
@@ -1,2 +1,2 @@
-deprecated-preupgrade.mo:14.15-14.25: warning [M0270], system function `preupgrade` is deprecated for caffeine; use the persistent-actor upgrade machinery (stable variables / migration functions) instead
-deprecated-preupgrade.mo:15.15-15.26: warning [M0270], system function `postupgrade` is deprecated for caffeine; use the persistent-actor upgrade machinery (stable variables / migration functions) instead
+deprecated-preupgrade.mo:14.15-14.25: warning [M0270], system function `preupgrade` is deprecated; use migration functions instead
+deprecated-preupgrade.mo:15.15-15.26: warning [M0270], system function `postupgrade` is deprecated; use migration functions instead

--- a/test/fail/ok/deprecated-preupgrade.tc.ok
+++ b/test/fail/ok/deprecated-preupgrade.tc.ok
@@ -1,0 +1,2 @@
+deprecated-preupgrade.mo:14.15-14.25: warning [M0270], system function `preupgrade` is deprecated for caffeine; use the persistent-actor upgrade machinery (stable variables / migration functions) instead
+deprecated-preupgrade.mo:15.15-15.26: warning [M0270], system function `postupgrade` is deprecated for caffeine; use the persistent-actor upgrade machinery (stable variables / migration functions) instead

--- a/test/fail/ok/deprecated-vals.tc-human.ok
+++ b/test/fail/ok/deprecated-vals.tc-human.ok
@@ -1,24 +1,24 @@
-warning[M0269]: member `.vals()` is deprecated for caffeine; use `.values()` instead
+warning[M0269]: member `.vals()` is deprecated; use `.values()` instead
     ┌─ deprecated-vals.mo:11:14
  11 │    let it = a.vals();            // value position, immutable array
     │               ^^^^ 
-warning[M0269]: member `.vals()` is deprecated for caffeine; use `.values()` instead
+warning[M0269]: member `.vals()` is deprecated; use `.values()` instead
     ┌─ deprecated-vals.mo:13:15
  13 │    for (x in a.vals()) {}        // call position
     │                ^^^^ 
-warning[M0269]: member `.vals()` is deprecated for caffeine; use `.values()` instead
+warning[M0269]: member `.vals()` is deprecated; use `.values()` instead
     ┌─ deprecated-vals.mo:18:14
  18 │    let it = m.vals();            // mutable array
     │               ^^^^ 
-warning[M0269]: member `.vals()` is deprecated for caffeine; use `.values()` instead
+warning[M0269]: member `.vals()` is deprecated; use `.values()` instead
     ┌─ deprecated-vals.mo:20:15
  20 │    for (x in m.vals()) {}
     │                ^^^^ 
-warning[M0269]: member `.vals()` is deprecated for caffeine; use `.values()` instead
+warning[M0269]: member `.vals()` is deprecated; use `.values()` instead
     ┌─ deprecated-vals.mo:25:14
  25 │    let it = b.vals();            // Blob
     │               ^^^^ 
-warning[M0269]: member `.vals()` is deprecated for caffeine; use `.values()` instead
+warning[M0269]: member `.vals()` is deprecated; use `.values()` instead
     ┌─ deprecated-vals.mo:27:15
  27 │    for (x in b.vals()) {}
     │                ^^^^ 

--- a/test/fail/ok/deprecated-vals.tc-human.ok
+++ b/test/fail/ok/deprecated-vals.tc-human.ok
@@ -1,0 +1,24 @@
+warning[M0269]: member `.vals()` is deprecated for caffeine; use `.values()` instead
+    ┌─ deprecated-vals.mo:11:14
+ 11 │    let it = a.vals();            // value position, immutable array
+    │               ^^^^ 
+warning[M0269]: member `.vals()` is deprecated for caffeine; use `.values()` instead
+    ┌─ deprecated-vals.mo:13:15
+ 13 │    for (x in a.vals()) {}        // call position
+    │                ^^^^ 
+warning[M0269]: member `.vals()` is deprecated for caffeine; use `.values()` instead
+    ┌─ deprecated-vals.mo:18:14
+ 18 │    let it = m.vals();            // mutable array
+    │               ^^^^ 
+warning[M0269]: member `.vals()` is deprecated for caffeine; use `.values()` instead
+    ┌─ deprecated-vals.mo:20:15
+ 20 │    for (x in m.vals()) {}
+    │                ^^^^ 
+warning[M0269]: member `.vals()` is deprecated for caffeine; use `.values()` instead
+    ┌─ deprecated-vals.mo:25:14
+ 25 │    let it = b.vals();            // Blob
+    │               ^^^^ 
+warning[M0269]: member `.vals()` is deprecated for caffeine; use `.values()` instead
+    ┌─ deprecated-vals.mo:27:15
+ 27 │    for (x in b.vals()) {}
+    │                ^^^^ 

--- a/test/fail/ok/deprecated-vals.tc.ok
+++ b/test/fail/ok/deprecated-vals.tc.ok
@@ -1,0 +1,6 @@
+deprecated-vals.mo:11.14-11.18: warning [M0269], member `.vals()` is deprecated for caffeine; use `.values()` instead
+deprecated-vals.mo:13.15-13.19: warning [M0269], member `.vals()` is deprecated for caffeine; use `.values()` instead
+deprecated-vals.mo:18.14-18.18: warning [M0269], member `.vals()` is deprecated for caffeine; use `.values()` instead
+deprecated-vals.mo:20.15-20.19: warning [M0269], member `.vals()` is deprecated for caffeine; use `.values()` instead
+deprecated-vals.mo:25.14-25.18: warning [M0269], member `.vals()` is deprecated for caffeine; use `.values()` instead
+deprecated-vals.mo:27.15-27.19: warning [M0269], member `.vals()` is deprecated for caffeine; use `.values()` instead

--- a/test/fail/ok/deprecated-vals.tc.ok
+++ b/test/fail/ok/deprecated-vals.tc.ok
@@ -1,6 +1,6 @@
-deprecated-vals.mo:11.14-11.18: warning [M0269], member `.vals()` is deprecated for caffeine; use `.values()` instead
-deprecated-vals.mo:13.15-13.19: warning [M0269], member `.vals()` is deprecated for caffeine; use `.values()` instead
-deprecated-vals.mo:18.14-18.18: warning [M0269], member `.vals()` is deprecated for caffeine; use `.values()` instead
-deprecated-vals.mo:20.15-20.19: warning [M0269], member `.vals()` is deprecated for caffeine; use `.values()` instead
-deprecated-vals.mo:25.14-25.18: warning [M0269], member `.vals()` is deprecated for caffeine; use `.values()` instead
-deprecated-vals.mo:27.15-27.19: warning [M0269], member `.vals()` is deprecated for caffeine; use `.values()` instead
+deprecated-vals.mo:11.14-11.18: warning [M0269], member `.vals()` is deprecated; use `.values()` instead
+deprecated-vals.mo:13.15-13.19: warning [M0269], member `.vals()` is deprecated; use `.values()` instead
+deprecated-vals.mo:18.14-18.18: warning [M0269], member `.vals()` is deprecated; use `.values()` instead
+deprecated-vals.mo:20.15-20.19: warning [M0269], member `.vals()` is deprecated; use `.values()` instead
+deprecated-vals.mo:25.14-25.18: warning [M0269], member `.vals()` is deprecated; use `.values()` instead
+deprecated-vals.mo:27.15-27.19: warning [M0269], member `.vals()` is deprecated; use `.values()` instead

--- a/test/fail/ok/warn-help.tc-human.ok
+++ b/test/fail/ok/warn-help.tc-human.ok
@@ -43,5 +43,7 @@ M0254 (W) Initial actor requires field
 M0265 (W) The `system` capability is not required by this mixin
 M0266 (W) floating-point literal has more precision than its type can represent
 M0268 (E) Migration directory disagrees with the deployed history recorded by the stable baseline
+M0269 (W) Deprecate `.vals()` in favor of `.values()`
+M0270 (W) Deprecate `system func preupgrade`/`postupgrade`
 
 Legend: A - allowed (warning disabled); W - warn (warning enabled); E - error (treated as error)

--- a/test/fail/ok/warn-help.tc.ok
+++ b/test/fail/ok/warn-help.tc.ok
@@ -43,5 +43,7 @@ M0254 (W) Initial actor requires field
 M0265 (W) The `system` capability is not required by this mixin
 M0266 (W) floating-point literal has more precision than its type can represent
 M0268 (E) Migration directory disagrees with the deployed history recorded by the stable baseline
+M0269 (W) Deprecate `.vals()` in favor of `.values()`
+M0270 (W) Deprecate `system func preupgrade`/`postupgrade`
 
 Legend: A - allowed (warning disabled); W - warn (warning enabled); E - error (treated as error)

--- a/test/json-stub/src/Json.mo
+++ b/test/json-stub/src/Json.mo
@@ -19,7 +19,7 @@ module {
       case (#array items) {
         var s = "[";
         var first = true;
-        for (item in items.vals()) {
+        for (item in items.values()) {
           if (not first) { s #= "," };
           s #= toText(item);
           first := false;
@@ -29,7 +29,7 @@ module {
       case (#obj pairs) {
         var s = "{";
         var first = true;
-        for ((k, v) in pairs.vals()) {
+        for ((k, v) in pairs.values()) {
           if (not first) { s #= "," };
           s #= "\"" # k # "\":" # toText(v);
           first := false;

--- a/test/run-drun-non-ci/test-cost/test-cost-http.mo
+++ b/test/run-drun-non-ci/test-cost/test-cost-http.mo
@@ -125,7 +125,7 @@ actor client {
     size += Prim.natToNat64(request.url.size());
 
     // Add headers byte length (sum of all names and values)
-    for (header in request.headers.vals()) {
+    for (header in request.headers.values()) {
       size += Prim.natToNat64(header.name.size());
       size += Prim.natToNat64(header.value.size());
     };

--- a/test/run-drun/actor-class-mgmt-enhanced.mo
+++ b/test/run-drun/actor-class-mgmt-enhanced.mo
@@ -1,4 +1,5 @@
 //ENHANCED-ORTHOGONAL-PERSISTENCE-ONLY
+//MOC-FLAG -A=M0270
 import Prim "mo:⛔";
 import Cycles = "cycles/cycles";
 import Cs "actor-class-mgmt/C";

--- a/test/run-drun/actor-class-mgmt-interp.mo
+++ b/test/run-drun/actor-class-mgmt-interp.mo
@@ -1,3 +1,4 @@
+//MOC-FLAG -A=M0270
 //MOC-FLAG -A=M0194
 import Prim "mo:⛔";
 import Cs "actor-class-mgmt/C";

--- a/test/run-drun/actor-class-mgmt.mo
+++ b/test/run-drun/actor-class-mgmt.mo
@@ -1,3 +1,4 @@
+//MOC-FLAG -A=M0270
 import Prim "mo:⛔";
 import Cycles = "cycles/cycles";
 import Cs "actor-class-mgmt/C";

--- a/test/run-drun/async-bang.mo
+++ b/test/run-drun/async-bang.mo
@@ -98,3 +98,4 @@ actor a {
 };
 
 a.go(); //OR-CALL ingress go "DIDL\x00\x00"
+//MOC-FLAG -A=M0269

--- a/test/run-drun/async-bang.mo
+++ b/test/run-drun/async-bang.mo
@@ -28,7 +28,7 @@ actor a {
     let o3 = do ? {
        var sum = 0;
        await async {};
-       for(o in [?1, ?2, ?3].vals()) {
+       for(o in [?1, ?2, ?3].values()) {
          sum += o!
        };
        sum
@@ -49,7 +49,7 @@ actor a {
     let o4 = do ? {
        var sum = 0;
        await async {};
-       for(o in [?1, ?2, null].vals()) {
+       for(o in [?1, ?2, null].values()) {
          sum += o!
        };
        sum
@@ -98,4 +98,3 @@ actor a {
 };
 
 a.go(); //OR-CALL ingress go "DIDL\x00\x00"
-//MOC-FLAG -A=M0269

--- a/test/run-drun/caller-info/caller-info.mo
+++ b/test/run-drun/caller-info/caller-info.mo
@@ -60,7 +60,7 @@ actor {
   };
 
   func lookupText(map : [(Text, Icrc3Value)], key : Text) : ?Text {
-    for ((k, v) in map.vals()) {
+    for ((k, v) in map.values()) {
       if (k == key) {
         switch v {
           case (#Text t) { return ?t };

--- a/test/run-drun/double-sharing-benchmark.mo
+++ b/test/run-drun/double-sharing-benchmark.mo
@@ -39,3 +39,4 @@ actor {
 //SKIP run-low
 //SKIP run
 //SKIP run-ir
+//MOC-FLAG -A=M0270

--- a/test/run-drun/float32-stable/main.mo
+++ b/test/run-drun/float32-stable/main.mo
@@ -9,7 +9,7 @@ actor {
 
   public func show() : async () {
     debugPrint (debug_show (float32ToFloat x));
-    for (v in arr.vals()) debugPrint (debug_show (float32ToFloat v))
+    for (v in arr.values()) debugPrint (debug_show (float32ToFloat v))
   };
 
   public func mutate() : async () {

--- a/test/run-drun/gc.mo
+++ b/test/run-drun/gc.mo
@@ -49,3 +49,4 @@ actor {
 //CALL ingress testArray "DIDL\x00\x00"
 //CALL ingress testArrayMut "DIDL\x00\x00"
 
+//MOC-FLAG -A=M0269

--- a/test/run-drun/general_await.mo
+++ b/test/run-drun/general_await.mo
@@ -124,3 +124,4 @@ actor Await {
 };
 
 Await.Test(); //OR-CALL ingress Test 0x4449444C0000
+//MOC-FLAG -A=M0269

--- a/test/run-drun/general_await.mo
+++ b/test/run-drun/general_await.mo
@@ -34,7 +34,7 @@ actor Await {
    for (i in os.keys()) {
      os[i] := ? (Ack());
    };
-   for (o in os.vals()) {
+   for (o in os.values()) {
      switch o {
        case (? a) await a;
        case null (assert false);
@@ -124,4 +124,3 @@ actor Await {
 };
 
 Await.Test(); //OR-CALL ingress Test 0x4449444C0000
-//MOC-FLAG -A=M0269

--- a/test/run-drun/general_await_implicit.mo
+++ b/test/run-drun/general_await_implicit.mo
@@ -33,7 +33,7 @@ actor Await {
    for (i in os.keys()) {
      os[i] := ? (Ack());
    };
-   for (o in os.vals()) {
+   for (o in os.values()) {
      switch o {
       case (? a) await a;
       case null (assert false);
@@ -123,4 +123,3 @@ actor Await {
 };
 
 Await.Test(); //OR-CALL ingress Test 0x4449444C0000
-//MOC-FLAG -A=M0269

--- a/test/run-drun/general_await_implicit.mo
+++ b/test/run-drun/general_await_implicit.mo
@@ -123,3 +123,4 @@ actor Await {
 };
 
 Await.Test(); //OR-CALL ingress Test 0x4449444C0000
+//MOC-FLAG -A=M0269

--- a/test/run-drun/incremental-actor-class-stabilization.mo
+++ b/test/run-drun/incremental-actor-class-stabilization.mo
@@ -1,5 +1,5 @@
 //ENHANCED-ORTHOGONAL-PERSISTENCE-ONLY
-//MOC-FLAG --stabilization-instruction-limit=10000
+//MOC-FLAG --stabilization-instruction-limit=10000 -A=M0270
 
 import Prim "mo:⛔";
 import Cycles = "cycles/cycles";

--- a/test/run-drun/incremental-stabilization.mo
+++ b/test/run-drun/incremental-stabilization.mo
@@ -67,3 +67,4 @@ actor {
 //SKIP run
 //SKIP run-ir
 //SKIP run-low
+//MOC-FLAG -A=M0270

--- a/test/run-drun/non-incremental-stabilization.mo
+++ b/test/run-drun/non-incremental-stabilization.mo
@@ -37,3 +37,4 @@ actor {
 //SKIP run
 //SKIP run-ir
 //SKIP run-low
+//MOC-FLAG -A=M0270

--- a/test/run-drun/query-footprint.mo
+++ b/test/run-drun/query-footprint.mo
@@ -38,3 +38,4 @@ actor footprint = {
 //SKIP run
 //SKIP run-ir
 //SKIP run-low
+//MOC-FLAG -A=M0270

--- a/test/run-drun/region0-stable-mem-blob.mo
+++ b/test/run-drun/region0-stable-mem-blob.mo
@@ -112,3 +112,4 @@ actor {
 //CALL ingress testBounds "DIDL\x00\x00"
 //CALL upgrade ""
 
+//MOC-FLAG -A=M0270

--- a/test/run-drun/region0-stable-mem-float.mo
+++ b/test/run-drun/region0-stable-mem-float.mo
@@ -89,3 +89,4 @@ actor {
 //CALL ingress testBounds "DIDL\x00\x00"
 //CALL upgrade ""
 
+//MOC-FLAG -A=M0270

--- a/test/run-drun/region0-stable-mem-grow.mo
+++ b/test/run-drun/region0-stable-mem-grow.mo
@@ -58,3 +58,4 @@ actor {
 //CALL upgrade ""
 //CALL ingress testGrow "DIDL\x00\x00"
 //CALL upgrade ""
+//MOC-FLAG -A=M0270

--- a/test/run-drun/region0-stable-mem-int16.mo
+++ b/test/run-drun/region0-stable-mem-int16.mo
@@ -89,3 +89,4 @@ actor {
 //CALL ingress testBounds "DIDL\x00\x00"
 //CALL upgrade ""
 
+//MOC-FLAG -A=M0270

--- a/test/run-drun/region0-stable-mem-int32.mo
+++ b/test/run-drun/region0-stable-mem-int32.mo
@@ -89,3 +89,4 @@ actor {
 //CALL ingress testBounds "DIDL\x00\x00"
 //CALL upgrade ""
 
+//MOC-FLAG -A=M0270

--- a/test/run-drun/region0-stable-mem-int64.mo
+++ b/test/run-drun/region0-stable-mem-int64.mo
@@ -89,3 +89,4 @@ actor {
 //CALL ingress testBounds "DIDL\x00\x00"
 //CALL upgrade ""
 
+//MOC-FLAG -A=M0270

--- a/test/run-drun/region0-stable-mem-int8.mo
+++ b/test/run-drun/region0-stable-mem-int8.mo
@@ -89,3 +89,4 @@ actor {
 //CALL ingress testBounds "DIDL\x00\x00"
 //CALL upgrade ""
 
+//MOC-FLAG -A=M0270

--- a/test/run-drun/region0-stable-mem-nat16.mo
+++ b/test/run-drun/region0-stable-mem-nat16.mo
@@ -89,3 +89,4 @@ actor {
 //CALL ingress testBounds "DIDL\x00\x00"
 //CALL upgrade ""
 
+//MOC-FLAG -A=M0270

--- a/test/run-drun/region0-stable-mem-nat32.mo
+++ b/test/run-drun/region0-stable-mem-nat32.mo
@@ -89,3 +89,4 @@ actor {
 //CALL ingress testBounds "DIDL\x00\x00"
 //CALL upgrade ""
 
+//MOC-FLAG -A=M0270

--- a/test/run-drun/region0-stable-mem-nat64.mo
+++ b/test/run-drun/region0-stable-mem-nat64.mo
@@ -89,3 +89,4 @@ actor {
 //CALL ingress testBounds "DIDL\x00\x00"
 //CALL upgrade ""
 
+//MOC-FLAG -A=M0270

--- a/test/run-drun/region0-stable-mem-nat8.mo
+++ b/test/run-drun/region0-stable-mem-nat8.mo
@@ -86,3 +86,4 @@ actor {
 //CALL upgrade ""
 //CALL ingress testBounds "DIDL\x00\x00"
 //CALL upgrade ""
+//MOC-FLAG -A=M0270

--- a/test/run-drun/snapshot.mo
+++ b/test/run-drun/snapshot.mo
@@ -1,3 +1,4 @@
+//MOC-FLAG -A=M0270
 import Prim "mo:prim";
 import Cycles "cycles/cycles";
 import TestActor "snapshot/test-actor";

--- a/test/run-drun/stabilization-authorization.mo
+++ b/test/run-drun/stabilization-authorization.mo
@@ -1,5 +1,5 @@
 //ENHANCED-ORTHOGONAL-PERSISTENCE-ONLY
-//MOC-FLAG --stabilization-instruction-limit=10000
+//MOC-FLAG --stabilization-instruction-limit=10000 -A=M0270
 
 import Prim "mo:⛔";
 import Cycles = "cycles/cycles";

--- a/test/run-drun/stabilize-beyond-stable-limit.mo
+++ b/test/run-drun/stabilize-beyond-stable-limit.mo
@@ -44,3 +44,4 @@ actor {
 //SKIP run-ir
 //SKIP run-low
 
+//MOC-FLAG -A=M0270

--- a/test/run-drun/stabilize-large-array.mo
+++ b/test/run-drun/stabilize-large-array.mo
@@ -33,3 +33,4 @@ actor {
 //SKIP run
 //SKIP run-ir
 //SKIP run-low
+//MOC-FLAG -A=M0270

--- a/test/run-drun/stable-exp.mo
+++ b/test/run-drun/stable-exp.mo
@@ -87,3 +87,4 @@ actor {
 //CALL upgrade ""
 //CALL upgrade ""
 
+//MOC-FLAG -A=M0270

--- a/test/run-drun/stable-mem-blob.mo
+++ b/test/run-drun/stable-mem-blob.mo
@@ -109,3 +109,4 @@ actor {
 //CALL ingress testBounds "DIDL\x00\x00"
 //CALL upgrade ""
 
+//MOC-FLAG -A=M0270

--- a/test/run-drun/stable-mem-float.mo
+++ b/test/run-drun/stable-mem-float.mo
@@ -88,3 +88,4 @@ actor {
 //CALL ingress testBounds "DIDL\x00\x00"
 //CALL upgrade ""
 
+//MOC-FLAG -A=M0270

--- a/test/run-drun/stable-mem-grow.mo
+++ b/test/run-drun/stable-mem-grow.mo
@@ -58,3 +58,4 @@ actor {
 //CALL upgrade ""
 //CALL ingress testGrow "DIDL\x00\x00"
 //CALL upgrade ""
+//MOC-FLAG -A=M0270

--- a/test/run-drun/stable-mem-int16.mo
+++ b/test/run-drun/stable-mem-int16.mo
@@ -88,3 +88,4 @@ actor {
 //CALL ingress testBounds "DIDL\x00\x00"
 //CALL upgrade ""
 
+//MOC-FLAG -A=M0270

--- a/test/run-drun/stable-mem-int32.mo
+++ b/test/run-drun/stable-mem-int32.mo
@@ -88,3 +88,4 @@ actor {
 //CALL ingress testBounds "DIDL\x00\x00"
 //CALL upgrade ""
 
+//MOC-FLAG -A=M0270

--- a/test/run-drun/stable-mem-int64.mo
+++ b/test/run-drun/stable-mem-int64.mo
@@ -88,3 +88,4 @@ actor {
 //CALL ingress testBounds "DIDL\x00\x00"
 //CALL upgrade ""
 
+//MOC-FLAG -A=M0270

--- a/test/run-drun/stable-mem-int8.mo
+++ b/test/run-drun/stable-mem-int8.mo
@@ -88,3 +88,4 @@ actor {
 //CALL ingress testBounds "DIDL\x00\x00"
 //CALL upgrade ""
 
+//MOC-FLAG -A=M0270

--- a/test/run-drun/stable-mem-nat16.mo
+++ b/test/run-drun/stable-mem-nat16.mo
@@ -88,3 +88,4 @@ actor {
 //CALL ingress testBounds "DIDL\x00\x00"
 //CALL upgrade ""
 
+//MOC-FLAG -A=M0270

--- a/test/run-drun/stable-mem-nat32.mo
+++ b/test/run-drun/stable-mem-nat32.mo
@@ -88,3 +88,4 @@ actor {
 //CALL ingress testBounds "DIDL\x00\x00"
 //CALL upgrade ""
 
+//MOC-FLAG -A=M0270

--- a/test/run-drun/stable-mem-nat64.mo
+++ b/test/run-drun/stable-mem-nat64.mo
@@ -88,3 +88,4 @@ actor {
 //CALL ingress testBounds "DIDL\x00\x00"
 //CALL upgrade ""
 
+//MOC-FLAG -A=M0270

--- a/test/run-drun/stable-mem-nat8.mo
+++ b/test/run-drun/stable-mem-nat8.mo
@@ -85,3 +85,4 @@ actor {
 //CALL upgrade ""
 //CALL ingress testBounds "DIDL\x00\x00"
 //CALL upgrade ""
+//MOC-FLAG -A=M0270

--- a/test/run-drun/stable-region-blob.mo
+++ b/test/run-drun/stable-region-blob.mo
@@ -103,3 +103,4 @@ actor {
 //CALL upgrade ""
 //CALL ingress testBounds "DIDL\x00\x00"
 //CALL upgrade ""
+//MOC-FLAG -A=M0270

--- a/test/run-drun/stable-regions-new-each-stabilization.mo
+++ b/test/run-drun/stable-regions-new-each-stabilization.mo
@@ -42,3 +42,4 @@ actor {
 //CALL ingress __motoko_stabilize_before_upgrade "DIDL\x00\x00"
 //CALL upgrade ""
 //CALL ingress sanityTest "DIDL\x00\x00"
+//MOC-FLAG -A=M0270

--- a/test/run-drun/stable-regions-new-each-upgrade.mo
+++ b/test/run-drun/stable-regions-new-each-upgrade.mo
@@ -38,3 +38,4 @@ actor {
 //CALL ingress sanityTest "DIDL\x00\x00"
 //CALL upgrade ""
 //CALL ingress sanityTest "DIDL\x00\x00"
+//MOC-FLAG -A=M0270

--- a/test/run-drun/stable-regions-one.mo
+++ b/test/run-drun/stable-regions-one.mo
@@ -38,3 +38,4 @@ actor {
 //CALL ingress sanityTest "DIDL\x00\x00"
 //CALL upgrade ""
 //CALL ingress sanityTest "DIDL\x00\x00"
+//MOC-FLAG -A=M0270

--- a/test/run-drun/stable-regions-stabilization.mo
+++ b/test/run-drun/stable-regions-stabilization.mo
@@ -48,3 +48,4 @@ actor {
 //CALL ingress __motoko_stabilize_before_upgrade "DIDL\x00\x00"
 //CALL upgrade ""
 //CALL ingress sanityTest "DIDL\x00\x00"
+//MOC-FLAG -A=M0270

--- a/test/run-drun/stable-regions-upgrade.mo
+++ b/test/run-drun/stable-regions-upgrade.mo
@@ -46,3 +46,4 @@ actor {
 //CALL ingress sanityTest "DIDL\x00\x00"
 //CALL upgrade ""
 //CALL ingress sanityTest "DIDL\x00\x00"
+//MOC-FLAG -A=M0270

--- a/test/run-drun/stable-size-no-overflow.mo
+++ b/test/run-drun/stable-size-no-overflow.mo
@@ -23,3 +23,4 @@ actor {
 
 //CALL upgrade ""
 
+//MOC-FLAG -A=M0270

--- a/test/run-drun/stable-size-overflow.mo
+++ b/test/run-drun/stable-size-overflow.mo
@@ -23,3 +23,4 @@ actor {
 
 //CALL upgrade ""
 
+//MOC-FLAG -A=M0270

--- a/test/run-drun/system-capability.mo
+++ b/test/run-drun/system-capability.mo
@@ -21,3 +21,4 @@ actor {
 //SKIP run-low
 //SKIP drun-run
 //SKIP wasm-run
+//MOC-FLAG -A=M0270

--- a/test/run-drun/weak-ref-test.mo
+++ b/test/run-drun/weak-ref-test.mo
@@ -90,3 +90,4 @@ persistent actor {
 //ENHANCED-ORTHOGONAL-PERSISTENCE-ONLY
 
 //CALL ingress test3 "DIDL\x00\x00"
+//MOC-FLAG -A=M0269

--- a/test/run-drun/weak-ref-test.mo
+++ b/test/run-drun/weak-ref-test.mo
@@ -41,7 +41,7 @@ persistent actor {
     while (idx < 5) {
 
       Prim.debugPrint(debug_show ("================"));
-      for (wr in wrs.vals()) {
+      for (wr in wrs.values()) {
         Prim.debugPrint(debug_show (Prim.isLive(wr)));
       };
 
@@ -66,7 +66,7 @@ persistent actor {
 
       Prim.debugPrint(debug_show ("================"));
 
-      for (wr in wrs.vals()) {
+      for (wr in wrs.values()) {
         let val = Prim.weakGet(wr);
         Prim.debugPrint(debug_show (val));
         Prim.debugPrint(debug_show (Prim.isLive(wr)));
@@ -90,4 +90,3 @@ persistent actor {
 //ENHANCED-ORTHOGONAL-PERSISTENCE-ONLY
 
 //CALL ingress test3 "DIDL\x00\x00"
-//MOC-FLAG -A=M0269

--- a/test/run/array-gen.mo
+++ b/test/run/array-gen.mo
@@ -3,7 +3,7 @@ import Prim "mo:⛔";
 let a = Prim.Array_init<Nat>(10,42);
 
 assert (a.size() == 10);
-for (n in a.vals()) {
+for (n in a.values()) {
   assert(n == 42);
 };
 for (n in a.values()) {
@@ -59,4 +59,3 @@ tabulate(1);
 tabulate(2);
 tabulate(1000);
 tabulate(1000_000);
-//MOC-FLAG -A=M0269

--- a/test/run/array-gen.mo
+++ b/test/run/array-gen.mo
@@ -59,3 +59,4 @@ tabulate(1);
 tabulate(2);
 tabulate(1000);
 tabulate(1000_000);
+//MOC-FLAG -A=M0269

--- a/test/run/array.mo
+++ b/test/run/array.mo
@@ -112,3 +112,4 @@ let homogeneous = [true, false, true];
 
 assert not homogeneous[1];
 assert homogeneous[2]
+//MOC-FLAG -A=M0269

--- a/test/run/bang.mo
+++ b/test/run/bang.mo
@@ -22,7 +22,7 @@ assert (o2 == null);
 
 let o3 = do ? {
    var sum = 0;
-   for(o in [?1, ?2, ?3].vals()) {
+   for(o in [?1, ?2, ?3].values()) {
      sum += o!
    };
    sum
@@ -41,7 +41,7 @@ assert (o3Values == ? 6);
 
 let o4 = do ? {
    var sum = 0;
-   for(o in [?1, ?2, null].vals()) {
+   for(o in [?1, ?2, null].values()) {
      sum += o!
    };
    sum
@@ -80,4 +80,3 @@ let o7 = do ? {
 };
 print o7;
 assert (o7 == null);
-//MOC-FLAG -A=M0269

--- a/test/run/bang.mo
+++ b/test/run/bang.mo
@@ -80,3 +80,4 @@ let o7 = do ? {
 };
 print o7;
 assert (o7 == null);
+//MOC-FLAG -A=M0269

--- a/test/run/implicit-derivation-lib-ambig-fallthrough.mo
+++ b/test/run/implicit-derivation-lib-ambig-fallthrough.mo
@@ -14,7 +14,7 @@ module Combiner {
   public func show(__record : [(Text, () -> Text)]) : Text {
     var s = "{";
     var first = true;
-    for ((k, v) in __record.vals()) {
+    for ((k, v) in __record.values()) {
       if (not first) { s #= "," };
       s #= k # ":" # v();
       first := false;
@@ -26,4 +26,3 @@ module Combiner {
 func render(r : R, show : (implicit : R -> Text)) : Text = show(r);
 
 assert render({ a = 1; b = 2 }) == "{a:1,b:2}";
-//MOC-FLAG -A=M0269

--- a/test/run/implicit-derivation-lib-ambig-fallthrough.mo
+++ b/test/run/implicit-derivation-lib-ambig-fallthrough.mo
@@ -26,3 +26,4 @@ module Combiner {
 func render(r : R, show : (implicit : R -> Text)) : Text = show(r);
 
 assert render({ a = 1; b = 2 }) == "{a:1,b:2}";
+//MOC-FLAG -A=M0269

--- a/test/run/implicit-derivation-structural-compare.mo
+++ b/test/run/implicit-derivation-structural-compare.mo
@@ -130,3 +130,4 @@ let tt3 : TaggedTeam = { key = (1 : Nat, "A"); size = 3 };
 assert cmp(tt1, tt2) == #less; // key: (1,"A") < (2,"B")
 assert cmp(tt1, tt3) == #greater; // same key; size: 5 > 3
 assert cmp(tt1, { key = (1 : Nat, "A"); size = 5 }) == #equal;
+//MOC-FLAG -A=M0269

--- a/test/run/implicit-derivation-structural-compare.mo
+++ b/test/run/implicit-derivation-structural-compare.mo
@@ -11,7 +11,7 @@ import Order "mo:core/Order";
 // Thunks enable genuine short-circuiting: remaining fields are never evaluated.
 module RecordCmp {
   public func compare(__record : [(Text, () -> Order.Order)]) : Order.Order {
-    for ((_, ordThunk) in __record.vals()) {
+    for ((_, ordThunk) in __record.values()) {
       let ord = ordThunk();
       if (ord != #equal) return ord;
     };
@@ -22,7 +22,7 @@ module RecordCmp {
 // __tuple combiner: same fold, but receives [() -> Order] without field names
 module TupleCmp {
   public func compare(__tuple : [() -> Order.Order]) : Order.Order {
-    for (ordThunk in __tuple.vals()) {
+    for (ordThunk in __tuple.values()) {
       let ord = ordThunk();
       if (ord != #equal) return ord;
     };
@@ -130,4 +130,3 @@ let tt3 : TaggedTeam = { key = (1 : Nat, "A"); size = 3 };
 assert cmp(tt1, tt2) == #less; // key: (1,"A") < (2,"B")
 assert cmp(tt1, tt3) == #greater; // same key; size: 5 > 3
 assert cmp(tt1, { key = (1 : Nat, "A"); size = 5 }) == #equal;
-//MOC-FLAG -A=M0269

--- a/test/run/implicit-derivation-structural-dispatch.mo
+++ b/test/run/implicit-derivation-structural-dispatch.mo
@@ -24,7 +24,7 @@ module RecRender {
   public func render(__record : [(Text, () -> Text)]) : Text {
     var s = "{";
     var first = true;
-    for ((lab, v) in __record.vals()) {
+    for ((lab, v) in __record.values()) {
       if (not first) { s #= ", " };
       s #= lab # ":" # v();
       first := false;
@@ -39,7 +39,7 @@ module TupRender {
   public func render(__tuple : [() -> Text]) : Text {
     var s = "(";
     var first = true;
-    for (v in __tuple.vals()) {
+    for (v in __tuple.values()) {
       if (not first) { s #= ", " };
       s #= v();
       first := false;
@@ -90,4 +90,3 @@ assert zeroFields({}, {}) == "{}";
 type Pair = (Text, Nat);
 func showPair(x : Pair, render : (implicit : Pair -> Text)) : Text = render(x);
 assert showPair(("world", 7 : Nat)) == "(world, 7)";
-//MOC-FLAG -A=M0269

--- a/test/run/implicit-derivation-structural-dispatch.mo
+++ b/test/run/implicit-derivation-structural-dispatch.mo
@@ -90,3 +90,4 @@ assert zeroFields({}, {}) == "{}";
 type Pair = (Text, Nat);
 func showPair(x : Pair, render : (implicit : Pair -> Text)) : Text = render(x);
 assert showPair(("world", 7 : Nat)) == "(world, 7)";
+//MOC-FLAG -A=M0269

--- a/test/run/implicit-derivation-structural-variant.mo
+++ b/test/run/implicit-derivation-structural-variant.mo
@@ -60,3 +60,4 @@ assert s6 == "#ping(7)";
 type Tree = { #leaf : Nat; #nest : Tree };
 let s7 = inspect<Tree>(#nest (#nest (#leaf 3)));
 assert s7 == "#nest(#nest(#leaf(3)))";
+//MOC-FLAG -A=M0269

--- a/test/run/implicit-derivation-structural-variant.mo
+++ b/test/run/implicit-derivation-structural-variant.mo
@@ -41,7 +41,7 @@ module RecordShow {
   public func show(__record : [(Text, () -> Text)]) : Text {
     var s = "{";
     var first = true;
-    for ((k, v) in __record.vals()) {
+    for ((k, v) in __record.values()) {
       if (not first) { s #= "," };
       s #= k # "=" # v();
       first := false;
@@ -60,4 +60,3 @@ assert s6 == "#ping(7)";
 type Tree = { #leaf : Nat; #nest : Tree };
 let s7 = inspect<Tree>(#nest (#nest (#leaf 3)));
 assert s7 == "#nest(#nest(#leaf(3)))";
-//MOC-FLAG -A=M0269

--- a/test/run/implicit-monoid.mo
+++ b/test/run/implicit-monoid.mo
@@ -10,7 +10,7 @@ type Monoid<T> = module {
 
 func fold<T>(xs : [T], Monoid : (implicit : Monoid<T>)) : T {
   var acc = Monoid.empty;
-  for (x in xs.vals()) {
+  for (x in xs.values()) {
     acc := Monoid.combine(acc, x);
   };
   acc;
@@ -57,4 +57,3 @@ do {
   let Monoid = Nat.MonoidMul;
   assert fold([2, 3, 4]) == 24;
 };
-//MOC-FLAG -A=M0269

--- a/test/run/implicit-monoid.mo
+++ b/test/run/implicit-monoid.mo
@@ -57,3 +57,4 @@ do {
   let Monoid = Nat.MonoidMul;
   assert fold([2, 3, 4]) == 24;
 };
+//MOC-FLAG -A=M0269

--- a/test/run/implicits-example.mo
+++ b/test/run/implicits-example.mo
@@ -14,7 +14,7 @@ module Array {
 
   public func toText<T>(as : [T], toText : (implicit : T -> Text)) : Text {
      var t = "";
-     for (a in as.vals()) {
+     for (a in as.values()) {
        t := t # (toText(a));
      };
      t
@@ -54,4 +54,3 @@ func test () {
 };
 
 test();
-//MOC-FLAG -A=M0269

--- a/test/run/implicits-example.mo
+++ b/test/run/implicits-example.mo
@@ -54,3 +54,4 @@ func test () {
 };
 
 test();
+//MOC-FLAG -A=M0269

--- a/test/run/iter-no-alloc.mo
+++ b/test/run/iter-no-alloc.mo
@@ -25,3 +25,4 @@ iter("record", Prim.Array_tabulate<{foo : Nat}>(iters,func x = ({ foo = x })));
 //SKIP run
 //SKIP run-ir
 //SKIP run-low
+//MOC-FLAG -A=M0269

--- a/test/run/iter-no-alloc.mo
+++ b/test/run/iter-no-alloc.mo
@@ -5,7 +5,7 @@ let iters = 10_000;
 func iter<A>(what : Text, xs : [A]) {
   let before = Prim.rts_heap_size();
   for (_ in xs.keys()) {};
-  for (_ in xs.vals()) {};
+  for (_ in xs.values()) {};
   for (_ in xs.values()) {};
   let after = Prim.rts_heap_size();
   Prim.debugPrint("Allocation per iteration (" # what # "): " # debug_show ((after-before) / iters : Nat));
@@ -25,4 +25,3 @@ iter("record", Prim.Array_tabulate<{foo : Nat}>(iters,func x = ({ foo = x })));
 //SKIP run
 //SKIP run-ir
 //SKIP run-low
-//MOC-FLAG -A=M0269

--- a/test/run/mut-array-iter-max.mo
+++ b/test/run/mut-array-iter-max.mo
@@ -3,7 +3,7 @@ import Prim "mo:⛔";
 let max_size = 2**29; // maximum array size
 let a = Prim.Array_init<Nat>(max_size, 666);
 var c1 = 0;
-for (v in a.vals()) {
+for (v in a.values()) {
  assert v == 666; c1 += 1;
 };
 var c2 = 0;
@@ -24,4 +24,3 @@ Prim.debugPrint(debug_show d);
 //SKIP run
 //SKIP run-ir
 //SKIP run-low
-//MOC-FLAG -A=M0269

--- a/test/run/mut-array-iter-max.mo
+++ b/test/run/mut-array-iter-max.mo
@@ -24,3 +24,4 @@ Prim.debugPrint(debug_show d);
 //SKIP run
 //SKIP run-ir
 //SKIP run-low
+//MOC-FLAG -A=M0269

--- a/test/run/optimise-for-array-classical.mo
+++ b/test/run/optimise-for-array-classical.mo
@@ -18,7 +18,7 @@ import Prim "mo:⛔";
 // FHECK-NEXT: call $print_text
 // FHECK:      i32.const 4
 // FHECK-NEXT: i32.add
-for (check0 in ["hello", "world"].vals()) { Prim.debugPrint check0 };
+for (check0 in ["hello", "world"].values()) { Prim.debugPrint check0 };
 
 // FHECK-NOT:  call $@immut_array_size
 // DON'TFHECK: i32.load offset=(5 or 9) 
@@ -46,7 +46,7 @@ for (check0 in ["hello", "world"].values()) { Prim.debugPrint check0 };
 // FHECK:      i32.load offset=
 // FHECK-NEXT: local.tee $check1
 // FHECK-NEXT: call $print_text
-for (check1 in [var "hello", "mutable", "world"].vals()) { Prim.debugPrint check1 };
+for (check1 in [var "hello", "mutable", "world"].values()) { Prim.debugPrint check1 };
 
 
 // FHECK-NOT:  call $@mut_array_size
@@ -74,7 +74,7 @@ array[1] := "remutable";
 // DON'T-FHECK: local.set $check2
 // `arr` being a `VarE` already (but we rebind anyway, otherwise we open a can of worms)
 // later when we have path compression for variables in the backend, we can bring this back
-for (check2 in array.vals()) { Prim.debugPrint check2 };
+for (check2 in array.values()) { Prim.debugPrint check2 };
 
 let arrayValues = [var "hello", "unexpected", "world"];
 arrayValues[1] := "remutable";
@@ -101,7 +101,7 @@ for (check2 in arrayValues.values()) { Prim.debugPrint check2 };
 // FHECK:      i32.load offset=
 // FHECK-NEXT: local.tee $check3
 // interfering parentheses don't disturb us
-for (check3 in (((["hello", "immutable", "world"].vals())))) { Prim.debugPrint check3 };
+for (check3 in (((["hello", "immutable", "world"].values())))) { Prim.debugPrint check3 };
 
 // FHECK-NOT:  call $@immut_array_size
 // DON'TFHECK: i32.load offset=(5 or 9)
@@ -129,7 +129,7 @@ for (check3 in (((["hello", "immutable", "world"].values())))) { Prim.debugPrint
 // bottom iteration expression is treated fairly
 var c1 = 42;
 if (c1 == c1 + 1) {
-    for (check4 in (loop {}).vals()) { Prim.debugPrint check4 }
+    for (check4 in (loop {}).values()) { Prim.debugPrint check4 }
 };
 
 // FHECK:      i32.const 84
@@ -157,7 +157,7 @@ if (c2 == c2 + 1) {
 // FHECK-NEXT: else
 // typed bottom iteration expression is treated fairly
 if (c1 == c1 + 1) {
-    for (check5 in ((loop {}) : [Text]).vals()) { Prim.debugPrint check5 }
+    for (check5 in ((loop {}) : [Text]).values()) { Prim.debugPrint check5 }
 };
 
 // FHECK:      call $B_add
@@ -177,7 +177,7 @@ let check6 = [var "hello", "immutable", "world"];
 check6[1] := "mutable";
 // `check6` being a `VarE` already and iteration variable is named identically
 // this passes the IR type check, which demonstrates that no name capture happens
-for (check6 in check6.vals()) { ignore check6 };
+for (check6 in check6.values()) { ignore check6 };
 
 let check6Values = [var "hello", "immutable", "world"];
 check6Values[1] := "mutable";
@@ -190,7 +190,7 @@ for (check6 in check6Values.values()) { ignore check6 };
 // FHECK:      i32.const 2
 // FHECK:      i32.shl
 // argument to vals can have an effect too, expect it
-for (check7 in [].vals(Prim.debugPrint "want to see you")) { };
+for (check7 in [].values(Prim.debugPrint "want to see you")) { };
 
 // DON'TFHECK: i32.load offset=(5 or 9)
 // FHECK:      i32.load offset=
@@ -223,7 +223,7 @@ func _f9<A>(array : [A]) {
 
 // make sure that one-byte-sized elements still work
 var sum10 : Nat8 = 0;
-for (check10 in ([3, 5, 7, 11] : [Nat8]).vals()) { sum10 += check10 };
+for (check10 in ([3, 5, 7, 11] : [Nat8]).values()) { sum10 += check10 };
 assert sum10 == 26;
 
 // make sure that one-byte-sized elements still work
@@ -235,4 +235,3 @@ assert sum10 == 26;
 sum10 := 0;
 for (check10 in ([3, 5, 7, 11] : [Nat8]).values()) { sum10 += check10 };
 assert sum10 == 26
-//MOC-FLAG -A=M0269

--- a/test/run/optimise-for-array-classical.mo
+++ b/test/run/optimise-for-array-classical.mo
@@ -235,3 +235,4 @@ assert sum10 == 26;
 sum10 := 0;
 for (check10 in ([3, 5, 7, 11] : [Nat8]).values()) { sum10 += check10 };
 assert sum10 == 26
+//MOC-FLAG -A=M0269

--- a/test/run/optimise-for-array-enhanced.mo
+++ b/test/run/optimise-for-array-enhanced.mo
@@ -72,7 +72,7 @@ for (check3 in (((["hello", "immutable", "world"].values())))) { Prim.debugPrint
 // bottom iteration expression is treated fairly
 var c = 42;
 if (c == c + 1) {
-    for (check4 in (loop {}).vals()) { Prim.debugPrint check4 }
+    for (check4 in (loop {}).values()) { Prim.debugPrint check4 }
 };
 
 // FIX-CHECK:      i64.const 170
@@ -102,7 +102,7 @@ if (c == c + 1) {
 // FIX-CHECK-NEXT: else
 // typed bottom iteration expression is treated fairly
 if (c == c + 1) {
-    for (check5 in ((loop {}) : [Text]).vals()) { Prim.debugPrint check5 }
+    for (check5 in ((loop {}) : [Text]).values()) { Prim.debugPrint check5 }
 };
 
 // FIX-CHECK:      call $B_add
@@ -158,4 +158,3 @@ func _f9<A>(array : [A]) {
 var sum10 : Nat8 = 0;
 for (check10 in ([3, 5, 7, 11] : [Nat8]).values()) { sum10 += check10 };
 assert sum10 == 26;
-//MOC-FLAG -A=M0269

--- a/test/run/optimise-for-array-enhanced.mo
+++ b/test/run/optimise-for-array-enhanced.mo
@@ -158,3 +158,4 @@ func _f9<A>(array : [A]) {
 var sum10 : Nat8 = 0;
 for (check10 in ([3, 5, 7, 11] : [Nat8]).values()) { sum10 += check10 };
 assert sum10 == 26;
+//MOC-FLAG -A=M0269


### PR DESCRIPTION
Part of the planned breaking-change list in #6231.

## What changes for users

Two new **non-breaking, default-on warnings** (emit at type-check; silence with `-A=M0269` / `-A=M0270`):

- **M0269** — `` `.vals()` `` on arrays and `Blob` is deprecated in favor of `` `.values()` ``.
  ```motoko
  let it = arr.vals();   // warning [M0269], use .values()
  ```
- **M0270** — `system func preupgrade()` / `system func postupgrade()` are deprecated, steering toward the persistent-actor upgrade machinery (stable variables / migration functions).
  ```motoko
  actor { system func preupgrade() {} }   // warning [M0270]
  ```

Both are backward-compatible: existing code still compiles, just with a warning. This starts the deprecation clock for a future breaking release.

## Why

These two deprecations are item D in #6231's list of planned breaking changes. Landing them as default-on warnings first lets the ecosystem migrate before the features are eventually removed.

## Migration notes

- Replace `arr.vals()` / `blob.vals()` with `arr.values()` / `blob.values()`.
- For upgrade logic in `system func preupgrade/postupgrade`, adopt stable variables or the migration-function machinery.
- To keep current behavior in CI/downstream builds, silence per-warning: `-A=M0269`, `-A=M0270`.

## Tests

- New `fail/` tests covering both warnings (value + call positions, actors, negative cases that must **not** warn).
- Regenerated `--warn-help` goldens (M0269/M0270 now listed).
- Added `-A=M0269`/`-A=M0270` to existing tests that intentionally exercise `.vals()`/`preupgrade`/`postupgrade`.

Made with [Cursor](https://cursor.com)