### PR TITLE
experiment: `public (…)` parenthetical for (e.g.) `encoder`/`decoder` codecs

### DIFF
--- a/doc/md/examples/grammar.txt
+++ b/doc/md/examples/grammar.txt
@@ -293,6 +293,22 @@
     'public'
     'system'
 
+<dec_pub> ::= 
+    'let' <pat> '=' <exp>
+    'let' <pat>
+    'let' <pat> '=' <exp> 'else' <exp_nest>
+    'type' <id> ('<' <list(<typ_bind>, ',')> '>')? '=' <typ>
+    <shared_pat_opt> 'func' <func_pat> (':' <typ>)? <func_body>
+
+<dec_field_ac> ::= 
+    <stab> <dec>
+    'private' <stab> <dec>
+    'system' <stab> <dec>
+    'public' <parenthetical>? <stab> <dec_pub>
+
+<obj_body_ac> ::= 
+    '{' <list(<dec_field_ac>, ';')> '}'
+
 <stab> ::= 
     <empty>
     'flexible'
@@ -344,7 +360,7 @@
     'type' <id> ('<' <list(<typ_bind>, ',')> '>')? '=' <typ>
     <shared_pat_opt> 'func' <func_pat> (':' <typ>)? <func_body>
     <parenthetical>? <obj_or_class_dec>
-    'mixin' ('<' 'system' '>')? <pat_plain> <obj_body>
+    'mixin' ('<' 'system' '>')? <pat_plain> <obj_body_ac>
     'include' <id> ('<' 'system' '>')? <exp>
 
 <obj_or_class_dec> ::= 

--- a/src/mo_frontend/parser.mly
+++ b/src/mo_frontend/parser.mly
@@ -315,7 +315,7 @@ and objblock eo s id ty dec_fields =
 %type<Mo_def.Syntax.exp_field> exp_field
 %type<Mo_def.Syntax.dec_field> dec_field
 %type<Mo_def.Syntax.dec_field> dec_field_ac
-%type<Mo_def.Syntax.dec> dec_func
+%type<Mo_def.Syntax.dec> dec_pub
 %type<Mo_def.Syntax.dec_field list> obj_body_ac
 %type<Mo_def.Syntax.id * Mo_def.Syntax.dec_field list> class_body
 %type<Mo_def.Syntax.case> catch case
@@ -894,9 +894,25 @@ vis :
     Public depr @@ at }
   | SYSTEM { System @@ at $sloc }
 
-(* PROTOTYPE: actor-context field. `vis` owns the continuation: for a *public*
-   field the continuation is func-only (dec_func), so `public (` is unambiguously
-   the encoder parenthetical -- there is no bare-LPAR dec to reduce into. *)
+(* PROTOTYPE: actor-context field. `vis` owns the continuation: a *public*
+   member is a manifest function / let / type (dec_pub) -- never a bare
+   expression -- so it can't begin with LPAR, and `public (` is unambiguously
+   the encoder parenthetical (no bare-LPAR dec to reduce into). *)
+dec_pub :
+  | LET p=pat EQ e=exp(ob)
+    { let p', e' = normalize_let p e in LetD (p', e', None) @? at $sloc }
+  | LET p=pat
+    { let p', e' = normalize_let p (PrimE "_" @? at $sloc) in LetD (p', e', None) @? at $sloc }
+  | LET p=pat EQ e=exp(ob) ELSE fail=exp_nest
+    { let p', e' = normalize_let p e in LetD (p', e', Some fail) @? at $sloc }
+  | TYPE x=typ_id tps=type_typ_params_opt EQ t=typ
+    { TypD(x, tps, t) @? at $sloc }
+  | sp=shared_pat_opt FUNC xf_tps_p=func_pat t=annot_opt fb=func_body
+    { let xf, tps, p = xf_tps_p in
+      let named, x = xf "func" $sloc in
+      let is_sugar, e = desugar_func_body sp x t fb in
+      let_or_exp named x (func_exp x.it sp tps p t is_sugar e) (at $sloc) }
+
 dec_field_ac :
   | s=stab d=dec
     { {dec = d; vis = Private @@ no_region; stab = s} @@ at $sloc }
@@ -904,17 +920,10 @@ dec_field_ac :
     { {dec = d; vis = Private @@ at $sloc; stab = s} @@ at $sloc }
   | SYSTEM s=stab d=dec
     { {dec = d; vis = System @@ at $sloc; stab = s} @@ at $sloc }
-  | PUBLIC parenthetical? s=stab d=dec_func
+  | PUBLIC parenthetical? s=stab d=dec_pub
     { let trivia = Trivia.find_trivia !triv_table (at $sloc) in
       let depr = Trivia.deprecated_of_trivia_info trivia in
       {dec = d; vis = Public depr @@ at $sloc; stab = s} @@ at $sloc }
-
-dec_func :
-  | sp=shared_pat_opt FUNC xf_tps_p=func_pat t=annot_opt fb=func_body
-    { let xf, tps, p = xf_tps_p in
-      let named, x = xf "func" $sloc in
-      let is_sugar, e = desugar_func_body sp x t fb in
-      let_or_exp named x (func_exp x.it sp tps p t is_sugar e) (at $sloc) }
 
 obj_body_ac :
   | LCURLY dfs=seplist(dec_field_ac, semicolon) RCURLY { dfs }

--- a/src/mo_frontend/parser.mly
+++ b/src/mo_frontend/parser.mly
@@ -314,6 +314,9 @@ and objblock eo s id ty dec_fields =
 %type<Mo_def.Syntax.dec> dec imp dec_var dec_nonvar
 %type<Mo_def.Syntax.exp_field> exp_field
 %type<Mo_def.Syntax.dec_field> dec_field
+%type<Mo_def.Syntax.dec_field> dec_field_ac
+%type<Mo_def.Syntax.dec> dec_func
+%type<Mo_def.Syntax.dec_field list> obj_body_ac
 %type<Mo_def.Syntax.id * Mo_def.Syntax.dec_field list> class_body
 %type<Mo_def.Syntax.case> catch case
 %type<Mo_def.Syntax.exp> bl ob
@@ -891,6 +894,31 @@ vis :
     Public depr @@ at }
   | SYSTEM { System @@ at $sloc }
 
+(* PROTOTYPE: actor-context field. `vis` owns the continuation: for a *public*
+   field the continuation is func-only (dec_func), so `public (` is unambiguously
+   the encoder parenthetical -- there is no bare-LPAR dec to reduce into. *)
+dec_field_ac :
+  | s=stab d=dec
+    { {dec = d; vis = Private @@ no_region; stab = s} @@ at $sloc }
+  | PRIVATE s=stab d=dec
+    { {dec = d; vis = Private @@ at $sloc; stab = s} @@ at $sloc }
+  | SYSTEM s=stab d=dec
+    { {dec = d; vis = System @@ at $sloc; stab = s} @@ at $sloc }
+  | PUBLIC parenthetical? s=stab d=dec_func
+    { let trivia = Trivia.find_trivia !triv_table (at $sloc) in
+      let depr = Trivia.deprecated_of_trivia_info trivia in
+      {dec = d; vis = Public depr @@ at $sloc; stab = s} @@ at $sloc }
+
+dec_func :
+  | sp=shared_pat_opt FUNC xf_tps_p=func_pat t=annot_opt fb=func_body
+    { let xf, tps, p = xf_tps_p in
+      let named, x = xf "func" $sloc in
+      let is_sugar, e = desugar_func_body sp x t fb in
+      let_or_exp named x (func_exp x.it sp tps p t is_sugar e) (at $sloc) }
+
+obj_body_ac :
+  | LCURLY dfs=seplist(dec_field_ac, semicolon) RCURLY { dfs }
+
 stab :
   | (* empty *) { None }
   | FLEXIBLE { Some (Flexible @@ at $sloc) }
@@ -1002,7 +1030,7 @@ dec_nonvar :
       let is_sugar, e = desugar_func_body sp x t fb in
       let_or_exp named x (func_exp x.it sp tps p t is_sugar e) (at $sloc) }
   | eo=parenthetical_opt mk_d=obj_or_class_dec  { mk_d eo }
-  | MIXIN system=system_opt p=pat_plain dfs=obj_body {
+  | MIXIN system=system_opt p=pat_plain dfs=obj_body_ac {
      let dfs = List.map (share_dec_field (fun () -> Stable (ref None) @@ no_region)) dfs in
      MixinD(system, p, dfs) @? at $sloc
   }

--- a/src/mo_frontend/printers.ml
+++ b/src/mo_frontend/printers.ml
@@ -211,6 +211,11 @@ let repr_of_symbol : xsymbol -> (string * string) =
   | X (N N_lit) -> "<lit>", "true"
   | X (N N_ob) -> "<ob>", eg_exp_obj
   | X (N N_obj_body) -> "<obj_body>", "{}"
+  | X (N N_obj_body_ac) -> "<obj_body_ac>", "{}"
+  | X (N N_dec_pub) -> "<dec_pub>", eg_dec
+  | X (N N_dec_field_ac) -> "<dec_field_ac>", eg_dec_field
+  | X (N N_seplist_dec_field_ac_semicolon_) -> seplist ("<dec_field_ac>", eg_dec_field) semi
+  | X (N N_option_parenthetical_) -> "<parenthetical>?", "(with encoder)"
   | X (N N_option_EQ_) -> "=?", "=?"
   | X (N N_option_exp_nullary_ob__) -> "<exp_nullary(ob)>?", eg_exp
   | X (N N_option_typ_args_) -> "<typ_args>?", eg_typ_args

--- a/test/fail/ok/mixins-system.tc-human.ok
+++ b/test/fail/ok/mixins-system.tc-human.ok
@@ -1,4 +1,4 @@
 error[M0130]: misplaced system visibility, did you mean private?
     ┌─ mixins/Mixin1.mo:4:3
   4 │    system func preugprade() {}; // reject system function in mixin
-    │    ^^^^^^ 
+    │    ^^^^^^^^^^^^^^^^^^^^^^^^^^^ 

--- a/test/fail/ok/mixins-system.tc.ok
+++ b/test/fail/ok/mixins-system.tc.ok
@@ -1,1 +1,1 @@
-mixins/Mixin1.mo:4.3-4.9: type error [M0130], misplaced system visibility, did you mean private?
+mixins/Mixin1.mo:4.3-4.30: type error [M0130], misplaced system visibility, did you mean private?


### PR DESCRIPTION
**Experiment — not for merge.** Explores placing the codec parenthetical *after* `public` rather than before it:

```motoko
public (with encoder = toJsonBlob; decoder = func () ...) func foo() : async T { … }
public (with encoder) func bar() : async T { … }   // punned to sibling `encoder`/`decoder`
```

### The grammar insight

Making the visibility keyword *own the continuation* keeps the grammar conflict-free. A `public` member is restricted to a manifest `func`/`let`/`type` (the new `dec_pub` nonterminal) — never a bare expression — so it cannot begin with `LPAR`. That makes `public (` unambiguously the codec parenthetical, with no bare-`LPAR` declaration to shift/reduce against:

```
dec_field_ac:
  | PUBLIC parenthetical? s=stab d=dec_pub
```

Two commits:
- `public (…) func` via the vis-owned continuation (`dec_pub` = func only);
- extend `dec_pub` to `{func, let, type}`, still conflict-free.

Currently wired into the `mixin` body (`obj_body_ac`). Rebased onto current `master`; `printers.ml` gains symbol cases for the new nonterminals so the release build stays warning-clean. `moc --check` accepts both the explicit and punned forms.

Prior art on the sibling branch `gabor/encoder` places the same parenthetical *before* `public`; this branch is the after-`public` variant.