### PR TITLE
feat: suggest contextual dot notation (M0236) by default

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@
     warns about calls like `Map.filter(map, ...)` that could be written with
     dot notation `map.filter(...)`. Silence with `-A M0236`. The related
     suggestions `M0223` (redundant type instantiation) and `M0237` (redundant
-    explicit arguments) remain off by default (allow with `-W`).
+    explicit arguments) remain off by default (allow with `-W`). (#6361)
 
 ## 1.16.0 (2026-09-09)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,15 @@
 # Motoko compiler changelog
 
+## Next
+
+* motoko (`moc`)
+
+  * feat: the contextual dot suggestion (`M0236`) is now on by default: `moc`
+    warns about calls like `Map.filter(map, ...)` that could be written with
+    dot notation `map.filter(...)`. Silence with `-A M0236`. The related
+    suggestions `M0223` (redundant type instantiation) and `M0237` (redundant
+    explicit arguments) remain off by default (allow with `-W`).
+
 ## 1.16.0 (2026-09-09)
 
 * motoko (`moc`)

--- a/doc/md/fundamentals/contextual-dot.md
+++ b/doc/md/fundamentals/contextual-dot.md
@@ -136,10 +136,10 @@ let uppercased = texts.map(func(t) { /* convert to uppercase */ });
 
 ## Compiler warnings and best practices
 
-The Motoko compiler can optionally warn you about opportunities to use contextual dot notation. You can enable this with the `-W M0236` flag:
+The Motoko compiler warns when a function call could use contextual dot notation, e.g. `Array.filter(arr, ...)` where `arr.filter(...)` would work. This warning (`M0236`) is enabled by default. Silence it with the `-A M0236` flag:
 
 ```bash
-moc -W M0236 myfile.mo
+moc -A M0236 myfile.mo
 ```
 
 This helps you maintain consistent coding style across your project.

--- a/src/mo_config/flags.ml
+++ b/src/mo_config/flags.ml
@@ -96,7 +96,6 @@ let generate_view_queries = ref false
 let default_warning_levels = M.empty
   |> M.add "M0223" Allow (* don't report redundant instantions *)
   |> M.add "M0235" Allow (* don't deprecate for non-caffeine *)
-  |> M.add "M0236" Allow (* don't suggest contextual dot notation *)
   |> M.add "M0237" Allow (* don't report redundant explicit arguments *)
   |> M.add "M0268" (Error : lint_level) (* diverging from the deployed migration history is a deployment hazard *)
 

--- a/test/fail/ok/implicit-suggest.tc-human.ok
+++ b/test/fail/ok/implicit-suggest.tc-human.ok
@@ -1,23 +1,65 @@
+warning[M0236]: You can use the dot notation `peopleMap.get(...)` here
+    ┌─ implicit-suggest.mo:41:13
+ 41 │       ignore Map.get(peopleMap, Nat.compare, 1); // warn
+    │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+    = help: replace `Map` with `peopleMap`
+    = help: remove `peopleMap,`
 warning[M0237]: The `Nat.compare` argument can be inferred and omitted here (the function parameter is `implicit`).
     ┌─ implicit-suggest.mo:41:32
  41 │       ignore Map.get(peopleMap, Nat.compare, 1); // warn
     │                                 ^^^^^^^^^^^ 
     = help: remove `Nat.compare,`
+warning[M0236]: You can use the dot notation `peopleMap.get(...)` here
+    ┌─ implicit-suggest.mo:42:13
+ 42 │       ignore Map.get(peopleMap, 1); // ok
+    │              ^^^^^^^^^^^^^^^^^^^^^ 
+    = help: replace `Map` with `peopleMap`
+    = help: remove `peopleMap,`
 warning[M0237]: The `Nat.compare` argument can be inferred and omitted here (the function parameter is `implicit`).
     ┌─ implicit-suggest.mo:44:27
  44 │       ignore peopleMap.get(Nat.compare, 1); // warn
     │                            ^^^^^^^^^^^ 
     = help: remove `Nat.compare,`
+warning[M0236]: You can use the dot notation `peopleMap.get(...)` here
+    ┌─ implicit-suggest.mo:52:13
+ 52 │       ignore Map.get(peopleMap, compare, 1); // warn
+    │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+    = help: replace `Map` with `peopleMap`
+    = help: remove `peopleMap,`
 warning[M0237]: The `compare` argument can be inferred and omitted here (the function parameter is `implicit`).
     ┌─ implicit-suggest.mo:52:32
  52 │       ignore Map.get(peopleMap, compare, 1); // warn
     │                                 ^^^^^^^ 
     = help: remove `compare,`
+warning[M0236]: You can use the dot notation `peopleMap.get(...)` here
+    ┌─ implicit-suggest.mo:53:13
+ 53 │       ignore Map.get(peopleMap, Nat.compare, 1); // ok
+    │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+    = help: replace `Map` with `peopleMap`
+    = help: remove `peopleMap,`
+warning[M0236]: You can use the dot notation `peopleMap.get(...)` here
+    ┌─ implicit-suggest.mo:54:13
+ 54 │       ignore Map.get(peopleMap, 1); // ok
+    │              ^^^^^^^^^^^^^^^^^^^^^ 
+    = help: replace `Map` with `peopleMap`
+    = help: remove `peopleMap,`
 warning[M0237]: The `compare` argument can be inferred and omitted here (the function parameter is `implicit`).
     ┌─ implicit-suggest.mo:56:27
  56 │       ignore peopleMap.get(compare, 1); // warn
     │                            ^^^^^^^ 
     = help: remove `compare,`
+warning[M0236]: You can use the dot notation `peopleMap.get(...)` here
+    ┌─ implicit-suggest.mo:57:13
+ 57 │       ignore Map.get(peopleMap, Nat.compare, 1); // ok
+    │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+    = help: replace `Map` with `peopleMap`
+    = help: remove `peopleMap,`
+warning[M0236]: You can use the dot notation `ambMap.get(...)` here
+    ┌─ implicit-suggest.mo:73:12
+ 73 │      ignore Map.get(ambMap, Amb1.compare, #amb); // don't warn (suggestion would be ambiguous)
+    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+    = help: replace `Map` with `ambMap`
+    = help: remove `ambMap,`
 error[M0231]: ambiguous implicit argument named `compare` of type 
   (Amb1.T, Amb1.T) -> Order.
     ┌─ implicit-suggest.mo:74:12

--- a/test/fail/ok/implicit-suggest.tc.ok
+++ b/test/fail/ok/implicit-suggest.tc.ok
@@ -1,7 +1,14 @@
+implicit-suggest.mo:41.13-41.47: warning [M0236], You can use the dot notation `peopleMap.get(...)` here
 implicit-suggest.mo:41.32-41.43: warning [M0237], The `Nat.compare` argument can be inferred and omitted here (the function parameter is `implicit`).
+implicit-suggest.mo:42.13-42.34: warning [M0236], You can use the dot notation `peopleMap.get(...)` here
 implicit-suggest.mo:44.27-44.38: warning [M0237], The `Nat.compare` argument can be inferred and omitted here (the function parameter is `implicit`).
+implicit-suggest.mo:52.13-52.43: warning [M0236], You can use the dot notation `peopleMap.get(...)` here
 implicit-suggest.mo:52.32-52.39: warning [M0237], The `compare` argument can be inferred and omitted here (the function parameter is `implicit`).
+implicit-suggest.mo:53.13-53.47: warning [M0236], You can use the dot notation `peopleMap.get(...)` here
+implicit-suggest.mo:54.13-54.34: warning [M0236], You can use the dot notation `peopleMap.get(...)` here
 implicit-suggest.mo:56.27-56.34: warning [M0237], The `compare` argument can be inferred and omitted here (the function parameter is `implicit`).
+implicit-suggest.mo:57.13-57.47: warning [M0236], You can use the dot notation `peopleMap.get(...)` here
+implicit-suggest.mo:73.12-73.47: warning [M0236], You can use the dot notation `ambMap.get(...)` here
 implicit-suggest.mo:74.12-74.33: type error [M0231], ambiguous implicit argument named `compare` of type 
   (Amb1.T, Amb1.T) -> Order.
 note: The ambiguous implicit candidates are: `Amb1.compare`, `_Amb2.compare`.

--- a/test/fail/ok/inf-error.tc-human.ok
+++ b/test/fail/ok/inf-error.tc-human.ok
@@ -1,3 +1,15 @@
+warning[M0236]: You can use the dot notation `peopleMap.get(...)` here
+    ┌─ inf-error.mo:44:13
+ 44 │       ignore Map.get(peopleMap, Nat.compare, 1); // ok
+    │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+    = help: replace `Map` with `peopleMap`
+    = help: remove `peopleMap,`
+warning[M0236]: You can use the dot notation `peopleMap.get(...)` here
+    ┌─ inf-error.mo:45:13
+ 45 │       ignore Map.get(peopleMap, 1); // ok
+    │              ^^^^^^^^^^^^^^^^^^^^^ 
+    = help: replace `Map` with `peopleMap`
+    = help: remove `peopleMap,`
 error[M0096]: expression of type
   Text
 cannot produce expected type
@@ -24,6 +36,18 @@ error[M0230]: Cannot determine implicit argument `compare` of type
  52 │       ignore peopleMap.get("test"); // bad
     │              ^^^^^^^^^^^^^^^^^^^^^ 
     = note: If you're trying to omit an implicit argument named `compare` you need to have a matching declaration named `compare` in scope.
+warning[M0236]: You can use the dot notation `peopleMap.set(...)` here
+    ┌─ inf-error.mo:57:13
+ 57 │       ignore Map.set(peopleMap, Nat.compare, 1, ""); // ok
+    │              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+    = help: replace `Map` with `peopleMap`
+    = help: remove `peopleMap,`
+warning[M0236]: You can use the dot notation `peopleMap.set(...)` here
+    ┌─ inf-error.mo:58:13
+ 58 │       ignore Map.set(peopleMap, 1, ""); // ok
+    │              ^^^^^^^^^^^^^^^^^^^^^^^^^ 
+    = help: replace `Map` with `peopleMap`
+    = help: remove `peopleMap,`
 error[M0096]: expression of type
   Text
 cannot produce expected type

--- a/test/fail/ok/inf-error.tc.ok
+++ b/test/fail/ok/inf-error.tc.ok
@@ -1,3 +1,5 @@
+inf-error.mo:44.13-44.47: warning [M0236], You can use the dot notation `peopleMap.get(...)` here
+inf-error.mo:45.13-45.34: warning [M0236], You can use the dot notation `peopleMap.get(...)` here
 inf-error.mo:46.45-46.51: type error [M0096], expression of type
   Text
 cannot produce expected type
@@ -12,6 +14,8 @@ cannot produce expected type
 inf-error.mo:52.13-52.34: type error [M0230], Cannot determine implicit argument `compare` of type
   (Any, Any) -> Order
 note: If you're trying to omit an implicit argument named `compare` you need to have a matching declaration named `compare` in scope.
+inf-error.mo:57.13-57.51: warning [M0236], You can use the dot notation `peopleMap.set(...)` here
+inf-error.mo:58.13-58.38: warning [M0236], You can use the dot notation `peopleMap.set(...)` here
 inf-error.mo:59.45-59.51: type error [M0096], expression of type
   Text
 cannot produce expected type

--- a/test/fail/ok/warn-help.tc-human.ok
+++ b/test/fail/ok/warn-help.tc-human.ok
@@ -31,7 +31,7 @@ M0218 (A) Redundant `stable`
 M0222 (A) Ignored `async*`
 M0223 (A) Redundant type instantiation
 M0235 (A) Deprecate for caffeine
-M0236 (A) Suggest contextual dot notation
+M0236 (W) Suggest contextual dot notation
 M0237 (A) Suggest redundant explicit arguments
 M0239 (W) Avoid binding a unit `()` result
 M0240 (W) Unused identifier in shared pattern warning

--- a/test/fail/ok/warn-help.tc.ok
+++ b/test/fail/ok/warn-help.tc.ok
@@ -31,7 +31,7 @@ M0218 (A) Redundant `stable`
 M0222 (A) Ignored `async*`
 M0223 (A) Redundant type instantiation
 M0235 (A) Deprecate for caffeine
-M0236 (A) Suggest contextual dot notation
+M0236 (W) Suggest contextual dot notation
 M0237 (A) Suggest redundant explicit arguments
 M0239 (W) Avoid binding a unit `()` result
 M0240 (W) Unused identifier in shared pattern warning

--- a/test/run-drun/ok/data-view-nested.tc.ok
+++ b/test/run-drun/ok/data-view-nested.tc.ok
@@ -6,8 +6,3 @@ data-view-sample/views.mo:213.12-213.33: warning [M0236], You can use the dot no
 data-view-sample/views.mo:216.12-216.33: warning [M0236], You can use the dot notation `self.values(...)` here
 data-view-sample/views.mo:233.12-233.34: warning [M0236], You can use the dot notation `self.values(...)` here
 data-view-sample/views.mo:236.12-236.34: warning [M0236], You can use the dot notation `self.values(...)` here
-data-view-sample.mo:248.26-248.40: warning [M0154], field fromNat32 is deprecated
-note: Use `Nat32.toChar` instead.
-data-view-sample.mo:248.41-248.54: warning [M0154], field fromNat is deprecated
-note: Use `Nat.toNat32` instead.
-data-view-sample.mo:248.14-248.59: warning [M0236], You can use the dot notation `Char.fromNat32(Nat32.fromNat(i)).toText(...)` here

--- a/test/run/ok/implicit-derivation-core.tc.ok
+++ b/test/run/ok/implicit-derivation-core.tc.ok
@@ -1,0 +1,2 @@
+implicit-derivation-core.mo:58.16-58.42: warning [M0236], You can use the dot notation `[3, 1, 2].sort(...)` here
+implicit-derivation-core.mo:77.49-77.69: warning [M0236], You can use the dot notation `arr.sort(...)` here

--- a/test/run/ok/implicit-derivation-record-variant.tc.ok
+++ b/test/run/ok/implicit-derivation-record-variant.tc.ok
@@ -1,0 +1,5 @@
+implicit-derivation-record-variant.mo:148.29-148.69: warning [M0236], You can use the dot notation `l1.compare(...)` here
+implicit-derivation-record-variant.mo:264.14-264.51: warning [M0236], You can use the dot notation `tasks.sort(...)` here
+implicit-derivation-record-variant.mo:273.16-273.61: warning [M0236], You can use the dot notation `tasks.sort(...)` here
+implicit-derivation-record-variant.mo:284.15-284.77: warning [M0236], You can use the dot notation `tasks.sort(...)` here
+implicit-derivation-record-variant.mo:287.17-287.87: warning [M0236], You can use the dot notation `tasks.sort(...)` here


### PR DESCRIPTION
When a call like `Map.filter(map, ...)` could instead be written `map.filter(...)`, `moc` now flags it by default. Before, this suggestion (`M0236`) was opt-in — you only saw it by passing `-W M0236`.

**Before** — default flags, no M0236 output:

```
$ moc --check test.mo
# <- nothing about dot notation
```

**After** — default flags now warn:

```
$ moc --check test.mo
test.mo:58.16-58.42: warning [M0236], You can use the dot notation `[3, 1, 2].sort(...)` here
test.mo:77.49-77.69: warning [M0236], You can use the dot notation `arr.sort(...)` here
```

Opt out where the module-qualified form is clearer, exactly as before for any warning:

```
$ moc --check -A M0236 test.mo
# no M0236 output
```

## What is unchanged

- **`M0223`** (redundant type instantiation) and **`M0237`** (redundant explicit arguments) stay off by default, as discussed in the issue: they compare to `M0236` but are more case-sensitive and costlier to suggest correctly, so they're intentionally not flipped here.
- Everything else in `default_warning_levels` (`M0235`, `M0268`) is untouched.

## Migration

Projects that prefer module-qualified calls and want to keep byte-identical compiler output should add `-A M0236` to `moc` flags / their mops lint config. Projects with no explicit M0236 setting simply start seeing the suggestion.

Split out of [#6231](https://github.com/caffeinelabs/motoko/issues/6231).

🤖 Generated with [Claude Code](https://claude.com/claude-code)