### PR TITLE
feat: add Prim.costVetkdDeriveKey primitive

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,13 @@
     receiver (including the built-in fields of arrays, blobs and text)
     suppresses the suggestion (#6343).
 
+  * feat: add `Prim.costVetkdDeriveKey` for querying the cycle cost of the
+    IC `cost_vetkd_derive_key` system call, mirroring the existing
+    `costSignWithEcdsa`/`costSignWithSchnorr` primitives. It takes a `Text`
+    key name and a `Nat32` curve encoding and returns `(resultCode, costOrUndefined)`,
+    where a non-zero `resultCode` signals an invalid key name or curve
+    encoding, and `costOrUndefined` is the cost when `resultCode == 0` (#6337).
+
 ## 1.15.1 (2026-09-02)
 
 * motoko (`moc`)

--- a/Changelog.md
+++ b/Changelog.md
@@ -16,7 +16,7 @@
     `costSignWithEcdsa`/`costSignWithSchnorr` primitives. It takes a `Text`
     key name and a `Nat32` curve encoding and returns `(resultCode, costOrUndefined)`,
     where a non-zero `resultCode` signals an invalid key name or curve
-    encoding, and `costOrUndefined` is the cost when `resultCode == 0` (#6337).
+    encoding, and `costOrUndefined` is the cost when `resultCode == 0` (#6353).
 
 ## 1.15.1 (2026-09-02)
 

--- a/src/codegen/compile_classical.ml
+++ b/src/codegen/compile_classical.ml
@@ -5153,6 +5153,7 @@ module IC = struct
     E.add_func_import env "ic0" "cost_http_request" [I64Type; I64Type; i] [];
     E.add_func_import env "ic0" "cost_sign_with_ecdsa" [i; i; I32Type; i] [I32Type];
     E.add_func_import env "ic0" "cost_sign_with_schnorr" [i; i; I32Type; i] [I32Type];
+    E.add_func_import env "ic0" "cost_vetkd_derive_key" [i; i; I32Type; i] [I32Type];
 
     E.add_func_import env "ic0" "certified_data_set" (is 2) [];
     E.add_func_import env "ic0" "data_certificate_present" [] [I32Type];
@@ -10499,6 +10500,22 @@ module Cost = struct
           Cycles.from_word128_ptr env
         )
       )
+
+  let vetkd_derive_key env =
+    Func.share_code2 Func.Always env "cost_vetkd_derive_key"
+      (("key_name", IC.i), ("curve", I32Type))
+      [IC.i; I32Type]
+      (fun env get_key_name get_curve ->
+        Stack.with_words env "dst" 4l (fun get_dst ->
+          get_key_name ^^ Text.to_blob env ^^ Blob.as_ptr_len env ^^
+          get_curve ^^
+          get_dst ^^
+          IC.ic_system_call "cost_vetkd_derive_key" env  ^^
+          StackRep.adjust env (SR.UnboxedWord32 Type.Int32) SR.Vanilla ^^
+          get_dst ^^
+          Cycles.from_word128_ptr env
+        )
+      )
 end
 
 (* The actual compiler code that looks at the AST *)
@@ -12744,6 +12761,11 @@ and compile_prim_invocation (env : E.t) ae p es at =
     compile_exp_vanilla env ae key_name ^^
     compile_exp_as env ae (SR.UnboxedWord32 Type.Nat32) algorithm ^^
     Cost.sign_with_schnorr env
+  | OtherPrim "costVetkdDeriveKey", [key_name; curve] ->
+    SR.UnboxedTuple 2,
+    compile_exp_vanilla env ae key_name ^^
+    compile_exp_as env ae (SR.UnboxedWord32 Type.Nat32) curve ^^
+    Cost.vetkd_derive_key env
 
   | SystemTimeoutSetPrim, [e1] ->
     SR.unit, compile_exp_as env ae (SR.UnboxedWord32 Type.Nat32) e1 ^^ IC.system_call env "call_with_best_effort_response"

--- a/src/codegen/compile_enhanced.ml
+++ b/src/codegen/compile_enhanced.ml
@@ -4929,6 +4929,7 @@ module IC = struct
     E.add_func_import env "ic0" "cost_http_request" [I64Type; I64Type; i] [];
     E.add_func_import env "ic0" "cost_sign_with_ecdsa" [i; i; I32Type; i] [I32Type];
     E.add_func_import env "ic0" "cost_sign_with_schnorr" [i; i; I32Type; i] [I32Type];
+    E.add_func_import env "ic0" "cost_vetkd_derive_key" [i; i; I32Type; i] [I32Type];
 
     E.add_func_import env "ic0" "certified_data_set" (is 2) [];
     E.add_func_import env "ic0" "data_certificate_present" [] [I32Type];
@@ -10998,6 +10999,24 @@ module Cost = struct
           Cycles.from_word128_ptr env
         )
       )
+
+  let vetkd_derive_key env =
+    Func.share_code2 Func.Always env "cost_vetkd_derive_key"
+      (("key_name", IC.i), ("curve", I32Type))
+      [IC.i; I64Type]
+      (fun env get_key_name get_curve ->
+        Stack.with_words env "dst" 2L (fun get_dst ->
+          get_key_name ^^ Text.to_blob env ^^ Blob.as_ptr_len env ^^
+          get_curve ^^
+          get_dst ^^
+          IC.ic_system_call "cost_vetkd_derive_key" env ^^
+          G.i (Convert (Wasm_exts.Values.I64 I64Op.ExtendUI32)) ^^
+          TaggedSmallWord.msb_adjust Type.Nat32 ^^
+          StackRep.adjust env (SR.UnboxedWord64 Type.Nat32) SR.Vanilla ^^
+          get_dst ^^
+          Cycles.from_word128_ptr env
+        )
+      )
 end
 
 (* The actual compiler code that looks at the AST *)
@@ -13129,6 +13148,13 @@ and compile_prim_invocation (env : E.t) ae p es at =
     TaggedSmallWord.lsb_adjust Type.Nat32 ^^
     G.i (Convert (Wasm_exts.Values.I32 I32Op.WrapI64)) ^^
     Cost.sign_with_schnorr env
+  | OtherPrim "costVetkdDeriveKey", [key_name; curve] ->
+    SR.UnboxedTuple 2,
+    compile_exp_vanilla env ae key_name ^^
+    compile_exp_as env ae (SR.UnboxedWord64 Type.Nat32) curve ^^
+    TaggedSmallWord.lsb_adjust Type.Nat32 ^^
+    G.i (Convert (Wasm_exts.Values.I32 I32Op.WrapI64)) ^^
+    Cost.vetkd_derive_key env
 
   | SystemTimeoutSetPrim, [e1] ->
     SR.unit,

--- a/src/prelude/prim.mo
+++ b/src/prelude/prim.mo
@@ -684,6 +684,8 @@ func costSignWithEcdsa(keyName : Text, curveEncoding : Nat32) : (resultCode : Na
 
 func costSignWithSchnorr(keyName : Text, algorithmEncoding : Nat32) : (resultCode : Nat32, costOrUndefined : Nat) = (prim "costSignWithSchnorr" : (Text, Nat32) -> (Nat32, Nat))(keyName, algorithmEncoding);
 
+func costVetkdDeriveKey(keyName : Text, curveEncoding : Nat32) : (resultCode : Nat32, costOrUndefined : Nat) = (prim "costVetkdDeriveKey" : (Text, Nat32) -> (Nat32, Nat))(keyName, curveEncoding);
+
 // certified data
 func setCertifiedData(data : Blob) = (prim "setCertifiedData" : Blob -> ()) data;
 func getCertificate() : ?Blob = (prim "getCertificate" : () -> ?Blob)();

--- a/test/fail/ok/no-timer-canc.tc-human.ok
+++ b/test/fail/ok/no-timer-canc.tc-human.ok
@@ -108,6 +108,9 @@ error[M0119]: object field cancelTimer is not contained in expected type
     costSignWithSchnorr :
       (keyName : Text, algorithmEncoding : Nat32) ->
         (resultCode : Nat32, costOrUndefined : Nat);
+    costVetkdDeriveKey :
+      (keyName : Text, curveEncoding : Nat32) ->
+        (resultCode : Nat32, costOrUndefined : Nat);
     createActor : (wasm : Blob, argument : Blob) -> async Principal;
     ctzInt16 : (w : Int16) -> Int16;
     ctzInt32 : (w : Int32) -> Int32;

--- a/test/fail/ok/no-timer-canc.tc.ok
+++ b/test/fail/ok/no-timer-canc.tc.ok
@@ -108,6 +108,9 @@ no-timer-canc.mo:3.10-3.21: type error [M0119], object field cancelTimer is not 
     costSignWithSchnorr :
       (keyName : Text, algorithmEncoding : Nat32) ->
         (resultCode : Nat32, costOrUndefined : Nat);
+    costVetkdDeriveKey :
+      (keyName : Text, curveEncoding : Nat32) ->
+        (resultCode : Nat32, costOrUndefined : Nat);
     createActor : (wasm : Blob, argument : Blob) -> async Principal;
     ctzInt16 : (w : Int16) -> Int16;
     ctzInt32 : (w : Int32) -> Int32;

--- a/test/fail/ok/no-timer-set.tc-human.ok
+++ b/test/fail/ok/no-timer-set.tc-human.ok
@@ -108,6 +108,9 @@ error[M0119]: object field setTimer is not contained in expected type
     costSignWithSchnorr :
       (keyName : Text, algorithmEncoding : Nat32) ->
         (resultCode : Nat32, costOrUndefined : Nat);
+    costVetkdDeriveKey :
+      (keyName : Text, curveEncoding : Nat32) ->
+        (resultCode : Nat32, costOrUndefined : Nat);
     createActor : (wasm : Blob, argument : Blob) -> async Principal;
     ctzInt16 : (w : Int16) -> Int16;
     ctzInt32 : (w : Int32) -> Int32;

--- a/test/fail/ok/no-timer-set.tc.ok
+++ b/test/fail/ok/no-timer-set.tc.ok
@@ -108,6 +108,9 @@ no-timer-set.mo:3.10-3.18: type error [M0119], object field setTimer is not cont
     costSignWithSchnorr :
       (keyName : Text, algorithmEncoding : Nat32) ->
         (resultCode : Nat32, costOrUndefined : Nat);
+    costVetkdDeriveKey :
+      (keyName : Text, curveEncoding : Nat32) ->
+        (resultCode : Nat32, costOrUndefined : Nat);
     createActor : (wasm : Blob, argument : Blob) -> async Principal;
     ctzInt16 : (w : Int16) -> Int16;
     ctzInt32 : (w : Int32) -> Int32;

--- a/test/fail/ok/suggest-long-ai.tc-human.ok
+++ b/test/fail/ok/suggest-long-ai.tc-human.ok
@@ -109,6 +109,9 @@ error[M0072]: field stableM does not exist in type:
     costSignWithSchnorr :
       (keyName : Text, algorithmEncoding : Nat32) ->
         (resultCode : Nat32, costOrUndefined : Nat);
+    costVetkdDeriveKey :
+      (keyName : Text, curveEncoding : Nat32) ->
+        (resultCode : Nat32, costOrUndefined : Nat);
     createActor : (wasm : Blob, argument : Blob) -> async Principal;
     ctzInt16 : (w : Int16) -> Int16;
     ctzInt32 : (w : Int32) -> Int32;

--- a/test/fail/ok/suggest-long-ai.tc.ok
+++ b/test/fail/ok/suggest-long-ai.tc.ok
@@ -109,6 +109,9 @@ suggest-long-ai.mo:4.6-4.13: type error [M0072], field stableM does not exist in
     costSignWithSchnorr :
       (keyName : Text, algorithmEncoding : Nat32) ->
         (resultCode : Nat32, costOrUndefined : Nat);
+    costVetkdDeriveKey :
+      (keyName : Text, curveEncoding : Nat32) ->
+        (resultCode : Nat32, costOrUndefined : Nat);
     createActor : (wasm : Blob, argument : Blob) -> async Principal;
     ctzInt16 : (w : Int16) -> Int16;
     ctzInt32 : (w : Int32) -> Int32;

--- a/test/fail/ok/suggest-short-ai.tc-human.ok
+++ b/test/fail/ok/suggest-short-ai.tc-human.ok
@@ -109,6 +109,9 @@ error[M0072]: field s does not exist in type:
     costSignWithSchnorr :
       (keyName : Text, algorithmEncoding : Nat32) ->
         (resultCode : Nat32, costOrUndefined : Nat);
+    costVetkdDeriveKey :
+      (keyName : Text, curveEncoding : Nat32) ->
+        (resultCode : Nat32, costOrUndefined : Nat);
     createActor : (wasm : Blob, argument : Blob) -> async Principal;
     ctzInt16 : (w : Int16) -> Int16;
     ctzInt32 : (w : Int32) -> Int32;

--- a/test/fail/ok/suggest-short-ai.tc.ok
+++ b/test/fail/ok/suggest-short-ai.tc.ok
@@ -109,6 +109,9 @@ suggest-short-ai.mo:4.6-4.7: type error [M0072], field s does not exist in type:
     costSignWithSchnorr :
       (keyName : Text, algorithmEncoding : Nat32) ->
         (resultCode : Nat32, costOrUndefined : Nat);
+    costVetkdDeriveKey :
+      (keyName : Text, curveEncoding : Nat32) ->
+        (resultCode : Nat32, costOrUndefined : Nat);
     createActor : (wasm : Blob, argument : Blob) -> async Principal;
     ctzInt16 : (w : Int16) -> Int16;
     ctzInt32 : (w : Int32) -> Int32;

--- a/test/run-drun-non-ci/test-cost/test-cost-vetkd.mo
+++ b/test/run-drun-non-ci/test-cost/test-cost-vetkd.mo
@@ -1,0 +1,67 @@
+import Prim "mo:⛔";
+
+actor client {
+  func print(t : Text) = Prim.debugPrint("client: " # t);
+
+  type Key = { name : Text; curve : VetKDCurve };
+  type VetKDCurve = { #bls12_381 };
+  type Args = {
+    input : Blob;
+    context : Blob;
+    transport_public_key : Blob;
+    key_id : Key;
+  };
+  let ic00 = actor "aaaaa-aa" : actor {
+    vetkd_derive_key : shared Args -> async { encrypted_key : Blob };
+  };
+  func encodeCurve(curve : VetKDCurve) : Nat32 = switch curve {
+    case (#bls12_381) 0;
+  };
+
+  public shared ({ caller }) func go() : async () {
+    let fakeContext = Prim.arrayToBlob([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+    let fakeTransportPublicKey = Prim.arrayToBlob([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+    let key : Key = { name = "test_key_1"; curve = #bls12_381 };
+    let args : Args = {
+      input = Prim.blobOfPrincipal(caller);
+      context = fakeContext;
+      transport_public_key = fakeTransportPublicKey;
+      key_id = key;
+    };
+
+    await test(args);
+  };
+
+  func test(args : Args) : async () {
+    let (code, cost) = Prim.costVetkdDeriveKey(args.key_id.name, encodeCurve(args.key_id.curve));
+    print(debug_show (code, cost) # " -- vetkd derive key cost");
+    assert code == 0 and cost > 0;
+
+    printCycles();
+    let { encrypted_key } = await (with cycles = cost) ic00.vetkd_derive_key(args);
+    print("encrypted_key: " # debug_show (encrypted_key));
+    printCycles();
+
+    // Try the same args with less cycles, it should fail
+    try {
+      let _ = await (with cycles = cost - 1) ic00.vetkd_derive_key(args);
+      assert false; // Should not happen
+    } catch (e) {
+      assert Prim.errorCode(e) == #canister_reject;
+      print("error message: " # debug_show (Prim.errorMessage(e)));
+    };
+    print("---");
+  };
+
+  func printCycles() {
+    print("Cycles.balance()   = " # debug_show (Prim.cyclesBalance()));
+    print("Cycles.available() = " # debug_show (Prim.cyclesAvailable()));
+    print("Cycles.refunded()  = " # debug_show (Prim.cyclesRefunded()));
+  };
+};
+
+client.go(); //OR-CALL ingress go "DIDL\x00\x00"
+
+//SKIP run
+//SKIP run-ir
+//SKIP run-low

--- a/test/run-drun/cost-prims-enhanced.mo
+++ b/test/run-drun/cost-prims-enhanced.mo
@@ -6,6 +6,7 @@
 //   OtherPrim "costHttpRequest"
 //   OtherPrim "costSignWithEcdsa"
 //   OtherPrim "costSignWithSchnorr"
+//   OtherPrim "costVetkdDeriveKey"
 //SKIP run
 //SKIP run-low
 //SKIP run-ir
@@ -36,17 +37,20 @@ actor {
     // OtherPrim "costHttpRequest"
     Prim.debugPrint(debug_show (Prim.costHttpRequest(15, 2000)) # " -- cost_http_request");
 
-    // OtherPrim "costSignWithEcdsa" / "costSignWithSchnorr"
+    // OtherPrim "costSignWithEcdsa" / "costSignWithSchnorr" / "costVetkdDeriveKey"
     // drun has empty key sets; all queries produce error codes
     let validKey = "test_key_1";
     let invalidCurveOrAlgorithm : Nat32 = 42;
     let validCurveOrAlgorithm : Nat32 = 0;
     testCost(Prim.costSignWithEcdsa(validKey, invalidCurveOrAlgorithm), " -- cost_sign_with_ecdsa");
     testCost(Prim.costSignWithSchnorr(validKey, invalidCurveOrAlgorithm), " -- cost_sign_with_schnorr");
+    testCost(Prim.costVetkdDeriveKey(validKey, invalidCurveOrAlgorithm), " -- cost_vetkd_derive_key");
     testCost(Prim.costSignWithEcdsa("wrong_key", validCurveOrAlgorithm), " -- cost_sign_with_ecdsa");
     testCost(Prim.costSignWithSchnorr("wrong_key", validCurveOrAlgorithm), " -- cost_sign_with_schnorr");
+    testCost(Prim.costVetkdDeriveKey("wrong_key", validCurveOrAlgorithm), " -- cost_vetkd_derive_key");
     testCost(Prim.costSignWithEcdsa(validKey, validCurveOrAlgorithm), " -- cost_sign_with_ecdsa");
     testCost(Prim.costSignWithSchnorr(validKey, validCurveOrAlgorithm), " -- cost_sign_with_schnorr");
+    testCost(Prim.costVetkdDeriveKey(validKey, validCurveOrAlgorithm), " -- cost_vetkd_derive_key");
   };
 };
 


### PR DESCRIPTION
## What changes for users

Adds `Prim.costVetkdDeriveKey : (Text, Nat32) -> (Nat32, Nat)` to `mo:⛔`, wrapping the IC system call `ic0.cost_vetkd_derive_key`. It mirrors the existing `costSignWithEcdsa` / `costSignWithSchnorr` primitives.

**Before**, a Motoko library on the vetkd path had to pin the derivation fee as a compiled-in literal:

```motoko
await (with cycles = 26_153_846_153) (actor ("aaaaa-aa") : VetkdSystemApi).vetkd_derive_key(request);
```

That constant encodes both the base fee and the signing subnet's node count, so it silently goes stale when either changes, and it over-reserves (~2.6x) for cheaper test keys.

**After**, the library can resolve the current cost at runtime and attach exactly the required cycles:

```motoko
let (code, cost) = Prim.costVetkdDeriveKey(keyName, curveEncoding);
assert code == 0;
await (with cycles = cost) ... .vetkd_derive_key(request);
```

A non-zero `resultCode` signals an invalid key name or curve encoding, `costOrUndefined` holds the cost when the code is zero. This closes the gap in #6337: the two signing cost prims were already exposed, vetKD was the missing one.

## Why

`dfinity/vetkeys`' Motoko library (`ic_vetkeys`) hardcodes the fee and is blocked on this (dfinity/vetkeys#442). Rust got `ic_cdk::api::cost_vetkd_derive_key` in ic-cdk v0.18.3; Motoko had no way to reach the system API. #5001 originally included this prim and dropped it because the replica hadn't exported the function yet — that runtime blocker is gone, so this finishes the #5001 scope under the function's current name.

## Notes

- The primitive is declared in `src/prelude/prim.mo` and dispatched in both codegen backends (`compile_enhanced.ml`, `compile_classical.ml`), importing `ic0.cost_vetkd_derive_key : (i64, i64, i32, i64) -> i32` — structurally identical to `cost_sign_with_ecdsa`. No interpreter arm (cost prims are codegen-only).
- **Verified by exercising the path on PocketIC.** I compiled the emitted wasm and ran `Prim.costVetkdDeriveKey` through this repo's PocketIC harness. It executed end-to-end and returned the same shape as its sibling: in this environment it yields `(2, <large cost>)`, exactly matching `Prim.costSignWithEcdsa` under identical conditions. The code path, ABI, and error-code convention are faithful to the ECDSA/Schnorr twins.
- **Why the end-to-end test is in `run-drun-non-ci`.** `test/run-drun-non-ci/test-cost/test-cost-vetkd.mo` mirrors `test-cost-ecdsa.mo` / `test-cost-schnorr.mo`. It asserts `code == 0` and performs a real `vetkd_derive_key` call, which requires a subnet with a provisioned threshold-signing key. This repo's PocketIC harness provisions no such key (`PocketIcBuilder` app subnet, no key setup), so all three cost prims return the "signing unavailable" error code there. The DRUN-era rationale for keeping these out of CI ("drun limitations") is largely obsolete — the tests execute on PocketIC today — but they still need a keyed subnet to reach their success path, so they stay non-CI by design.
- `test/run-drun/cost-prims-enhanced.mo` (in CI) is extended with the new arm; it exercises the compiler dispatch on the enhanced backend and passes.

Closes #6337

Made with [Cursor](https://cursor.com)