### PR TITLE
style: compress the comments added by the running-GC cache change

### DIFF
--- a/rts/motoko-rts/src/gc/incremental.rs
+++ b/rts/motoko-rts/src/gc/incremental.rs
@@ -45,9 +45,7 @@ pub mod time;
 #[ic_mem_fn(ic_only)]
 unsafe fn initialize_incremental_gc<M: Memory>(mem: &mut M) {
     initialize(mem);
-    // The `State` is now adopted (fresh on install, persisted-in-place on a
-    // stable-heap EOP upgrade). Re-seat the backend `__running_gc` cache from it:
-    // this runs in the wasm `(start)`, before any exported entry or write barrier.
+    // Instantiation reset the `__running_gc` global, but under EOP the persisted phase may be mid-cycle.
     get_incremental_gc_state().resync_running_gc_cache();
 }
 
@@ -72,11 +70,7 @@ unsafe fn initialize<M: Memory>(_mem: &mut M) {
 #[ic_mem_fn(ic_only)]
 unsafe fn schedule_incremental_gc<M: Memory>(mem: &mut M) {
     let state = get_incremental_gc_state();
-    // Sanity: the backend `__running_gc` cache must equal the authoritative
-    // `phase != Pause` (the value the uncached pre-PR code computed live). Runs
-    // every schedule point, so it catches a decohered cache — e.g. a missing
-    // start-time re-seat after a stable-heap EOP upgrade landing mid-cycle —
-    // on the first GC scheduling after the assignment that would skip a barrier.
+    // A stale `__running_gc` cache silently skips barriers, so check it against the authoritative phase.
     #[cfg(debug_assertions)]
     debug_assert_eq!(get_running_gc(), (state.phase() != Phase::Pause) as i32);
     let running = state.phase() != Phase::Pause;
@@ -162,12 +156,7 @@ pub enum Phase {
 /// Use a long-term representation by relying on C layout.
 #[repr(C)]
 pub struct State {
-    /// Current GC phase. **DO NOT assign directly** — always go through
-    /// [`State::set_phase`], which keeps the backend-side `__running_gc`
-    /// global in sync via the `set_running_gc` export on every
-    /// `Pause ↔ non-Pause` transition. The field privacy (no `pub`)
-    /// enforces this within the module; the rule is repeated here for
-    /// future contributors to make the invariant explicit.
+    /// Only assign through `set_phase`, which mirrors the running flag into the backend `__running_gc` global.
     phase_inner: Phase,
     partitioned_heap: PartitionedHeap,
     allocation_count: usize, // Number of allocations during an active GC run.
@@ -176,29 +165,19 @@ pub struct State {
     statistics: Statistics,
 }
 
-// The persisted layout of `State` is a compatibility contract with canisters built
-// by an earlier compiler: an in-place EOP upgrade reinterprets the very same bytes,
-// which is why the struct is `#[repr(C)]`. Renaming a field is free, but reordering
-// or resizing one is not — that needs `persistence::VERSION` bumped. Pin what the
-// upgrade path and the barriers depend on, so such a change breaks the build here
-// rather than a canister in the field.
+// An in-place EOP upgrade reinterprets these bytes, so reordering or resizing fields needs a `persistence::VERSION` bump.
 const _: () = assert!(core::mem::offset_of!(State, phase_inner) == 0);
 const _: () = assert!(core::mem::size_of::<Phase>() == 4);
 
 #[cfg(feature = "ic")]
 unsafe extern "C" {
-    // Provided by generated code: pushes the running-GC boolean to a
-    // backend-side global so the write-barrier fast path can read it
-    // without an RTS round-trip.
+    // Exported by generated code, lets barriers skip the RTS call while the GC is paused.
     fn set_running_gc(state: i32);
 }
 
 #[cfg(all(feature = "ic", debug_assertions))]
 unsafe extern "C" {
-    // Sanity-only read-mirror of `set_running_gc`, provided by generated code
-    // under `--sanity-checks` (incremental GC only). Lets the RTS assert the
-    // `__running_gc` cache still agrees with the authoritative GC phase — the
-    // value the pre-cache code computed live on every barrier.
+    // Only exported under `--sanity-checks`, which is exactly when the debug RTS gets linked.
     fn get_running_gc() -> i32;
 }
 
@@ -217,17 +196,8 @@ impl State {
         }
     }
 
-    /// Re-seat the backend-cached `__running_gc` global from the authoritative
-    /// `phase_inner` — without a phase transition. Idempotent.
-    ///
-    /// `set_phase` only pushes the global on a `Pause ↔ non-Pause` *transition*,
-    /// which assumes the global already agrees with `phase_inner`. That assumption
-    /// breaks at canister start: module (re-)instantiation resets the global to its
-    /// init value (0 = not running), independently of the GC `State` — which, under
-    /// stable-heap EOP, persists in main memory in place and may be mid-cycle
-    /// (`phase_inner != Pause`). Call this once after the `State` is adopted from
-    /// persistence, before any write barrier can fire, so the fast-path cache matches
-    /// the phase.
+    /// `set_phase` only pushes the flag on transitions, so after instantiation resets the global
+    /// the persisted phase must be pushed once explicitly, before any barrier runs.
     #[cfg(feature = "ic")]
     pub fn resync_running_gc_cache(&self) {
         unsafe { set_running_gc((self.phase_inner != Phase::Pause) as i32) }

--- a/src/codegen/compile_classical.ml
+++ b/src/codegen/compile_classical.ml
@@ -613,10 +613,7 @@ module E = struct
     | ps, rs  -> VarBlockType (nr (func_type env (FuncType (ps, rs))))
 
   let if_ env tys thn els = G.if_ (as_block_type env tys) thn els
-  (* Multi-value-aware `if`, a thin wrapper over `as_block_type`:
-     [param]/[return] are optional `stack_type`s (default empty). With
-     both omitted this is just a nullary `if`. Mirror of
-     `compile_enhanced.ml`'s `E.if'`. *)
+  (* Multi-value `if`; unlike `if_` it takes a raw i32 condition and block params. *)
   let if' env ?param ?(return=[]) thn els =
     G.if_ (as_block_type ?param env return) thn els
   let i32s n = Lib.List.make n I32Type
@@ -1208,10 +1205,7 @@ module GC = struct
     if !Flags.gc_strategy <> Flags.Incremental then
       E.add_global32 env "_HP" Mutable 0l
     else
-      (* GC-running flag. RTS-side cache of `phase != Pause`, written
-         via `set_running_gc` (RTS_Exports). Registered early so
-         `Tagged.write_with_barrier` can resolve it during expression
-         compilation. *)
+      (* Registered before expression compilation, which already reads it in the barriers. *)
       E.add_global32 env "__running_gc" Mutable 0l
 
   let get_mutator_instructions env =
@@ -2209,8 +2203,7 @@ module Tagged = struct
 
   let allocation_barrier env =
     (if !Flags.gc_strategy = Flags.Incremental then
-      (* Inline running-GC fast path. RTS body returns the argument
-         unchanged on Pause, so skip the call. *)
+      (* The RTS returns its argument unchanged while paused, so skip the call. *)
       G.i (GlobalGet (nr (E.get_global env "__running_gc"))) ^^
       E.if' env ~param:(E.i32s 1) ~return:(E.i32s 1)
         (E.call_rts env "allocation_barrier")
@@ -2222,9 +2215,6 @@ module Tagged = struct
     let (set_value, get_value) = new_local env "written_value" in
     let (set_location, get_location) = new_local env "write_location" in
     set_value ^^ set_location ^^
-    (* Read the backend-cached running-GC flag (i32). The RTS pushes
-       the flag via `set_running_gc` on every Pause↔non-Pause
-       transition, so the fast path avoids the RTS round-trip. *)
     G.i (GlobalGet (nr (E.get_global env "__running_gc"))) ^^
     G.if0 (
       get_location ^^ get_value ^^
@@ -6523,12 +6513,7 @@ module RTS_Exports = struct
       edesc = nr (FuncExport (nr bigint_trap_fi))
     });
 
-    (* GC-running flag export (incremental GC only). The RTS pushes
-       cached `phase != Pause` here on every Pause↔non-Pause
-       transition; the write_with_barrier fast path reads
-       `__running_gc` directly instead of round-tripping through an
-       RTS call. The global itself is registered in
-       `GC.register_globals`. *)
+    (* The RTS mirrors `phase != Pause` into `__running_gc`, so barriers can skip the RTS call while paused. *)
     if !Flags.gc_strategy = Flags.Incremental then begin
       let set_running_gc_fi = E.add_fun env "set_running_gc" (
         Func.of_body env ["state", I32Type] [] (fun env ->
@@ -6542,11 +6527,7 @@ module RTS_Exports = struct
       })
     end;
 
-    (* Sanity-only read-mirror of `set_running_gc`: lets the RTS assert the
-       `__running_gc` cache still agrees with the authoritative GC phase
-       (differential oracle vs. the pre-cache behaviour). Created *and* exported
-       only under `--sanity-checks` with the incremental GC; the RTS imports it
-       only in debug builds, so producer and consumer coincide. *)
+    (* Imported only by the debug RTS, which is linked exactly under `--sanity-checks`. *)
     if !Flags.sanity && !Flags.gc_strategy = Flags.Incremental then begin
       let get_running_gc_fi = E.add_fun env "get_running_gc" (
         Func.of_body env [] [I32Type] (fun env ->

--- a/src/codegen/compile_enhanced.ml
+++ b/src/codegen/compile_enhanced.ml
@@ -693,12 +693,7 @@ module E = struct
     G.if1 return_type then_block else_block
 
   let if_ env tys thn els = prepare_branch_condition ^^ G.if_ (as_block_type env tys) thn els
-  (* [if' env ?param ?return thn els] — block-type-aware multi-value `if`,
-     a thin wrapper over `as_block_type`. [param]/[return] are optional
-     `stack_type`s (default empty). Unlike `if_`, does *not*
-     `prepare_branch_condition` (no `i32.wrap_i64`): the caller must place
-     an i32 condition on the wasm stack themselves — use this for raw-wasm
-     conditions like `global.get` of an i32 flag. *)
+  (* Multi-value `if`; unlike `if_` it takes a raw i32 condition (no `prepare_branch_condition`) and block params. *)
   let if' env ?param ?(return=[]) thn els =
     G.if_ (as_block_type ?param env return) thn els
   let i64s n = Lib.List.make n I64Type
@@ -1320,11 +1315,7 @@ module GC = struct
     E.add_global64 env "__mutator_instructions" Mutable 0L;
     E.add_global64 env "__collector_instructions" Mutable 0L;
     E.add_global64 env "__lifetime_instructions" Mutable 0L;
-    (* GC-running flag. RTS-side cache of `phase != Pause`, written via
-       the `set_running_gc` export below (registered in RTS_Exports).
-       Registered here so `Tagged.write_with_barrier` can resolve the
-       global during expression compilation, which runs before
-       `conclude_module`. *)
+    (* Registered before expression compilation, which already reads it in the barriers. *)
     E.add_global32 env "__running_gc" Mutable 0l
 
   let get_mutator_instructions env =
@@ -2143,22 +2134,14 @@ module Tagged = struct
     go cases
 
   let allocation_barrier env =
-    (* Inline running-GC fast path. The RTS function returns its
-       argument unchanged when `state.phase() == Pause`, so a single
-       `global.get __running_gc` + multi-value `if (param i64) (result i64)`
-       elides the function-call overhead on the common (paused) path,
-       leaving the new_object on the stack identity-wise. *)
+    (* The RTS returns its argument unchanged while paused, so skip the call. *)
     G.i (GlobalGet (nr (E.get_global env "__running_gc"))) ^^
     E.if' env ~param:(E.i64s 1) ~return:(E.i64s 1)
       (E.call_rts env "allocation_barrier")
       G.nop
 
   let write_with_barrier env =
-    (* Stack on entry: [location, value]. Read the backend-cached
-       running-GC flag (i32) and dispatch via a multi-value
-       `if (param i64 i64)` block-type so the operands flow through
-       without locals. The RTS pushes the flag via `set_running_gc`
-       on every Pause↔non-Pause transition. *)
+    (* Stack on entry: [location, value]; both arms consume them via the block params. *)
     G.i (GlobalGet (nr (E.get_global env "__running_gc"))) ^^
     E.if' env ~param:(E.i64s 2)
       (E.call_rts env "write_with_barrier")
@@ -2354,11 +2337,7 @@ module WeakRef = struct
     Tagged.load_field env field
 
   (* Load the target through a load barrier, marking it during the GC mark phase.
-     Fast-path gated on the GC state, mirroring [Tagged.allocation_barrier]: the
-     RTS function returns its argument unchanged when the GC is paused, so a
-     single `global.get __running_gc` + multi-value `if (param i64) (result i64)`
-     elides the call on the common path and lets the loaded target flow through
-     without a local. *)
+     The RTS returns its argument unchanged while paused, so skip the call. *)
   let load_field_with_barrier env =
     load_field env ^^
     G.i (GlobalGet (nr (E.get_global env "__running_gc"))) ^^
@@ -6369,12 +6348,7 @@ module RTS_Exports = struct
       edesc = nr (FuncExport (nr bigint_trap_fi))
     });
 
-    (* GC-running flag export. The `__running_gc` global itself is
-       registered in `GC.register_globals` so `Tagged.write_with_barrier`
-       can resolve it during expression compilation. The RTS pushes
-       cached `phase != Pause` here on every Pause↔non-Pause transition;
-       the write_with_barrier fast path reads the global instead of
-       round-tripping through an RTS call. *)
+    (* The RTS mirrors `phase != Pause` into `__running_gc`, so barriers can skip the RTS call while paused. *)
     let set_running_gc_fi = E.add_fun env "set_running_gc" (
       Func.of_body env ["state", I32Type] [] (fun env ->
         G.i (LocalGet (nr 0l)) ^^
@@ -6386,11 +6360,7 @@ module RTS_Exports = struct
       edesc = nr (FuncExport (nr set_running_gc_fi))
     });
 
-    (* Sanity-only read-mirror of `set_running_gc`: lets the RTS assert the
-       `__running_gc` cache still agrees with the authoritative GC phase
-       (differential oracle vs. the pre-cache behaviour). Created *and* exported
-       only under `--sanity-checks` (incremental is implied by EOP); the RTS
-       imports it only in debug builds, so producer and consumer coincide. *)
+    (* Imported only by the debug RTS, which is linked exactly under `--sanity-checks`. *)
     if !Flags.sanity then begin
       let get_running_gc_fi = E.add_fun env "get_running_gc" (
         Func.of_body env [] [I32Type] (fun env ->

--- a/test/run-drun/gc-cache-upgrade.drun
+++ b/test/run-drun/gc-cache-upgrade.drun
@@ -1,6 +1,5 @@
 # ENHANCED-ORTHOGONAL-PERSISTENCE-ONLY
-# The GC state is persisted main memory; an upgrade brings a fresh module whose
-# `__running_gc` global starts at zero, so it must be re-seated from the phase.
+# Upgrading mid-GC-cycle must re-seat the fresh module's `__running_gc` global from the persisted phase.
 install $ID gc-cache-upgrade/v1.mo ""
 ingress $ID build "DIDL\x00\x00"
 upgrade $ID gc-cache-upgrade/v2.mo ""

--- a/test/run-drun/gc-cache-upgrade/v1.mo
+++ b/test/run-drun/gc-cache-upgrade/v1.mo
@@ -1,11 +1,7 @@
 import Prim "mo:prim";
 
-// Keeps a heap big enough that an incremental GC cycle spans several messages,
-// so an upgrade lands with `state.phase() != Pause`. The persisted phase must
-// re-seat the backend `__running_gc` cache, since the fresh module's globals
-// start at zero — otherwise the barriers below take the paused fast path while
-// the GC is marking. Under `--sanity-checks` the RTS asserts the cache against
-// the authoritative phase on every barrier, which is what gives this teeth.
+// The heap must exceed the GC increment limit so that a cycle spans several messages
+// and the upgrade lands mid-cycle; with a smaller heap a stale cache passes by accident.
 
 persistent actor {
 
@@ -17,7 +13,6 @@ persistent actor {
     };
   };
 
-  // Pointer writes (write barrier) plus fresh allocations (allocation barrier).
   public func churn() : async () {
     for (i in live.keys()) {
       live[i] := Prim.Array_init<Nat>(16 * 1024, i);

--- a/test/run-drun/gc-cache-upgrade/v2.mo
+++ b/test/run-drun/gc-cache-upgrade/v2.mo
@@ -1,13 +1,6 @@
 import Prim "mo:prim";
 
-// v2: same shape, so the upgrade is memory-compatible and the heap carries over.
-
-// Keeps a heap big enough that an incremental GC cycle spans several messages,
-// so an upgrade lands with `state.phase() != Pause`. The persisted phase must
-// re-seat the backend `__running_gc` cache, since the fresh module's globals
-// start at zero — otherwise the barriers below take the paused fast path while
-// the GC is marking. Under `--sanity-checks` the RTS asserts the cache against
-// the authoritative phase on every barrier, which is what gives this teeth.
+// Same shape as v1, so the upgrade is memory-compatible and the heap carries over.
 
 persistent actor {
 
@@ -19,7 +12,6 @@ persistent actor {
     };
   };
 
-  // Pointer writes (write barrier) plus fresh allocations (allocation barrier).
   public func churn() : async () {
     for (i in live.keys()) {
       live[i] := Prim.Array_init<Nat>(16 * 1024, i);


### PR DESCRIPTION
Targets [#6111](https://github.com/caffeinelabs/motoko/pull/6111) so it can be merged into that branch before it lands on master.

The new barrier code carried multi-paragraph comments that restated the diff, the PR discussion, and the code below them, wrapped mid-sentence at 70 columns. Each one is now a single line saying only the non-obvious *why*: the re-seat after instantiation, the raw i32 condition in `if'`, the stack shape through the block params, the persisted `State` layout contract, and the test heap sizing that makes the upgrade land mid-cycle. Everything else is dropped. The test comment also no longer claims the cache is checked on every barrier; it is checked at GC schedule points.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)