### PR TITLE
feat!: drop Intel-Mac (macos-15-intel) build/release legs and the base release tarball

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-15-intel, ubuntu-26.04-arm, macos-latest ]
+        os: [ ubuntu-latest, ubuntu-26.04-arm, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
     needs: prepare
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-15-intel, ubuntu-26.04-arm, macos-latest]
+        os: [ubuntu-latest, ubuntu-26.04-arm, macos-latest]
     concurrency:
       group: release-build-${{ matrix.os }}-${{ github.ref_name }}
       cancel-in-progress: true

--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,16 @@
     `system func preupgrade`/`postupgrade` are deprecated in favor of the
     persistent upgrade machinery. Silence with `-A=M0269` / `-A=M0270`
     (#6347).
+
+  * BREAKING CHANGE: the `motoko-Darwin-x86_64` release tarball and the
+    Intel-Mac (`macos-15-intel`) build/release CI legs are dropped; neither
+    the compiler nor its runtime are built or shipped for Intel Macs anymore.
+    x86_64-linux, aarch64-linux and Apple Silicon (`macos-latest`) binaries
+    continue to be produced. Users on Intel Macs should build from source.
+    The `motoko-base-library.tar.gz` release artifact is also dropped (the
+    `base` library remains available for tests as `base-tests`/`base-stub`);
+    `motoko-core.tar.gz` is unaffected. (#6355)
+
   * bugfix: The contextual dot suggestion (`M0236`) no longer proposes
     rewriting `M.f(e, ...)` to `e.f(...)` when the rewrite would resolve
     differently: the suggestion now validates the rewritten callee against

--- a/flake.nix
+++ b/flake.nix
@@ -254,7 +254,6 @@
         # Platform-specific release files.
         release-files-ubuntu-latest = import ./nix/release-files-ubuntu-latest.nix { inherit self pkgs; };
         "release-files-ubuntu-26.04-arm" = import ./nix/release-files-ubuntu-26.04-arm.nix { inherit self pkgs; };
-        release-files-macos-15-intel = import ./nix/release-files-macos-15-intel.nix { inherit self pkgs; };
         release-files-macos-latest = import ./nix/release-files-macos-latest.nix { inherit self pkgs; };
 
         # Common tests version - includes non-GC, non-release/debug specific tests.

--- a/nix/release-files-macos-15-intel.nix
+++ b/nix/release-files-macos-15-intel.nix
@@ -1,9 +1,0 @@
-{ self, pkgs }:
-let
-  common = import ./release-files-common.nix { inherit pkgs; };
-  packages = self.packages.${pkgs.stdenv.hostPlatform.system};
-in
-pkgs.runCommand "motoko-release-${common.releaseVersion}" { } ''
-  mkdir $out
-  cp ${common.as_tarball "Darwin-x86_64" (with packages.release; [ mo-doc moc ])} $out/motoko-Darwin-x86_64-${common.releaseVersion}.tar.gz
-''

--- a/nix/release-files-ubuntu-latest.nix
+++ b/nix/release-files-ubuntu-latest.nix
@@ -8,6 +8,5 @@ pkgs.runCommand "motoko-release-${common.releaseVersion}" { } ''
   cp ${common.as_tarball "Linux-x86_64" (with packages.release; [ mo-doc moc ])} $out/motoko-Linux-x86_64-${common.releaseVersion}.tar.gz
   cp ${common.as_js "moc" packages.js.moc} $out/moc-${common.releaseVersion}.js
   cp ${common.as_js "moc-interpreter" packages.js.moc_interpreter} $out/moc-interpreter-${common.releaseVersion}.js
-  tar --exclude=.github -C ${pkgs.sources.motoko-base-src} -czvf $out/motoko-base-library.tar.gz .
   tar --exclude=.github -C ${pkgs.sources.motoko-core-src} -czvf $out/motoko-core.tar.gz .
 ''


### PR DESCRIPTION
## Why

C-step of the moc v2 release plan ([#6231](https://github.com/caffeinelabs/motoko/issues/6231)): drop the Intel-Mac (`macos-15-intel`) build/release legs and stop shipping the `base` library tarball in releases.

## Changes

- **`.github/workflows/build.yml` / `release.yml`**: remove `macos-15-intel` from the CI build and release matrices. Remaining legs: `ubuntu-latest` (x86_64-linux), `ubuntu-26.04-arm` (aarch64-linux), `macos-latest` (Apple Silicon).
- **`flake.nix` / `nix/release-files-macos-15-intel.nix` (deleted)**: drop the `Darwin-x86_64` release-files builder and its flake entry.
- **`nix/release-files-ubuntu-latest.nix`**: stop producing `motoko-base-library.tar.gz`. `motoko-core.tar.gz`, the `base-tests` nix target and `test/base-stub` are all kept.

## Downstream impact (x86_64-darwin binaries)

- **mops** ~~(`cli/commands/toolchain/moc.ts`) is the only hard consumer of the caffeinelabs `motoko-Darwin-x86_64` tarball: on Intel Macs it downloads the native binary and never falls back to the Wasm `moc.js` it also caches, so `mops build/check/test` on x86_64-darwin will break once the tarball stops being published. **Coordination needed**: mops either adds a `moc.js`/Wasm fallback or drops x86_64-darwin support in the same release. A follow-up will land in the mops repo.~~ No. Moc v2 simply stops shipping this artifact and if there are any users still using it they should stay on v1 moc. No followup on mops is needed.
- **node-motoko** is Wasm-only (`moc.min.js`) — unaffected.
- **dfinity/sdk (dfx)** pins `dfinity/motoko` (upstream fork) releases, not this fork — unaffected.
- No other Caffeine workspace repo references the dropped artifacts.
- Note: nixpkgs 26.05 itself is the last release supporting `x86_64-darwin`.

Users on Intel Macs can still build moc from source (`nix build .#release.moc` or `make -C src moc`).

## Verification

`nix flake metadata` evaluates against the dirty tree; `nix-instantiate --parse` passes on both edited Nix files. CI (build + release matrices) will exercise the remaining legs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)