### PR TITLE
rts: validate persistent-metadata roots on upgrade

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Motoko compiler changelog
 
+## Next
+
+* bugfix: On upgrade, validate the persistent-metadata roots added after the first enhanced-orthogonal-persistence release (weak reference registry, dedup table, migration function list) instead of trusting any non-zero word. A canister that migrated from classical persistence keeps classical-heap bytes in those slots; they were taken for a live dedup-table GC root and a phantom migration list, so every later upgrade trapped with `cannot upgrade from an actor using enhanced migration`. Ill-formed roots are reset to null, well-formed ones are kept (#TBD).
+
 ## 1.14.1 (2026-08-17)
 
 * motoko (`moc`)

--- a/rts/motoko-rts/src/gc/incremental/partitioned_heap.rs
+++ b/rts/motoko-rts/src/gc/incremental/partitioned_heap.rs
@@ -559,6 +559,12 @@ impl PartitionedHeap {
         self.heap_base
     }
 
+    /// First address past the last partition (partition `i` covers `[i * PARTITION_SIZE, (i+1) * PARTITION_SIZE)`).
+    /// Used to bound pointers read back from persistent metadata before they are trusted.
+    pub fn end_address(&self) -> usize {
+        self.number_of_partitions * PARTITION_SIZE
+    }
+
     unsafe fn get_extension_table(&self, partition_index: usize) -> *mut PartitionTable {
         debug_assert!(partition_index >= PARTITIONS_PER_TABLE);
         let mut index = partition_index - PARTITIONS_PER_TABLE;

--- a/rts/motoko-rts/src/persistence.rs
+++ b/rts/motoko-rts/src/persistence.rs
@@ -198,17 +198,23 @@ unsafe fn is_dedup_table(object: Value) -> bool {
     object.tag() == TAG_ARRAY_M
 }
 
-/// The migration list is `?(Text, ?...)`: a `Some` whose field is a 2-tuple whose first
-/// element is a text (a UTF-8 blob or a concatenation).
+/// The migration list is `?(Text, ?...)`. Motoko represents `?v` as `v` itself (a `Some` box
+/// exists only for nested `?null`), so the root normally points STRAIGHT AT the 2-tuple; a
+/// `Some` box is accepted too. The tuple's first element is a text: a UTF-8 blob or a
+/// concatenation.
 unsafe fn is_migration_list(object: Value) -> bool {
-    if object.tag() != TAG_SOME {
+    let tuple_value = if object.tag() == TAG_SOME {
+        match resolve_root((*(object.get_ptr() as *const Some)).field) {
+            Option::Some(inner) => inner,
+            _ => return false,
+        }
+    } else {
+        object
+    };
+    if tuple_value.tag() != TAG_ARRAY_T {
         return false;
     }
-    let field = (*(object.get_ptr() as *const Some)).field;
-    let tuple = match resolve_root(field) {
-        Option::Some(tuple) if tuple.tag() == TAG_ARRAY_T => tuple.get_ptr() as *mut Array,
-        _ => return false,
-    };
+    let tuple = tuple_value.get_ptr() as *mut Array;
     if tuple.len() != 2 {
         return false;
     }

--- a/rts/motoko-rts/src/persistence.rs
+++ b/rts/motoko-rts/src/persistence.rs
@@ -21,7 +21,10 @@ use crate::{
     },
     rts_trap_with,
     stable_mem::read_persistence_version,
-    types::{Bytes, NULL_POINTER, TAG_BLOB_B, Value},
+    types::{
+        Array, Bytes, Some, NULL_POINTER, TAG_ARRAY_M, TAG_ARRAY_T, TAG_BLOB_B, TAG_BLOB_T, TAG_CONCAT,
+        TAG_SOME, Value,
+    },
 };
 
 use self::compatibility::TypeDescriptor;
@@ -131,26 +134,87 @@ pub unsafe fn initialize_memory<M: Memory>() {
     let metadata = PersistentMetadata::get();
     if use_enhanced_orthogonal_persistence() && metadata.is_initialized() {
         metadata.check_version();
-        // Explicit migration from a version of the RTS without weak reference support.
-        if (*metadata).weak_ref_registry.get_raw() == 0 {
-            // This is the first upgrade from a version of the RTS without weak reference
-            // support. We need to initialize the weak reference registry to NULL_POINTER.
-            (*metadata).weak_ref_registry = NULL_POINTER;
-        }
-        // Explicit migration from a version of the RTS without dedup table support.
-        if (*metadata).dedup_table.get_raw() == 0 {
-            // This is the first upgrade from a version of the RTS without dedup table support.
-            // We need to initialize the dedup table to NULL_POINTER.
-            (*metadata).dedup_table = NULL_POINTER;
-        }
-        // Explicit migration from a version of the RTS without migration functions support.
-        if (*metadata).migration_functions.get_raw() == 0 {
-            // This is the first upgrade from a version of the RTS without migration functions support.
-            // We need to initialize the migration functions array to NULL_POINTER.
-            (*metadata).migration_functions = NULL_POINTER;
-        }
+        // Roots added to the metadata after the first enhanced-orthogonal-persistence release
+        // (weak reference registry, dedup table, migration function list) are, on the first
+        // upgrade from an RTS that did not know them, WHATEVER THE MEMORY HELD THERE. That is
+        // zero for a canister installed under enhanced orthogonal persistence (Wasm memory is
+        // zero-initialized) but NOT for a canister that migrated from classical persistence:
+        // the metadata reserve was laid over the classical heap and only the fields the
+        // migrating RTS knew were written. Testing `== 0` then takes classical-heap bytes for
+        // a live root -- a garbage GC root, or a phantom migration list that makes every
+        // later upgrade trap with "cannot upgrade from an actor using enhanced migration".
+        // (Seen on a canister that went 0.14.9 classical -> 0.16.3 -> 1.14.1.) So each root
+        // is kept only if it is null or a well-formed pointer to an object of the shape that
+        // root holds, and reset to null otherwise. Resetting is safe: the registry and the
+        // dedup table are caches rebuilt on demand, and a genuine migration list is always
+        // well-formed.
+        sanitize_root(&mut (*metadata).weak_ref_registry, is_weak_ref_registry);
+        sanitize_root(&mut (*metadata).dedup_table, is_dedup_table);
+        sanitize_root(&mut (*metadata).migration_functions, is_migration_list);
     } else {
         metadata.initialize::<M>();
+    }
+}
+
+/// Is `address` a word-aligned address inside the partitioned heap (past the metadata)?
+unsafe fn in_heap(address: usize) -> bool {
+    use crate::constants::WORD_SIZE;
+    address >= HEAP_START
+        && address % WORD_SIZE == 0
+        && address < crate::gc::incremental::get_partitioned_heap().end_address()
+}
+
+/// Resolve a root read from metadata to the object it names, if it names one at all:
+/// a non-null pointer into the heap, followed through the incremental GC's forwarding pointer.
+unsafe fn resolve_root(value: Value) -> Option<Value> {
+    if !value.is_non_null_ptr() || !in_heap(value.get_ptr()) {
+        return None;
+    }
+    let forwarded = value.forward();
+    if !forwarded.is_non_null_ptr() || !in_heap(forwarded.get_ptr()) {
+        return None;
+    }
+    Option::Some(forwarded)
+}
+
+unsafe fn sanitize_root(root: &mut Value, well_formed: unsafe fn(Value) -> bool) {
+    if root.get_raw() == 0 || *root == NULL_POINTER {
+        *root = NULL_POINTER;
+        return;
+    }
+    match resolve_root(*root) {
+        Option::Some(object) if well_formed(object) => {}
+        _ => *root = NULL_POINTER,
+    }
+}
+
+/// The weak reference registry is a `MarkStack` stored inside a byte blob.
+unsafe fn is_weak_ref_registry(object: Value) -> bool {
+    object.tag() == TAG_BLOB_B
+}
+
+/// The dedup table is the prelude's `[var List]`.
+unsafe fn is_dedup_table(object: Value) -> bool {
+    object.tag() == TAG_ARRAY_M
+}
+
+/// The migration list is `?(Text, ?...)`: a `Some` whose field is a 2-tuple whose first
+/// element is a text (a UTF-8 blob or a concatenation).
+unsafe fn is_migration_list(object: Value) -> bool {
+    if object.tag() != TAG_SOME {
+        return false;
+    }
+    let field = (*(object.get_ptr() as *const Some)).field;
+    let tuple = match resolve_root(field) {
+        Option::Some(tuple) if tuple.tag() == TAG_ARRAY_T => tuple.get_ptr() as *mut Array,
+        _ => return false,
+    };
+    if tuple.len() != 2 {
+        return false;
+    }
+    match resolve_root(tuple.get(0)) {
+        Option::Some(name) => name.tag() == TAG_BLOB_T || name.tag() == TAG_CONCAT,
+        _ => false,
     }
 }
 


### PR DESCRIPTION
rts: validate persistent-metadata roots on upgrade

Fixes #6363.

`initialize_memory` initialised the roots added after the first EOP release (`weak_ref_registry`, `dedup_table`, `migration_functions`) by testing the slot for `== 0`. For a canister that migrated from classical persistence the metadata reserve lies over the old classical heap and only the fields the migrating runtime knew were written, so those slots hold heap garbage: a garbage GC root and a phantom migration list that makes every later upgrade trap with `cannot upgrade from an actor using enhanced migration`.

Each root is now kept only if it is null or a word-aligned pointer into the partitioned heap whose (forwarded) object has the shape that root holds, and reset to null otherwise. `PartitionedHeap::end_address` is added to bound the check.

Verified on PocketIC: classical 0.14.9 -> EOP 0.16.2 -> this runtime upgrades with data intact (unpatched 1.14.1 traps); unpatched-1.14.1-installed -> patched -> patched keeps its roots. RTS exports/imports unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
